### PR TITLE
Fix buffer overflow while parsing options and rename defines to not conflict with definitions from other projects

### DIFF
--- a/app/consapp/convbin/convbin.c
+++ b/app/consapp/convbin/convbin.c
@@ -289,9 +289,9 @@ static int convbin(int format, rnxopt_t *opt, const char *ifile, char **file,
     }
     for (i=0;i<NOUTFILE;i++) {
         if (!*dir||!*ofile[i]) continue;
-        if ((p=strrchr(ofile[i],FILEPATHSEP))) strcpy(work,p+1);
+        if ((p=strrchr(ofile[i],RTKLIB_FILEPATHSEP))) strcpy(work,p+1);
         else strcpy(work,ofile[i]);
-        sprintf(ofile[i],"%s%c%s",dir,FILEPATHSEP,work);
+        sprintf(ofile[i],"%s%c%s",dir,RTKLIB_FILEPATHSEP,work);
     }
     fprintf(stderr,"input file  : %s (%s)\n",ifile,formatstrs[format]);
     

--- a/app/qtapp/appcmn_qt/tspandlg.cpp
+++ b/app/qtapp/appcmn_qt/tspandlg.cpp
@@ -3,7 +3,6 @@
 #include <QShowEvent>
 #include <QDateTime>
 
-#define INHIBIT_RTK_LOCK_MACROS
 #include "rtklib.h"
 #include "plotmain.h"
 #include "tspandlg.h"

--- a/app/qtapp/rtkget_qt/getmain.h
+++ b/app/qtapp/rtkget_qt/getmain.h
@@ -8,7 +8,6 @@
 #include <QPixmap>
 #include <QSystemTrayIcon>
 
-#define INHIBIT_RTK_LOCK_MACROS
 #include "rtklib.h"
 
 #include "ui_getmain.h"

--- a/app/qtapp/rtkplot_qt/mapoptdlg.cpp
+++ b/app/qtapp/rtkplot_qt/mapoptdlg.cpp
@@ -1,6 +1,5 @@
 //---------------------------------------------------------------------------
 #include <stdio.h>
-#define INHIBIT_RTK_LOCK_MACROS
 #include "rtklib.h"
 
 #include <QShowEvent>

--- a/app/qtapp/rtkplot_qt/plotdraw.cpp
+++ b/app/qtapp/rtkplot_qt/plotdraw.cpp
@@ -5,7 +5,6 @@
 #include <QPainter>
 #include <QDebug>
 
-#define INHIBIT_RTK_LOCK_MACROS
 #include "rtklib.h"
 #include "plotmain.h"
 #include "graph.h"

--- a/app/qtapp/rtkplot_qt/plotmain.h
+++ b/app/qtapp/rtkplot_qt/plotmain.h
@@ -10,7 +10,6 @@
 
 #include "graph.h"
 #include "console.h"
-#define INHIBIT_RTK_LOCK_MACROS
 #include "rtklib.h"
 
 #include "ui_plotmain.h"

--- a/app/qtapp/rtkplot_qt/vmapdlg.cpp
+++ b/app/qtapp/rtkplot_qt/vmapdlg.cpp
@@ -3,8 +3,6 @@
 #include <QColorDialog>
 #include <QShowEvent>
 
-#define INHIBIT_RTK_LOCK_MACROS
-
 #include "vmapdlg.h"
 #include "plotmain.h"
 

--- a/src/download.c
+++ b/src/download.c
@@ -127,7 +127,7 @@ static void remot2local(const char *remot, const char *dir, char *local)
     else if ((p=strrchr(remot,'/'))) p++;
     else p=(char *)remot;
     
-    sprintf(local,"%s%c%s",dir,FILEPATHSEP,p);
+    sprintf(local,"%s%c%s",dir,RTKLIB_FILEPATHSEP,p);
 }
 /* test file existence -------------------------------------------------------*/
 static int exist_file(const char *local)
@@ -292,7 +292,7 @@ static int mkdir_r(const char *dir)
     if (!*dir||!strcmp(dir+1,":\\")) return 1;
     
     strcpy(pdir,dir);
