### PR TITLE
estpos: correct array allocations with QZSDT enabled

### DIFF
--- a/src/pntpos.c
+++ b/src/pntpos.c
@@ -415,7 +415,7 @@ static int estpos(const obsd_t *obs, int n, const double *rs, const double *dts,
     
     trace(3,"estpos  : n=%d\n",n);
     
-    v=mat(n+4,1); H=mat(NX,n+4); var=mat(n+4,1);
+    v=mat(n+NX-3,1); H=mat(NX,n+NX-3); var=mat(n+NX-3,1);
     
     for (i=0;i<3;i++) x[i]=sol->rr[i];
 


### PR DESCRIPTION
Fix memory corruption with QZSDT enabled and only one system configured.

rescode() can include up to (NX-3) extra constraints, and estpos() needs to allocate memory for all of these in the worst case, and was allocating an extra 4 rows but needs 5 extra rows with QZSDT enabled. Allocate an extra (NX-3) so that this handles more constraints being added in future, handles an increase in NX.