### PR TITLE
Update rtkcmn.c

### DIFF
--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -4046,7 +4046,7 @@ extern int rtk_uncompress(const char *file, char *uncfile)
 }
 /* dummy application functions for shared library ----------------------------*/
 #ifdef WIN_DLL
-extern int showmsg(char *format,...) {return 0;}
+extern int showmsg(const char *format,...) {return 0;}
 extern void settspan(gtime_t ts, gtime_t te) {}
 extern void settime(gtime_t time) {}
 #endif


### PR DESCRIPTION
Change `extern int showmsg(char *format,...) {return 0;}` to  match declaration in: 

https://github.com/rtklibexplorer/RTKLIB/blob/d95376c780e6f7e758ddc6cb450079cf84474a35/src/rtklib.h#L1818