### PR TITLE
Fix to take into account the direction of accel term

### DIFF
--- a/src/rtkpos.c
+++ b/src/rtkpos.c
@@ -529,7 +529,7 @@ static void udpos(rtk_t *rtk, double tt)
     /* include accel terms if filter is converged */
     if (var<rtk->opt.thresar[1]) {
         for (i=0;i<3;i++) {
-            F[i+(i+6)*nx]=SQR(tt)/2.0;
+            F[i+(i+6)*nx]=(tt>=0?1:-1)*SQR(tt)/2.0;
         }
     }
     else trace(3,"pos var too high for accel term: %.4f\n", var);


### PR DESCRIPTION
In this PR, I add the sign of the time delta `tt` to flip the accel direction depending on the forward/backward modes.

The time evolution of kalman-filter in the backward mode is calculated by using the `udpos` function with the reversed time delta `tt` to flip the direction of the velocity.
But the accel terms are given by `SQRT(tt)/2`, which always returns positive values. This seems that the accel terms in the backward mode shift the resulting position to the opposite side.
So I think the sign of the time delta is needed for the accel term.

I'm not familiar with the rtklib code so I might be wrong, but I appreciate it if you review this.