### PR TITLE
Replace some tabs with spaces.

### DIFF
--- a/app/consapp/convbin/convbin.c
+++ b/app/consapp/convbin/convbin.c
@@ -358,9 +358,9 @@ static int get_filetime(const char *file, gtime_t *time)
             time->sec=0.0;
             fclose(fp);
             return 1;
-		}
+        }
         fclose(fp);
-	}
+    }
     /* get modified time of input file */
     if (!stat(path,&st)&&(tm=gmtime(&st.st_mtime))) {
         ep[0]=tm->tm_year+1900;
@@ -385,7 +385,7 @@ static int cmdopts(int argc, char **argv, rnxopt_t *opt, char **ifile,
     
     opt->rnxver=304;
     opt->obstype=OBSTYPE_PR|OBSTYPE_CP;
-	opt->navsys=SYS_GPS|SYS_GLO|SYS_GAL|SYS_QZS|SYS_SBS|SYS_CMP|SYS_IRN;
+    opt->navsys=SYS_GPS|SYS_GLO|SYS_GAL|SYS_QZS|SYS_SBS|SYS_CMP|SYS_IRN;
     opt->ttol = 0.005;
     
     for (i=0;i<6;i++) for (j=0;j<64;j++) opt->mask[i][j]='1';

--- a/src/convgpx.c
+++ b/src/convgpx.c
@@ -155,8 +155,8 @@ extern int convgpx(const char *infile, const char *outfile, gtime_t ts,
     /* read solution file */
     if (!readsolt((char **)&infile,1,ts,te,tint,qflg,&solbuf)) return -1;
     
-	/* mean position */
-	for (i=0;i<3;i++) {
+    /* mean position */
+    for (i=0;i<3;i++) {
         for (j=0;j<solbuf.n;j++) rr[i]+=solbuf.data[j].rr[i];
         rr[i]/=solbuf.n;
     }

--- a/src/rcv/rt17.c
+++ b/src/rcv/rt17.c
@@ -470,7 +470,7 @@ EXPORT void free_rt17(raw_t *Raw)
 /* init_rt17 = Initialize RT17 dependent private storage */
 EXPORT int init_rt17(raw_t *Raw)
 {
-	rt17_t *rt17 = NULL;
+    rt17_t *rt17 = NULL;
     uint8_t *MessageBuffer = NULL, *PacketBuffer = NULL;
 
     if (Raw->format != STRFMT_RT17)
@@ -731,8 +731,8 @@ EXPORT int input_rt17f(raw_t *Raw, FILE *fp)
     
     for (i = 0; i < 4096; i++)
     {
-	if ((Data = fgetc(fp)) == EOF) return -2;
-	    if ((Ret = input_rt17(Raw, (uint8_t) Data))) return Ret;
+        if ((Data = fgetc(fp)) == EOF) return -2;
+            if ((Ret = input_rt17(Raw, (uint8_t) Data))) return Ret;
     }
 
     return 0; /* return at every 4k bytes */

--- a/src/rcv/ublox.c
+++ b/src/rcv/ublox.c
@@ -423,10 +423,10 @@ static int decode_rxmrawx(raw_t *raw)
         frqid=U1(p+23);    /* freqId (fcn + 7) */
         lockt=U2(p+24);    /* locktime (ms) */
         cn0  =U1(p+26);    /* cn0 (dBHz) */
-	prstd=U1(p+27)&15; /* pseudorange std-dev: (0.01*2^n meters) */
-	cpstd=U1(p+28)&15; /* cpStdev (n*0.004 m) */
-	/* subtract offset to use valid rinex format range (0->9) */
-	prstd=prstd>=5?prstd-5:0; /* prstd=0.01*2^(x-5) meters*/
+        prstd=U1(p+27)&15; /* pseudorange std-dev: (0.01*2^n meters) */
+        cpstd=U1(p+28)&15; /* cpStdev (n*0.004 m) */
+        /* subtract offset to use valid rinex format range (0->9) */
+        prstd=prstd>=5?prstd-5:0; /* prstd=0.01*2^(x-5) meters*/
 
         tstat=U1(p+30);    /* trkStat */
         if (!(tstat&1)) P=0.0;
@@ -1761,7 +1761,7 @@ extern int gen_ubx(const char *msg, uint8_t *buff)
         if (!*vcmd[k]) return 0;
 
         setU4(q,(unsigned long) vid[k]);
-	    q+=4;
+        q+=4;
 
         /* Set value */
         switch (vprm[k]) {

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -216,8 +216,8 @@ const prcopt_t prcopt_default={ /* defaults processing options */
     {1E-4,1E-3,1E-4,1E-1,1E-2,0.0}, /* prn[] */
     5E-12,                      /* sclkstab */
     {3.0,0.25,0.0,1E-9,1E-5,3.0,3.0,0.0}, /* thresar */
-	0.0,0.0,0.05,0,             /* elmaskar,elmaskhold,thresslip,thresdop, */
-	0.1,0.01,30.0,              /* varholdamb,gainholdamb,maxtdif */
+    0.0,0.0,0.05,0,             /* elmaskar,elmaskhold,thresslip,thresdop, */
+    0.1,0.01,30.0,              /* varholdamb,gainholdamb,maxtdif */
     {5.0,30.0},                 /* maxinno {phase,code} */
     {0},{0},{0},                /* baseline,ru,rb */
     {"",""},                    /* anttype */
@@ -267,13 +267,13 @@ static char *obscodes[]={       /* observation code strings */
 };
 static char codepris[7][MAXFREQ][16]={  /* code priority for each freq-index */
     /* L1/E1/B1I L2/E5b/B2I L5/E5a/B3I E6/LEX/B2A E5(a+b)         */
-	{"CPYWMNSLX","CPYWMNDLSX","IQX"     ,""       ,""       ,""}, /* GPS */
+    {"CPYWMNSLX","CPYWMNDLSX","IQX"     ,""       ,""       ,""}, /* GPS */
     {"CPABX"   ,"CPABX"     ,"IQX"     ,""       ,""       ,""}, /* GLO */
     {"CABXZ"   ,"XIQ"       ,"XIQ"     ,"ABCXZ"  ,"IQX"    ,""}, /* GAL */
     {"CLSXZ"   ,"LSX"       ,"IQXDPZ"  ,"LSXEZ"  ,""       ,""}, /* QZS */
     {"C"       ,"IQX"       ,""        ,""       ,""       ,""}, /* SBS */
-	{"IQXDPAN" ,"IQXDPZ"    ,"IQXA"    ,"DPX"   ,"DPX"    ,""}, /* BDS */
-	{"ABCX"    ,"ABCX"      ,""        ,""       ,""       ,""}  /* IRN */
+    {"IQXDPAN" ,"IQXDPZ"    ,"IQXA"    ,"DPX"   ,"DPX"    ,""}, /* BDS */
+    {"ABCX"    ,"ABCX"      ,""        ,""       ,""       ,""}  /* IRN */
 };
 static fatalfunc_t *fatalfunc=NULL; /* fatal callback function */
 

--- a/src/rtksvr.c
+++ b/src/rtksvr.c
@@ -490,73 +490,73 @@ static void periodic_cmd(int cycle, const char *cmd, stream_t *stream)
             strsendcmd(stream,msg);
         }
         if (!*q) break;
-	}
+    }
 }
 /* baseline length -----------------------------------------------------------*/
 static double baseline_len(const rtk_t *rtk)
 {
-	double dr[3];
-	int i;
+    double dr[3];
+    int i;
 
-	if (norm(rtk->sol.rr,3)<=0.0||norm(rtk->rb,3)<=0.0) return 0.0;
+    if (norm(rtk->sol.rr,3)<=0.0||norm(rtk->rb,3)<=0.0) return 0.0;
 
-	for (i=0;i<3;i++) {
-		dr[i]=rtk->sol.rr[i]-rtk->rb[i];
-	}
-	return norm(dr,3)*0.001; /* (km) */
+    for (i=0;i<3;i++) {
+        dr[i]=rtk->sol.rr[i]-rtk->rb[i];
+    }
+    return norm(dr,3)*0.001; /* (km) */
 }
 /* send nmea request to base/nrtk input stream -------------------------------*/
 static void send_nmea(rtksvr_t *svr, uint32_t *tickreset)
 {
-	sol_t sol_nmea={{0}};
-	double vel,bl;
-	uint32_t tick=tickget();
-	int i;
+    sol_t sol_nmea={{0}};
+    double vel,bl;
+    uint32_t tick=tickget();
+    int i;
 
-	if (svr->stream[1].state!=1) return;
-	sol_nmea.ns=10; /* Some servers don't like when ns = 0 */
+    if (svr->stream[1].state!=1) return;
+    sol_nmea.ns=10; /* Some servers don't like when ns = 0 */
 
-	if (svr->nmeareq==1) { /* lat-lon-hgt mode */
-		sol_nmea.stat=SOLQ_SINGLE;
-		sol_nmea.time=utc2gpst(timeget());
-		matcpy(sol_nmea.rr,svr->nmeapos,3,1);
-		strsendnmea(svr->stream+1,&sol_nmea);
-	}
-	else if (svr->nmeareq==2) { /* single-solution mode */
-		if (norm(svr->rtk.sol.rr,3)<=0.0) return;
-		sol_nmea.stat=SOLQ_SINGLE;
-		sol_nmea.time=utc2gpst(timeget());
-		matcpy(sol_nmea.rr,svr->rtk.sol.rr,3,1);
-		strsendnmea(svr->stream+1,&sol_nmea);
-	}
-	else if (svr->nmeareq==3) { /* reset-and-single-sol mode */
+    if (svr->nmeareq==1) { /* lat-lon-hgt mode */
+        sol_nmea.stat=SOLQ_SINGLE;
+        sol_nmea.time=utc2gpst(timeget());
+        matcpy(sol_nmea.rr,svr->nmeapos,3,1);
+        strsendnmea(svr->stream+1,&sol_nmea);
+    }
+    else if (svr->nmeareq==2) { /* single-solution mode */
+        if (norm(svr->rtk.sol.rr,3)<=0.0) return;
+        sol_nmea.stat=SOLQ_SINGLE;
+        sol_nmea.time=utc2gpst(timeget());
+        matcpy(sol_nmea.rr,svr->rtk.sol.rr,3,1);
+        strsendnmea(svr->stream+1,&sol_nmea);
+    }
+    else if (svr->nmeareq==3) { /* reset-and-single-sol mode */
 
-		/* send reset command if baseline over threshold */
-		bl=baseline_len(&svr->rtk);
-		if (bl>=svr->bl_reset&&(int)(tick-*tickreset)>MIN_INT_RESET) {
-			strsendcmd(svr->stream+1,svr->cmd_reset);
-			
-			tracet(2,"send reset: bl=%.3f rr=%.3f %.3f %.3f rb=%.3f %.3f %.3f\n",
-				   bl,svr->rtk.sol.rr[0],svr->rtk.sol.rr[1],svr->rtk.sol.rr[2],
-				   svr->rtk.rb[0],svr->rtk.rb[1],svr->rtk.rb[2]);
-			*tickreset=tick;
-		}
-		if (norm(svr->rtk.sol.rr,3)<=0.0) return;
-		sol_nmea.stat=SOLQ_SINGLE;
-		sol_nmea.time=utc2gpst(timeget());
-		matcpy(sol_nmea.rr,svr->rtk.sol.rr,3,1);
+        /* send reset command if baseline over threshold */
+        bl=baseline_len(&svr->rtk);
+        if (bl>=svr->bl_reset&&(int)(tick-*tickreset)>MIN_INT_RESET) {
+            strsendcmd(svr->stream+1,svr->cmd_reset);
+            
+            tracet(2,"send reset: bl=%.3f rr=%.3f %.3f %.3f rb=%.3f %.3f %.3f\n",
+                   bl,svr->rtk.sol.rr[0],svr->rtk.sol.rr[1],svr->rtk.sol.rr[2],
+                   svr->rtk.rb[0],svr->rtk.rb[1],svr->rtk.rb[2]);
+            *tickreset=tick;
+        }
+        if (norm(svr->rtk.sol.rr,3)<=0.0) return;
+        sol_nmea.stat=SOLQ_SINGLE;
+        sol_nmea.time=utc2gpst(timeget());
+        matcpy(sol_nmea.rr,svr->rtk.sol.rr,3,1);
 
-		/* set predicted position if velocity > 36km/h */
-		if ((vel=norm(svr->rtk.sol.rr+3,3))>10.0) {
-			for (i=0;i<3;i++) {
-				sol_nmea.rr[i]+=svr->rtk.sol.rr[i+3]/vel*svr->bl_reset*0.8;
-			}
-		}
-		strsendnmea(svr->stream+1,&sol_nmea);
+        /* set predicted position if velocity > 36km/h */
+        if ((vel=norm(svr->rtk.sol.rr+3,3))>10.0) {
+            for (i=0;i<3;i++) {
+                sol_nmea.rr[i]+=svr->rtk.sol.rr[i+3]/vel*svr->bl_reset*0.8;
+            }
+        }
+        strsendnmea(svr->stream+1,&sol_nmea);
 
-		tracet(3,"send nmea: rr=%.3f %.3f %.3f\n",sol_nmea.rr[0],sol_nmea.rr[1],
-			   sol_nmea.rr[2]);
-	}
+        tracet(3,"send nmea: rr=%.3f %.3f %.3f\n",sol_nmea.rr[0],sol_nmea.rr[1],
+               sol_nmea.rr[2]);
+    }
 }
 /* rtk server thread ---------------------------------------------------------*/
 #ifdef WIN32

--- a/src/src.pro
+++ b/src/src.pro
@@ -71,7 +71,7 @@ SOURCES += rtkcmn.c \
     rcv/rt17.c \
     rcv/septentrio.c \
     rcv/skytraq.c \
-	rcv/swiftnav.c \
+    rcv/swiftnav.c \
     rcv/ublox.c 
 
 HEADERS += rtklib.h

--- a/src/stream.c
+++ b/src/stream.c
@@ -1628,7 +1628,7 @@ static int rspntrip_c(ntrip_t *ntrip, char *msg)
         ntrip->state=2;
         sprintf(msg,"%s/%s",ntrip->tcp->svr.saddr,ntrip->mntpnt);
         tracet(3,"rspntrip_c: response ok nb=%d\n",ntrip->nb);
-		ntrip->tcp->tirecon=ticonnect;
+        ntrip->tcp->tirecon=ticonnect;
         return 1;
     }
     if ((p=strstr((char *)ntrip->buff,NTRIP_RSP_SRCTBL))) { /* source table */
@@ -1643,7 +1643,7 @@ static int rspntrip_c(ntrip_t *ntrip, char *msg)
         ntrip->nb=0;
         ntrip->buff[0]='\0';
         ntrip->state=0;
-		/* increase subsequent disconnect time to avoid too many reconnect requests */
+        /* increase subsequent disconnect time to avoid too many reconnect requests */
         if (ntrip->tcp->tirecon>300000) ntrip->tcp->tirecon=ntrip->tcp->tirecon*5/4;
 
         discontcp(&ntrip->tcp->svr,ntrip->tcp->tirecon);


### PR DESCRIPTION
Spaces give more consistent spacing and indentation than tabs across editors which might interpret tabs as 4 or 8 spaces, and many of the upstream files use spaces rather than tabs for indentation, so here is a suggestion to replace some of the sparse instances of tabs with spaces. Some code files use largely tabs and these are not patched to spaces here.