### PR TITLE
Fix a small bug in decode_obsdata()

### DIFF
--- a/src/rinex.c
+++ b/src/rinex.c
@@ -863,7 +863,7 @@ static int decode_obsdata(FILE *fp, char *buff, double ver, int mask,
             p[r[0]]=-1; p[r[1]]=-1;
         }
         else if (val[r[0]]!=0.0&&val[r[1]]==0.0) {
-            p[l[0]]=1; p[l[1]]=-1;
+            p[r[0]]=1; p[r[1]]=-1;
         }
         else if (val[r[0]]==0.0&&val[r[1]]!=0.0) {
             p[r[0]]=-1; p[r[1]]=1;


### PR DESCRIPTION
Higher priority selection for C3/P3 has a small logic error due to a typo.