### PR TITLE
modify makefiles for cli apps to build on OS X

### DIFF
--- a/app/convbin/gcc/makefile
+++ b/app/convbin/gcc/makefile
@@ -11,7 +11,12 @@ OPTIONS= -DTRACE -DENAGLO -DENAQZS -DENAGAL -DENACMP -DENAIRN -DNFREQ=7 -DNEXOBS
 
 CFLAGS = -O3 -ansi -pedantic -Wall -Wno-unused-but-set-variable $(INCLUDE) $(OPTIONS) -g
 
-LDLIBS = -lm -lrt
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S), Darwin)
+	LDLIBS  = -lm
+else
+	LDLIBS  = -lm -lrt
+endif
 
 all  : convbin
 
@@ -154,5 +159,3 @@ test18:
 test21:
 	stty raw < /dev/ttyACM0
 	./convbin -r ubx -o ubx.obs -n ubx.nav -s ubx.sbs -h ubx.hnav /dev/ttyACM0
-
-

--- a/app/pos2kml/gcc/makefile
+++ b/app/pos2kml/gcc/makefile
@@ -3,7 +3,13 @@
 BINDIR = /usr/local/bin
 SRC    = ../../../src
 CFLAGS = -Wall -O3 -ansi -pedantic -I$(SRC) -DTRACE
-LDLIBS  = -lm -lrt
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S), Darwin)
+	LDLIBS  = -lm
+else
+	LDLIBS  = -lm -lrt
+endif
 
 pos2kml    : pos2kml.o convkml.o convgpx.o solution.o geoid.o rtkcmn.o preceph.o
 

--- a/app/rnx2rtkp/gcc/makefile
+++ b/app/rnx2rtkp/gcc/makefile
@@ -9,7 +9,14 @@ OPTS    = -DTRACE -DENAGLO  -DENAGAL -DENACMP  -DNFREQ=3
 
 # for no lapack
 CFLAGS  = -Wall -O3 -ansi -pedantic -Wno-unused-but-set-variable -I$(SRC) $(OPTS) -g
-LDLIBS  = -lm -lrt
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S), Darwin)
+	LDLIBS  = -lm
+else
+	LDLIBS  = -lm -lrt
+endif
+
 #LDLIBS  = ../../../lib/iers/gcc/iers.a -lgfortran -lm -lrt
 
 #CFLAGS  = -Wall -O3 -ansi -pedantic -Wno-unused-but-set-variable -I$(SRC) -DLAPACK $(OPTS)
@@ -168,4 +175,3 @@ prof :
 
 install :
 	cp rnx2rtkp $(BINDIR)
-

--- a/app/rtkrcv/gcc/makefile
+++ b/app/rtkrcv/gcc/makefile
@@ -8,7 +8,13 @@ SRC    = ../../../src
 CTARGET= -DENAGLO -DENAQZS -DENACMP -DENAGAL -DENAIRN -DNFREQ=3 -DSVR_REUSEADDR
 
 CFLAGS = -Wall -O3 -ansi -pedantic -Wno-unused-but-set-variable -I$(SRC) -I.. -DTRACE $(CTARGET) -g
-LDLIBS  = -lm -lrt -lpthread
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S), Darwin)
+	LDLIBS  = -lm -lpthread
+else
+	LDLIBS  = -lm -lrt -lpthread
+endif
 
 all        : rtkrcv
 rtkrcv     : rtkrcv.o vt.o rtkcmn.o rtksvr.o rtkpos.o geoid.o solution.o lambda.o
@@ -147,4 +153,3 @@ test3:
 
 clean:
 	rm -f rtkrcv rtkrcv.exe rtkrcv.nav *.o *.out *.trace
-

--- a/app/str2str/gcc/makefile
+++ b/app/str2str/gcc/makefile
@@ -10,7 +10,13 @@ CTARGET=
 #OPTION = -DENAGLO -DENAGAL -DENAQZS -DENACMP -DENAIRN -DTRACE -DNFREQ=3 -DNEXOBS=3
 OPTION = -DENAGLO -DENAGAL -DENAQZS -DENACMP -DENAIRN -DTRACE -DNFREQ=3 -DNEXOBS=3 -DSVR_REUSEADDR
 CFLAGS = -Wall -O3 -ansi -pedantic -Wno-unused-but-set-variable -I$(SRC) $(OPTION) $(CTARGET) -g
-LDLIBS  = -lm -lrt -lpthread
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S), Darwin)
+	LDLIBS  = -lm -lpthread
+else
+	LDLIBS  = -lm -lrt -lpthread
+endif
 
 all        : str2str
 str2str    : str2str.o stream.o rtkcmn.o solution.o sbas.o geoid.o
@@ -125,4 +131,3 @@ test6:
 
 clean:
 	rm -f str2str str2str.exe *.o *.out *.trace
-


### PR DESCRIPTION
-lrt is not needed on OS X & will fail when building.  Adding to check if system is OS X.