### PR TITLE
qt: remove non-existing file ss2.c from src.pro

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -58,7 +58,6 @@ SOURCES += rtkcmn.c \
     rcv/rt17.c \
     rcv/septentrio.c \
     rcv/skytraq.c \
-    rcv/ss2.c \
     rcv/ublox.c \
     rcv/tersus.c \
     rcv/comnav.c \


### PR DESCRIPTION
File src/rcv/ss2.c was removed by commit c6312269a9a2c17ff6b52e9cce58a0940702a726:
"- Enhance event position log to handle events logged in following epoch..."