### PR TITLE
Fix telnet autostart

### DIFF
--- a/app/rtkrcv/rtkrcv.c
+++ b/app/rtkrcv/rtkrcv.c
@@ -1683,15 +1683,13 @@ int main(int argc, char **argv)
             return -1;
         }
     }
-    else {
-        /* open device for local console */
-        if (!(con[0]=con_open(0,dev))) {
-            fprintf(stderr,"console open error dev=%s\n",dev);
-            if (moniport>0) closemoni();
-            if (outstat>0) rtkclosestat();
-            traceclose();
-            return -1;
-        }
+    /* open device for local console */
+    if (!(con[0]=con_open(0,dev))) {
+      fprintf(stderr,"console open error dev=%s\n",dev);
+      if (moniport>0) closemoni();
+      if (outstat>0) rtkclosestat();
+      traceclose();
+      return -1;
     }
     signal(SIGINT, sigshut); /* keyboard interrupt */
     signal(SIGTERM,sigshut); /* external shutdown signal */


### PR DESCRIPTION
fixing #38 
autostart now works with telnet activated. If you need rtkrcv without a local console (to use as a systemd service for example), you can use the `-d /dev/null` flag.