### PR TITLE
Add specialized dot product methods for vectors of size two and three

### DIFF
--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -293,7 +293,7 @@ extern void eph2pos(gtime_t time, const eph_t *eph, double *rs, double *dts,
 /* glonass orbit differential equations --------------------------------------*/
 static void deq(const double *x, double *xdot, const double *acc)
 {
-    double a,b,c,r2=dot(x,x,3),r3=r2*sqrt(r2),omg2=SQR(OMGE_GLO);
+    double a,b,c,r2=dot3(x,x),r3=r2*sqrt(r2),omg2=SQR(OMGE_GLO);
 
     if (r2<=0.0) {
         xdot[0]=xdot[1]=xdot[2]=xdot[3]=xdot[4]=xdot[5]=0.0;
@@ -684,7 +684,7 @@ static int satpos_ssr(gtime_t time, gtime_t teph, int sat, const nav_t *nav,
         dts[1]=eph->f1+2.0*eph->f2*tk;
 
         /* relativity correction */
-        dts[0]-=2.0*dot(rs,rs+3,3)/CLIGHT/CLIGHT;
+        dts[0]-=2.0*dot3(rs,rs+3)/CLIGHT/CLIGHT;
     }
     /* radial-along-cross directions in ecef */
     if (!normv3(rs+3,ea)) return 0;

--- a/src/pntpos.c
+++ b/src/pntpos.c
@@ -582,8 +582,8 @@ static int resdop(const obsd_t *obs, int n, const double *rs, const double *dts,
             vs[j]=rs[j+3+i*6]-x[j];
         }
         /* range rate with earth rotation correction */
-        rate=dot(vs,e,3)+OMGE/CLIGHT*(rs[4+i*6]*rr[0]+rs[1+i*6]*x[0]-
-                                      rs[3+i*6]*rr[1]-rs[  i*6]*x[1]);
+        rate=dot3(vs,e)+OMGE/CLIGHT*(rs[4+i*6]*rr[0]+rs[1+i*6]*x[0]-
+                                     rs[3+i*6]*rr[1]-rs[  i*6]*x[1]);
         
         /* Std of range rate error (m/s) */
         sig=(err<=0.0)?1.0:err*CLIGHT/freq;

--- a/src/ppp.c
+++ b/src/ppp.c
@@ -219,7 +219,7 @@ static void testeclipse(const obsd_t *obs, int n, const nav_t *nav, double *rs)
         if (*type&&!strstr(type,"BLOCK IIA")) continue;
 
         /* sun-earth-satellite angle */
-        cosa=dot(rs+i*6,esun,3)/r;
+        cosa=dot3(rs+i*6,esun)/r;
         cosa=cosa<-1.0?-1.0:(cosa>1.0?1.0:cosa);
         ang=acos(cosa);
 
@@ -263,9 +263,9 @@ static int sat_yaw(gtime_t time, int sat, const char *type, int opt,
     cross3(rsun,n,p);
     if (!normv3(rs,es)||!normv3(rsun,esun)||!normv3(n,en)||
         !normv3(p,ep)) return 0;
-    beta=PI/2.0-acos(dot(esun,en,3));
-    E=acos(dot(es,ep,3));
-    mu=PI/2.0+(dot(es,esun,3)<=0?-E:E);
+    beta=PI/2.0-acos(dot3(esun,en));
+    E=acos(dot3(es,ep));
+    mu=PI/2.0+(dot3(es,esun)<=0?-E:E);
     if      (mu<-PI/2.0) mu+=2.0*PI;
     else if (mu>=PI/2.0) mu-=2.0*PI;
 
@@ -309,15 +309,15 @@ static int model_phw(gtime_t time, int sat, const char *type, int opt,
     cross3(ek,eys,eks);
     cross3(ek,eyr,ekr);
     for (i=0;i<3;i++) {
-        ds[i]=exs[i]-ek[i]*dot(ek,exs,3)-eks[i];
-        dr[i]=exr[i]-ek[i]*dot(ek,exr,3)+ekr[i];
+        ds[i]=exs[i]-ek[i]*dot3(ek,exs)-eks[i];
+        dr[i]=exr[i]-ek[i]*dot3(ek,exr)+ekr[i];
     }
-    cosp=dot(ds,dr,3)/norm(ds,3)/norm(dr,3);
+    cosp=dot3(ds,dr)/norm(ds,3)/norm(dr,3);
     if      (cosp<-1.0) cosp=-1.0;
     else if (cosp> 1.0) cosp= 1.0;
     ph=acos(cosp)/2.0/PI;
     cross3(ds,dr,drs);
-    if (dot(ek,drs,3)<0.0) ph=-ph;
+    if (dot3(ek,drs)<0.0) ph=-ph;
 
     *phw=ph+floor(*phw-ph+0.5); /* in cycle */
     return 1;
@@ -841,7 +841,7 @@ static void satantpcv(const double *rs, const double *rr, const pcv_t *pcv,
     }
     if (!normv3(ru,eu)||!normv3(rz,ez)) return;
 
-    cosa=dot(eu,ez,3);
+    cosa=dot3(eu,ez);
     cosa=cosa<-1.0?-1.0:(cosa>1.0?1.0:cosa);
     nadir=acos(cosa);
 

--- a/src/preceph.c
+++ b/src/preceph.c
@@ -804,7 +804,7 @@ extern int peph2pos(gtime_t time, int sat, const nav_t *nav, int opt,
     }
     /* relativistic effect correction */
     if (dtss[0]!=0.0) {
-        dts[0]=dtss[0]-2.0*dot(rs,rs+3,3)/CLIGHT/CLIGHT;
+        dts[0]=dtss[0]-2.0*dot3(rs,rs+3)/CLIGHT/CLIGHT;
         dts[1]=(dtst[0]-dtss[0])/tt;
     }
     else { /* no precise clock */

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -1020,6 +1020,24 @@ extern double *eye(int n)
     if ((p=zeros(n,n))) for (i=0;i<n;i++) p[i+i*n]=1.0;
     return p;
 }
+
+/* dot product -----------------------------------------------------------------
+ * inner product of vectors of size 2
+ * args   : double *a,*b     I   vectors a and b
+ * return : a'*b
+ *-----------------------------------------------------------------------------*/
+extern double dot2(const double* a, const double* b) { return a[0] * b[0] + a[1] * b[1]; }
+
+/* dot product -----------------------------------------------------------------
+ * inner product of vectors of size 3
+ * args   : double *a,*b     I   vectors a and b
+ * return : a'*b
+ *-----------------------------------------------------------------------------*/
+extern double dot3(const double* a, const double* b)
+{
+  return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+
 /* inner product ---------------------------------------------------------------
 * inner product of vectors
 * args   : double *a,*b     I   vector a,b (n x 1)
@@ -1033,6 +1051,7 @@ extern double dot(const double *a, const double *b, int n)
     while (--n>=0) c+=a[n]*b[n];
     return c;
 }
+
 /* euclid norm -----------------------------------------------------------------
 * euclid norm of vector
 * args   : double *a        I   vector a (n x 1)
@@ -1244,6 +1263,7 @@ extern int solve(const char *tr, const double *A, const double *Y, int n,
     return info;
 }
 #endif
+
 /* end of matrix routines ----------------------------------------------------*/
 
 /* least square estimation -----------------------------------------------------
@@ -1945,7 +1965,7 @@ extern double dms2deg(const double *dms)
 *-----------------------------------------------------------------------------*/
 extern void ecef2pos(const double *r, double *pos)
 {
-    double e2=FE_WGS84*(2.0-FE_WGS84),r2=dot(r,r,2),z,zk,v=RE_WGS84,sinp;
+    double e2=FE_WGS84*(2.0-FE_WGS84),r2=dot2(r,r),z,zk,v=RE_WGS84,sinp;
     
     for (z=r[2],zk=0.0;fabs(z-zk)>=1E-4;) {
         zk=z;
@@ -3566,7 +3586,7 @@ extern double satazel(const double *pos, const double *e, double *azel)
     
     if (pos[2]>-RE_WGS84) {
         ecef2enu(pos,e,enu);
-        az=dot(enu,enu,2)<1E-12?0.0:atan2(enu[0],enu[1]);
+        az=dot2(enu,enu)<1E-12?0.0:atan2(enu[0],enu[1]);
         if (az<0.0) az+=2*PI;
         el=asin(enu[2]);
     }
@@ -3875,7 +3895,7 @@ extern void antmodel(const pcv_t *pcv, const double *del, const double *azel,
     for (i=0;i<NFREQ;i++) {
         for (j=0;j<3;j++) off[j]=pcv->off[i][j]+del[j];
         
-        dant[i]=-dot(off,e,3)+(opt?interpvar(90.0-azel[1]*R2D,pcv->var[i]):0.0);
+        dant[i]=-dot3(off,e)+(opt?interpvar(90.0-azel[1]*R2D,pcv->var[i]):0.0);
     }
     trace(4,"antmodel: dant=%6.3f %6.3f\n",dant[0],dant[1]);
 }

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1362,6 +1362,8 @@ EXPORT double *mat  (int n, int m);
 EXPORT int    *imat (int n, int m);
 EXPORT double *zeros(int n, int m);
 EXPORT double *eye  (int n);
+EXPORT double dot2(const double *a, const double *b);
+EXPORT double dot3(const double *a, const double *b);
 EXPORT double dot (const double *a, const double *b, int n);
 EXPORT double norm(const double *a, int n);
 EXPORT void cross3(const double *a, const double *b, double *c);

--- a/src/tides.c
+++ b/src/tides.c
@@ -61,7 +61,7 @@ static void tide_pl(const double *eu, const double *rp, double GMp,
     p=(3.0*sinl*sinl-1.0)/2.0;
     H2=0.6078-0.0006*p;
     L2=0.0847+0.0002*p;
-    a=dot(ep,eu,3);
+    a=dot3(ep,eu);
     dp=K2*3.0*L2*a;
     du=K2*(H2*(1.5*a*a-0.5)-3.0*L2*a*a);
     

--- a/util/testeph/diffeph.c
+++ b/util/testeph/diffeph.c
@@ -82,9 +82,9 @@ static void printephdiff(gtime_t time, int sat, int eph1, int eph2,
     cross3(rs2,rs2+3,rc);
     if (!normv3(rc,ec)) return;
     cross3(ea,ec,er);
-    drss[0]=dot(drs,er,3); /* radial/along-trk/cross-trk */
-    drss[1]=dot(drs,ea,3);
-    drss[2]=dot(drs,ec,3);
+    drss[0]=dot3(drs,er); /* radial/along-trk/cross-trk */
+    drss[1]=dot3(drs,ea);
+    drss[2]=dot3(drs,ec);
     
     if (topt) {
         time2str(time,tstr,0);


### PR DESCRIPTION
As discussed in #191, this is a separate PR for adding the specializations of the dot product methods.