### PR TITLE
Fix QtApp when using Qt 5 issue #144

### DIFF
--- a/app/qtapp/rtkget_qt/getmain.cpp
+++ b/app/qtapp/rtkget_qt/getmain.cpp
@@ -504,7 +504,11 @@ void MainForm::dragEnterEvent(QDragEnterEvent *event)
 //---------------------------------------------------------------------------
 void MainForm::dropEvent(QDropEvent *event)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     if (StaList == childAt(event->position().toPoint()))
+#else
+    if (StaList == childAt(event->pos()))
+#endif
         LoadSta(event->mimeData()->text());
     event->acceptProposedAction();
 }

--- a/app/qtapp/rtkplot_qt/plotmain.cpp
+++ b/app/qtapp/rtkplot_qt/plotmain.cpp
@@ -1477,8 +1477,13 @@ void Plot::TimeScrollChange()
 // callback on mouse-down event ---------------------------------------------
 void Plot::mousePressEvent(QMouseEvent *event)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     X0 = Disp->mapFromGlobal(event->globalPosition()).x();
     Y0 = Disp->mapFromGlobal(event->globalPosition()).y();
+#else
+    X0 = Disp->mapFromGlobal(event->globalPos()).x();
+    Y0 = Disp->mapFromGlobal(event->globalPos()).y();
+#endif
     Xcent0 = Xcent;
 
     trace(3, "DispMouseDown: X=%d Y=%d\n", X0, Y0);
@@ -1500,11 +1505,19 @@ void Plot::mouseMove(QMouseEvent *event)
 {
     double dx, dy, dxs, dys;
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     if ((abs(Disp->mapFromGlobal(event->globalPosition()).x() - Xn) < 1) &&
         (abs(Disp->mapFromGlobal(event->globalPosition()).y() - Yn) < 1)) return;
 
     Xn = Disp->mapFromGlobal(event->globalPosition()).x();
     Yn = Disp->mapFromGlobal(event->globalPosition()).y();
+#else
+    if ((abs(Disp->mapFromGlobal(event->globalPos()).x() - Xn) < 1) &&
+        (abs(Disp->mapFromGlobal(event->globalPos()).y() - Yn) < 1)) return;
+
+    Xn = Disp->mapFromGlobal(event->globalPos()).x();
+    Yn = Disp->mapFromGlobal(event->globalPos()).y();
+#endif
 
     trace(4, "DispMouseMove: X=%d Y=%d\n", Xn, Yn);
 
@@ -1528,8 +1541,11 @@ void Plot::mouseMove(QMouseEvent *event)
 // callback on mouse-up event -----------------------------------------------
 void Plot::mouseReleaseEvent(QMouseEvent *event)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     trace(3, "DispMouseUp: X=%d Y=%d\n", Disp->mapFromGlobal(event->globalPosition()).x(), Disp->mapFromGlobal(event->globalPosition()).y());
-
+#else
+    trace(3, "DispMouseUp: X=%d Y=%d\n", Disp->mapFromGlobal(event->globalPos()).x(), Disp->mapFromGlobal(event->globalPos()).y());
+#endif
     Drag = 0;
     setCursor(Qt::ArrowCursor);
     Refresh();

--- a/app/qtapp/rtkpost_qt/postmain.cpp
+++ b/app/qtapp/rtkpost_qt/postmain.cpp
@@ -400,7 +400,11 @@ void  MainForm::dragEnterEvent(QDragEnterEvent *event)
 }
 void  MainForm::dropEvent(QDropEvent *event)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     QPoint point=event->position().toPoint();
+#else
+    QPoint point=event->pos();
+#endif
     int top;
     
     if (!event->mimeData()->hasFormat("text/uri-list")) return;


### PR DESCRIPTION
This should fix #144.

There are some API's difference between Qt5 and Qt6. Commit f04f12728 added support for Qt6 but broke Qt5. 