### PR TITLE
add and allow leading slash of ntrip source request

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -1491,7 +1491,7 @@ static int reqntrip_s(ntrip_t *ntrip, char *msg)
     
     tracet(3,"reqntrip_s: state=%d\n",ntrip->state);
     
-    p+=sprintf(p,"SOURCE %s %s\r\n",ntrip->passwd,ntrip->mntpnt);
+    p+=sprintf(p,"SOURCE %s /%s\r\n",ntrip->passwd,ntrip->mntpnt);
     p+=sprintf(p,"Source-Agent: NTRIP %s\r\n",NTRIP_AGENT);
     p+=sprintf(p,"STR: %s\r\n",ntrip->str);
     p+=sprintf(p,"\r\n");
@@ -1948,6 +1948,7 @@ static void rsp_ntripc_s(ntripc_t *ntripc, int i)
         return;
     }
     sscanf(p,"SOURCE %255s %255s",passwd,mntpnt);
+    if (mntpnt&&mntpnt[0]=='/') memmove(mntpnt, mntpnt+1, sizeof(mntpnt-1));
     
     if ((p=strstr((char *)con->buff,"STR: "))&&(q=strstr(p,"\r\n"))) {
         n=MIN(q-(p+5),255);

--- a/src/stream.c
+++ b/src/stream.c
@@ -1941,7 +1941,8 @@ static void rsp_ntripc_s(ntripc_t *ntripc, int i)
     }
     /* test SOURCE and Source-Agent */
     if (!(p=strstr((char *)con->buff,"SOURCE"))||!(q=strstr(p,"\r\n"))||
-        !(q=strstr(q,"Source-Agent:"))||!strstr(q,"\r\n\r\n")) {
+        !(strstr(q,"Source-Agent:")||strstr(q,"User-Agent:"))||
+        !strstr(q,"\r\n\r\n")) {
         tracet(2,"rsp_ntripc_s: NTRIP request error\n");
         discon_ntripc(ntripc,i);
         return;


### PR DESCRIPTION
to fix issue #66, this pull request will add leading slash to source connection and allow connection contain slash. the old ntrip client can still connect to new server without add leading slash, but old ntrip caster can not deal with connection with leading slash.