### PR TITLE
Initialize the bias index table when reading DCB files too.

### DIFF
--- a/src/preceph.c
+++ b/src/preceph.c
@@ -452,8 +452,6 @@ static int readbiaf(const char *file, nav_t *nav)
 
     trace(3,"readbiaf: file=%s\n",file);
 
-    init_bias_ix(); /* init translation table from code to table column */
-
     if (!(fp=fopen(file,"r"))) {
         trace(2,"dcb parameters file open error: %s\n",file);
         return 0;
@@ -516,7 +514,9 @@ extern int readdcb(const char *file, nav_t *nav, const sta_t *sta)
     char *efiles[MAXEXFILE]={0};
     
     trace(3,"readdcb : file=%s\n",file);
-    
+
+    init_bias_ix(); /* init translation table from code to table column */
+
     for (i=0;i<MAXSAT;i++) for (j=0;j<MAX_CODE_BIAS_FREQS;j++) for (k=0;k<MAX_CODE_BIASES;k++) {
         nav->cbias[i][j][k]=0.0;
     }


### PR DESCRIPTION
Move the call to init_bias_ix() into readdcb() so that this table is also initialized when reading only DCB files, otherwise this table is uninitialized and the biases are usable in some paths.