### PR TITLE
Handle bad Septentrio SBF messages where crc or block length == 0

### DIFF
--- a/src/rcv/septentrio.c
+++ b/src/rcv/septentrio.c
@@ -789,8 +789,10 @@ static int decode_sbf(raw_t *raw)
     uint32_t week,tow;
     char tstr[32];
     int type=U2(p+4)&0x1fff;
+    uint16_t crc;
     
-    if (rtk_crc16(p+4,raw->len-4)!=U2(p+2)) {
+    crc=rtk_crc16(p+4,raw->len-4);
+    if (crc!=U2(p+2)||crc==0) {
         trace(2,"sbf crc error: type=%d len=%d\n",type,raw->len);
         return -1;
     }
@@ -911,7 +913,7 @@ extern int input_sbff(raw_t *raw, FILE *fp)
         raw->nbyte=0;
         return -1;
     }
-    if (fread(raw->buff+8,raw->len-8,1,fp)<1) return -2;
+    if (raw->len!=0&&fread(raw->buff+8,raw->len-8,1,fp)<1) return -2;
     raw->nbyte=0;
     
     /* decode SBF block */


### PR DESCRIPTION
Previous behaviour would cause convbin to silently fail when an SBF message with a CRC == 0 or with a block of length 0 would be encountered. The two conditions usually occur together and is a result of a malformed SBF message. 

Septentrio's proprietary SBF2RINEX conversion tool is able to handle this condition by simply discarding the SBF block.

This PR does two things:

1) If the CRC is zero, return an error (-1) for that block
2) Add an extra condition to check that block length != 0 before attempting to read bytes after the header (first 8 bytes)