-    if ((p=strrchr(pdir,FILEPATHSEP))) {
+    if ((p=strrchr(pdir,RTKLIB_FILEPATHSEP))) {
         *p='\0';
         h=FindFirstFile(pdir,&data);
         if (h==INVALID_HANDLE_VALUE) {
@@ -311,7 +311,7 @@ static int mkdir_r(const char *dir)
     if (!*dir) return 1;
     
     strcpy(pdir,dir);
-    if ((p=strrchr(pdir,FILEPATHSEP))) {
+    if ((p=strrchr(pdir,RTKLIB_FILEPATHSEP))) {
         *p='\0';
         if (!(fp=fopen(pdir,"r"))) {
             if (!mkdir_r(pdir)) return 0;
@@ -362,7 +362,7 @@ static int rep_paths(path_t *path, const char *file)
     strcpy(buff1,path->remot);
     strcpy(buff2,path->local);
     if ((p=strrchr(buff1,'/'))) p++; else p=buff1;
-    if ((q=strrchr(buff2,FILEPATHSEP))) q++; else q=buff2;
+    if ((q=strrchr(buff2,RTKLIB_FILEPATHSEP))) q++; else q=buff2;
     strcpy(p,file);
     strcpy(q,file);
     
@@ -434,7 +434,7 @@ static int exec_down(path_t *path, char *remot_p, const char *usr,
     opt2=" 2> /dev/null";
 #endif
     strcpy(dir,path->local);
-    if ((p=strrchr(dir,FILEPATHSEP))) *p='\0';
+    if ((p=strrchr(dir,RTKLIB_FILEPATHSEP))) *p='\0';
     
     if      (!strncmp(path->remot,"ftp://"  ,6)) proto=0;
     else if (!strncmp(path->remot,"ftps://" ,7)) proto=2;

--- a/src/options.c
+++ b/src/options.c
@@ -232,8 +232,9 @@ static int str2enum(const char *str, const char *comment, int *val)
     for (p=comment;;p++) {
        if (!(p=strstr(p,str))) break;
        if (*(p-1)!=':') continue;
-       for (p-=2;'0'<=*p&&*p<='9';p--) ;
-       return sscanf(p+1,"%d",val)==1;
+       for (p-=2;'0'<=*p&&*p<='9'&&p>comment;p--) ;
+       p = p == comment ? p : p + 1;
+       return sscanf(p,"%d",val)==1;
     }
     sprintf(s,"%.30s:",str);
     if ((p=strstr(comment,s))) { /* number */

--- a/src/rinex.c
+++ b/src/rinex.c
@@ -1685,7 +1685,7 @@ extern int readrnxt(const char *file, int rcv, gtime_t ts, gtime_t te,
     }
     /* if station name empty, set 4-char name from file head */
     if (type=='O'&&sta) {
-        if (!(p=strrchr(file,FILEPATHSEP))) p=file-1;
+        if (!(p=strrchr(file,RTKLIB_FILEPATHSEP))) p=file-1;
         if (!*sta->name) setstr(sta->name,p+1,4);
     }
     for (i=0;i<MAXEXFILE;i++) free(files[i]);

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -3039,24 +3039,24 @@ static char file_trace[1024];   /* trace file */
 static int level_trace=0;       /* level of trace */
 static uint32_t tick_trace=0;   /* tick time at traceopen (ms) */
 static gtime_t time_trace={0};  /* time at traceopen */
-static lock_t lock_trace;       /* lock for trace */
+static rtklib_lock_t lock_trace;       /* lock for trace */
 
 static void traceswap(void)
 {
     gtime_t time=utc2gpst(timeget());
     char path[1024];
     
-    lock(&lock_trace);
+    rtklib_lock(&lock_trace);
     
     if ((int)(time2gpst(time      ,NULL)/INT_SWAP_TRAC)==
         (int)(time2gpst(time_trace,NULL)/INT_SWAP_TRAC)) {
-        unlock(&lock_trace);
+        rtklib_unlock(&lock_trace);
         return;
     }
     time_trace=time;
     
     if (!reppath(file_trace,path,time,"","")) {
-        unlock(&lock_trace);
+        rtklib_unlock(&lock_trace);
         return;
     }
     if (fp_trace) fclose(fp_trace);
@@ -3064,7 +3064,7 @@ static void traceswap(void)
     if (!(fp_trace=fopen(path,"w"))) {
         fp_trace=stderr;
     }
-    unlock(&lock_trace);
+    rtklib_unlock(&lock_trace);
 }
 extern void traceopen(const char *file)
 {
@@ -3076,7 +3076,7 @@ extern void traceopen(const char *file)
     strcpy(file_trace,file);
     tick_trace=tickget();
     time_trace=time;
-    initlock(&lock_trace);
+    rtklib_initlock(&lock_trace);
 }
 extern void traceclose(void)
 {
@@ -3360,7 +3360,7 @@ static int mkdir_r(const char *dir)
     if (!*dir||!strcmp(dir+1,":\\")) return 1;
     
     sprintf(pdir,"%.1023s",dir);
-    if ((p=strrchr(pdir,FILEPATHSEP))) {
+    if ((p=strrchr(pdir,RTKLIB_FILEPATHSEP))) {
         *p='\0';
         h=FindFirstFile(pdir,&data);
         if (h==INVALID_HANDLE_VALUE) {
@@ -3377,7 +3377,7 @@ static int mkdir_r(const char *dir)
     if (!*dir) return 1;
     
     sprintf(pdir,"%.1023s",dir);
-    if ((p=strrchr(pdir,FILEPATHSEP))) {
+    if ((p=strrchr(pdir,RTKLIB_FILEPATHSEP))) {
         *p='\0';
         if (!(fp=fopen(pdir,"r"))) {
             if (!mkdir_r(pdir)) return 0;
@@ -3402,7 +3402,7 @@ extern void createdir(const char *path)
     tracet(3,"createdir: path=%s\n",path);
     
     strcpy(buff,path);
-    if (!(p=strrchr(buff,FILEPATHSEP))) return;
+    if (!(p=strrchr(buff,RTKLIB_FILEPATHSEP))) return;
     *p='\0';
     
     mkdir_r(buff);

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -524,23 +524,19 @@ extern "C" {
 #define P2_55       2.775557561562891E-17 /* 2^-55 */
 
 #ifdef WIN32
-#define thread_t    HANDLE
-#define lock_t      CRITICAL_SECTION
-#define initlock(f) InitializeCriticalSection(f)
-#define lock(f)     EnterCriticalSection(f)
-#define unlock(f)   LeaveCriticalSection(f)
-#define FILEPATHSEP '\\'
+#define rtklib_thread_t    HANDLE
+#define rtklib_lock_t      CRITICAL_SECTION
+#define rtklib_initlock(f) InitializeCriticalSection(f)
+#define rtklib_lock(f)     EnterCriticalSection(f)
+#define rtklib_unlock(f)   LeaveCriticalSection(f)
+#define RTKLIB_FILEPATHSEP '\\'
 #else
-#define thread_t    pthread_t
-#define lock_t      pthread_mutex_t
-#if defined( INHIBIT_RTK_LOCK_MACROS)
-#else
-/* these defs break apple mutex */
-#define initlock(f) pthread_mutex_init((f),NULL)
-#define lock(f)     pthread_mutex_lock(f)
-#define unlock(f)   pthread_mutex_unlock(f)
-#endif
-#define FILEPATHSEP '/'
+#define rtklib_thread_t    pthread_t
+#define rtklib_lock_t      pthread_mutex_t
+#define rtklib_initlock(f) pthread_mutex_init(f,NULL)
+#define rtklib_lock(f)     pthread_mutex_lock(f)
+#define rtklib_unlock(f)   pthread_mutex_unlock(f)
+#define RTKLIB_FILEPATHSEP '/'
 #endif
 
 /* type definitions ----------------------------------------------------------*/
@@ -1224,7 +1220,7 @@ typedef struct {        /* stream type */
     uint32_t tick_o;    /* output tick */
     uint32_t tact;      /* active tick */
     uint32_t inbt,outbt; /* input/output bytes at tick */
-    lock_t lock;        /* lock flag */
+    rtklib_lock_t lock; /* lock flag */
     void *port;         /* type dependent port control struct */
     char path[MAXSTRPATH]; /* stream path */
     char msg [MAXSTRMSG];  /* stream message */
@@ -1259,8 +1255,8 @@ typedef struct {        /* stream server type */
     stream_t stream[16]; /* input/output streams */
     stream_t strlog[16]; /* return log streams */
     strconv_t *conv[16]; /* stream converter */
-    thread_t thread;    /* server thread */
-    lock_t lock;        /* lock flag */
+    rtklib_thread_t thread; /* server thread */
+    rtklib_lock_t lock; /* lock flag */
 } strsvr_t;
 
 typedef struct {        /* RTK server type */
@@ -1294,7 +1290,7 @@ typedef struct {        /* RTK server type */
     stream_t stream[8]; /* streams {rov,base,corr,sol1,sol2,logr,logb,logc} */
     stream_t *moni;     /* monitor stream */
     uint32_t tick;      /* start tick */
-    thread_t thread;    /* server thread */
+    rtklib_thread_t thread; /* server thread */
     int cputime;        /* CPU time (ms) for a processing cycle */
     int prcout;         /* missing observation data count */
     int nave;           /* number of averaging base pos */
@@ -1302,7 +1298,7 @@ typedef struct {        /* RTK server type */
     char cmds_periodic[3][MAXRCVCMD]; /* periodic commands */
     char cmd_reset[MAXRCVCMD]; /* reset command */
     double bl_reset;    /* baseline length to reset (km) */
-    lock_t lock;        /* lock flag */
+    rtklib_lock_t lock; /* lock flag */
 } rtksvr_t;
 
 typedef struct {        /* GIS data point type */

--- a/src/stream.c
+++ b/src/stream.c
@@ -2317,7 +2317,7 @@ static void *ftpthread(void *arg)
     reppath(ftp->file,remote,time,"","");
     
     if ((p=strrchr(remote,'/'))) p++; else p=remote;
-    sprintf(local,"%.768s%c%.254s",localdir,FILEPATHSEP,p);
+    sprintf(local,"%.768s%c%.254s",localdir,RTKLIB_FILEPATHSEP,p);
     sprintf(errfile,"%.1019s.err",local);
     
     /* if local file exist, skip download */


### PR DESCRIPTION
Hi there!

While using rtklib for a project, I discovered these two small defects and fixed them:

1. While converting string options to an enum, it was possible to read out of bounds data, when iterating backwards through the comments.
2. The definitions for the different `lock...` methods and classes conflicted with definitions in the stdcpp library and / or some Qt libraries. I fixed this by renaming the defines to have an `rtklib_` prefix, to hopefully prevent this in the future.

I've also been working on improving the runtime performance of rtklib and was wondering whether these changes might also be of interested. I'll open a separate PR for some initial improvements and we can discuss there.