### PR TITLE
matmu: improve cache data access patterns and hoist tests.

### DIFF
--- a/src/lambda.c
+++ b/src/lambda.c
@@ -191,7 +191,7 @@ extern int lambda(int n, int m, const double *a, const double *Q, double *F,
         
         /* lambda reduction (z=Z'*a, Qz=Z'*Q*Z=L'*diag(D)*L) */
         reduction(n,L,D,Z);
-        matmul("TN",n,1,n,1.0,Z,a,0.0,z); /* z=Z'*a */
+        matmul("TN",n,1,n,Z,a,z); /* z=Z'*a */
         
         /* mlambda search 
             z = transformed double-diff phase biases

--- a/src/pntpos.c
+++ b/src/pntpos.c
@@ -575,7 +575,7 @@ static int resdop(const obsd_t *obs, int n, const double *rs, const double *dts,
         a[0]=sin(azel[i*2])*cosel;
         a[1]=cos(azel[i*2])*cosel;
         a[2]=sin(azel[1+i*2]);
-        matmul("TN",3,1,3,1.0,E,a,0.0,e);
+        matmul("TN",3,1,3,E,a,e);
         
         /* satellite velocity relative to receiver in ECEF */
         for (j=0;j<3;j++) {

--- a/src/ppp.c
+++ b/src/ppp.c
@@ -587,9 +587,9 @@ static void udpos_ppp(rtk_t *rtk)
         }
     }
     /* x=F*x, P=F*P*F+Q */
-    matmul("NN",nx,1,nx,1.0,F,x,0.0,xp);
-    matmul("NN",nx,nx,nx,1.0,F,P,0.0,FP);
-    matmul("NT",nx,nx,nx,1.0,FP,F,0.0,P);
+    matmul("NN",nx,1,nx,F,x,xp);
+    matmul("NN",nx,nx,nx,F,P,FP);
+    matmul("NT",nx,nx,nx,FP,F,P);
 
     for (i=0;i<nx;i++) {
         rtk->x[ix[i]]=xp[i];

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -1105,19 +1105,42 @@ extern void matcpy(double *A, const double *B, int n, int m)
 #ifdef LAPACK /* with LAPACK/BLAS or MKL */
 
 /* multiply matrix (wrapper of blas dgemm) -------------------------------------
-* multiply matrix by matrix (C=alpha*A*B+beta*C)
+* multiply matrix by matrix (C=A*B)
 * args   : char   *tr       I  transpose flags ("N":normal,"T":transpose)
 *          int    n,k,m     I  size of (transposed) matrix A,B
-*          double alpha     I  alpha
 *          double *A,*B     I  (transposed) matrix A (n x m), B (m x k)
-*          double beta      I  beta
-*          double *C        IO matrix C (n x k)
+*          double *C        O matrix C (n x k)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void matmul(const char *tr, int n, int k, int m, double alpha,
-                   const double *A, const double *B, double beta, double *C)
+extern void matmul(const char *tr, int n, int k, int m,
+                   const double *A, const double *B, double *C)
 {
     int lda=tr[0]=='T'?m:n,ldb=tr[1]=='T'?k:m;
+    const double alpha=1,beta=0;
+
+    dgemm_((char *)tr,(char *)tr+1,&n,&k,&m,&alpha,(double *)A,&lda,(double *)B,
+           &ldb,&beta,C,&n);
+}
+/* multiply matrix (wrapper of blas dgemm) -------------------------------------
+* multiply matrix by matrix (C=C+A*B)
+*-----------------------------------------------------------------------------*/
+extern void matmulp(const char *tr, int n, int k, int m,
+                    const double *A, const double *B, double *C)
+{
+    int lda=tr[0]=='T'?m:n,ldb=tr[1]=='T'?k:m;
+    const double alpha=1,beta=1;
+
+    dgemm_((char *)tr,(char *)tr+1,&n,&k,&m,&alpha,(double *)A,&lda,(double *)B,
+           &ldb,&beta,C,&n);
+}
+/* multiply matrix (wrapper of blas dgemm) -------------------------------------
+* multiply matrix by matrix (C=C-A*B)
+*-----------------------------------------------------------------------------*/
+extern void matmulm(const char *tr, int n, int k, int m,
+                    const double *A, const double *B, double *C)
+{
+    int lda=tr[0]=='T'?m:n,ldb=tr[1]=='T'?k:m;
+    const double alpha=-1,beta=1;
     
     dgemm_((char *)tr,(char *)tr+1,&n,&k,&m,&alpha,(double *)A,&lda,(double *)B,
            &ldb,&beta,C,&n);
@@ -1167,21 +1190,136 @@ extern int solve(const char *tr, const double *A, const double *Y, int n,
 #else /* without LAPACK/BLAS or MKL */
 
 /* multiply matrix -----------------------------------------------------------*/
-extern void matmul(const char *tr, int n, int k, int m, double alpha,
-                   const double *A, const double *B, double beta, double *C)
+extern void matmul(const char *tr, int n, int k, int m,
+                   const double *A, const double *B, double *C)
 {
-    double d;
-    int i,j,x,f=tr[0]=='N'?(tr[1]=='N'?1:2):(tr[1]=='N'?3:4);
-    
-    for (i=0;i<n;i++) for (j=0;j<k;j++) {
-        d=0.0;
-        switch (f) {
-            case 1: for (x=0;x<m;x++) d+=A[i+x*n]*B[x+j*m]; break;
-            case 2: for (x=0;x<m;x++) d+=A[i+x*n]*B[j+x*k]; break;
-            case 3: for (x=0;x<m;x++) d+=A[x+i*m]*B[x+j*m]; break;
-            case 4: for (x=0;x<m;x++) d+=A[x+i*m]*B[j+x*k]; break;
-        }
-        if (beta==0.0) C[i+j*n]=alpha*d; else C[i+j*n]=alpha*d+beta*C[i+j*n];
+    int f=(tr[0]!='N')*2+(tr[1]!='N');
+
+    switch (f) {
+        case 0: /* NN */
+          for (int j=0;j<k;j++) {
+              for (int i=0;i<n;i++) {
+                  double d=0.0;
+                  for (int x=0;x<m;x++) d+=A[i+x*n]*B[x+j*m];
+                  C[i+j*n]=d;
+              }
+          }
+          break;
+        case 1: /* NT */
+          for (int j=0;j<k;j++) {
+              for (int i=0;i<n;i++) {
+                  double d=0.0;
+                  for (int x=0;x<m;x++) d+=A[i+x*n]*B[j+x*k];
+                  C[i+j*n]=d;
+              }
+          }
+          break;
+        case 2: /* TN */
+          for (int j=0;j<k;j++) {
+              for (int i=0;i<n;i++) {
+                  double d=0.0;
+                  for (int x=0;x<m;x++) d+=A[x+i*m]*B[x+j*m];
+                  C[i+j*n]=d;
+              }
+          }
+          break;
+        case 3: /* TT */
+          for (int j=0;j<k;j++) {
+              for (int i=0;i<n;i++) {
+                  double d=0.0;
+                  for (int x=0;x<m;x++) d+=A[x+i*m]*B[j+x*k];
+                  C[i+j*n]=d;
+              }
+          }
+          break;
+    }
+}
+extern void matmulp(const char *tr, int n, int k, int m,
+                    const double *A, const double *B, double *C)
+{
+    int f=(tr[0]!='N')*2+(tr[1]!='N');
+
+    switch (f) {
+        case 0: /* NN */
+          for (int j=0;j<k;j++) {
+              for (int i=0;i<n;i++) {
+                  double d=0.0;
+                  for (int x=0;x<m;x++) d+=A[i+x*n]*B[x+j*m];
+                  C[i+j*n]+=d;
+              }
+          }
+          break;
+        case 1: /* NT */
+          for (int j=0;j<k;j++) {
+              for (int i=0;i<n;i++) {
+                  double d=0.0;
+                  for (int x=0;x<m;x++) d+=A[i+x*n]*B[j+x*k];
+                  C[i+j*n]+=d;
+              }
+          }
+          break;
+        case 2: /* TN */
+          for (int j=0;j<k;j++) {
+              for (int i=0;i<n;i++) {
+                  double d=0.0;
+                  for (int x=0;x<m;x++) d+=A[x+i*m]*B[x+j*m];
+                  C[i+j*n]+=d;
+              }
+          }
+          break;
+        case 3: /* TT */
+          for (int j=0;j<k;j++) {
+              for (int i=0;i<n;i++) {
+                  double d=0.0;
+                  for (int x=0;x<m;x++) d+=A[x+i*m]*B[j+x*k];
+                  C[i+j*n]+=d;
+              }
+          }
+          break;
+    }
+}
+extern void matmulm(const char *tr, int n, int k, int m,
+                    const double *A, const double *B, double *C)
+{
+    int f=(tr[0]!='N')*2+(tr[1]!='N');
+
+    switch (f) {
+        case 0: /* NN */
+          for (int j=0;j<k;j++) {
+              for (int i=0;i<n;i++) {
+                  double d=0.0;
+                  for (int x=0;x<m;x++) d+=A[i+x*n]*B[x+j*m];
+                  C[i+j*n]-=d;
+              }
+          }
+          break;
+        case 1: /* NT */
+          for (int j=0;j<k;j++) {
+              for (int i=0;i<n;i++) {
+                  double d=0.0;
+                  for (int x=0;x<m;x++) d+=A[i+x*n]*B[j+x*k];
+                  C[i+j*n]-=d;
+              }
+          }
+          break;
+        case 2: /* TN */
+          for (int j=0;j<k;j++) {
+              for (int i=0;i<n;i++) {
+                  double d=0.0;
+                  for (int x=0;x<m;x++) d+=A[x+i*m]*B[x+j*m];
+                  C[i+j*n]-=d;
+              }
+          }
+          break;
+        case 3: /* TT */
+          for (int j=0;j<k;j++) {
+              for (int i=0;i<n;i++) {
+                  double d=0.0;
+                  for (int x=0;x<m;x++) d+=A[x+i*m]*B[j+x*k];
+                  C[i+j*n]-=d;
+              }
+          }
+          break;
     }
 }
 /* LU decomposition ----------------------------------------------------------*/
@@ -1258,7 +1396,7 @@ extern int solve(const char *tr, const double *A, const double *Y, int n,
     int info;
     
     matcpy(B,A,n,n);
-    if (!(info=matinv(B,n))) matmul(tr[0]=='N'?"NN":"TN",n,m,n,1.0,B,Y,0.0,X);
+    if (!(info=matinv(B,n))) matmul(tr[0]=='N'?"NN":"TN",n,m,n,B,Y,X);
     free(B);
     return info;
 }
@@ -1285,9 +1423,9 @@ extern int lsq(const double *A, const double *y, int n, int m, double *x,
     
     if (m<n) return -1;
     Ay=mat(n,1);
-    matmul("NN",n,1,m,1.0,A,y,0.0,Ay); /* Ay=A*y */
-    matmul("NT",n,n,m,1.0,A,A,0.0,Q);  /* Q=A*A' */
-    if (!(info=matinv(Q,n))) matmul("NN",n,1,n,1.0,Q,Ay,0.0,x); /* x=Q^-1*Ay */
+    matmul("NN",n,1,m,A,y,Ay); /* Ay=A*y */
+    matmul("NT",n,n,m,A,A,Q);  /* Q=A*A' */
+    if (!(info=matinv(Q,n))) matmul("NN",n,1,n,Q,Ay,x); /* x=Q^-1*Ay */
     free(Ay);
     return info;
 }
@@ -1317,13 +1455,13 @@ static int filter_(const double *x, const double *P, const double *H,
     
     matcpy(Q,R,m,m);
     matcpy(xp,x,n,1);
-    matmul("NN",n,m,n,1.0,P,H,0.0,F);       /* Q=H'*P*H+R */
-    matmul("TN",m,m,n,1.0,H,F,1.0,Q);
+    matmul("NN",n,m,n,P,H,F);       /* Q=H'*P*H+R */
+    matmulp("TN",m,m,n,H,F,Q);
     if (!(info=matinv(Q,m))) {
-        matmul("NN",n,m,m,1.0,F,Q,0.0,K);   /* K=P*H*Q^-1 */
-        matmul("NN",n,1,m,1.0,K,v,1.0,xp);  /* xp=x+K*v */
-        matmul("NT",n,n,m,-1.0,K,H,1.0,I);  /* Pp=(I-K*H')*P */
-        matmul("NN",n,n,n,1.0,I,P,0.0,Pp);
+        matmul("NN",n,m,m,F,Q,K);   /* K=P*H*Q^-1 */
+        matmulp("NN",n,1,m,K,v,xp);  /* xp=x+K*v */
+        matmulm("NT",n,n,m,K,H,I);  /* Pp=(I-K*H')*P */
+        matmul("NN",n,n,n,I,P,Pp);
     }
     free(F); free(Q); free(K); free(I);
     return info;
@@ -1380,9 +1518,9 @@ extern int smoother(const double *xf, const double *Qf, const double *xb,
     if (!matinv(invQf,n)&&!matinv(invQb,n)) {
         for (i=0;i<n*n;i++) Qs[i]=invQf[i]+invQb[i];
         if (!(info=matinv(Qs,n))) {
-            matmul("NN",n,1,n,1.0,invQf,xf,0.0,xx);
-            matmul("NN",n,1,n,1.0,invQb,xb,1.0,xx);
-            matmul("NN",n,1,n,1.0,Qs,xx,0.0,xs);
+            matmul("NN",n,1,n,invQf,xf,xx);
+            matmulp("NN",n,1,n,invQb,xb,xx);
+            matmul("NN",n,1,n,Qs,xx,xs);
         }
     }
     free(invQf); free(invQb); free(xx);
@@ -2027,7 +2165,7 @@ extern void ecef2enu(const double *pos, const double *r, double *e)
     double E[9];
     
     xyz2enu(pos,E);
-    matmul("NN",3,1,3,1.0,E,r,0.0,e);
+    matmul("NN",3,1,3,E,r,e);
 }
 /* transform local vector to ecef coordinate -----------------------------------
 * transform local tangential coordinate vector to ecef
@@ -2041,7 +2179,7 @@ extern void enu2ecef(const double *pos, const double *e, double *r)
     double E[9];
     
     xyz2enu(pos,E);
-    matmul("TN",3,1,3,1.0,E,e,0.0,r);
+    matmul("TN",3,1,3,E,e,r);
 }
 /* transform covariance to local tangential coordinate --------------------------
 * transform ecef covariance to local tangential coordinate
@@ -2055,8 +2193,8 @@ extern void covenu(const double *pos, const double *P, double *Q)
     double E[9],EP[9];
     
     xyz2enu(pos,E);
-    matmul("NN",3,3,3,1.0,E,P,0.0,EP);
-    matmul("NT",3,3,3,1.0,EP,E,0.0,Q);
+    matmul("NN",3,3,3,E,P,EP);
+    matmul("NT",3,3,3,EP,E,Q);
 }
 /* transform local enu coordinate covariance to xyz-ecef -----------------------
 * transform local enu covariance to xyz-ecef coordinate
@@ -2070,8 +2208,8 @@ extern void covecef(const double *pos, const double *Q, double *P)
     double E[9],EQ[9];
     
     xyz2enu(pos,E);
-    matmul("TN",3,3,3,1.0,E,Q,0.0,EQ);
-    matmul("NN",3,3,3,1.0,EQ,E,0.0,P);
+    matmul("TN",3,3,3,E,Q,EQ);
+    matmul("NN",3,3,3,EQ,E,P);
 }
 /* coordinate rotation matrix ------------------------------------------------*/
 #define Rx(t,X) do { \
@@ -2278,14 +2416,14 @@ extern void eci2ecef(gtime_t tutc, const double *erpv, double *U, double *gmst)
     z =(2306.2181*t+1.09468*t2+0.018203*t3)*AS2R;
     eps=(84381.448-46.8150*t-0.00059*t2+0.001813*t3)*AS2R;
     Rz(-z,R1); Ry(th,R2); Rz(-ze,R3);
-    matmul("NN",3,3,3,1.0,R1,R2,0.0,R);
-    matmul("NN",3,3,3,1.0,R, R3,0.0,P); /* P=Rz(-z)*Ry(th)*Rz(-ze) */
+    matmul("NN",3,3,3,R1,R2,R);
+    matmul("NN",3,3,3,R, R3,P); /* P=Rz(-z)*Ry(th)*Rz(-ze) */
     
     /* iau 1980 nutation */
     nut_iau1980(t,f,&dpsi,&deps);
     Rx(-eps-deps,R1); Rz(-dpsi,R2); Rx(eps,R3);
-    matmul("NN",3,3,3,1.0,R1,R2,0.0,R);
-    matmul("NN",3,3,3,1.0,R ,R3,0.0,N); /* N=Rx(-eps)*Rz(-dspi)*Rx(eps) */
+    matmul("NN",3,3,3,R1,R2,R);
+    matmul("NN",3,3,3,R ,R3,N); /* N=Rx(-eps)*Rz(-dspi)*Rx(eps) */
     
     /* greenwich aparent sidereal time (rad) */
     gmst_=utc2gmst(tutc_,erpv[2]);
@@ -2294,10 +2432,10 @@ extern void eci2ecef(gtime_t tutc, const double *erpv, double *U, double *gmst)
     
     /* eci to ecef transformation matrix */
     Ry(-erpv[0],R1); Rx(-erpv[1],R2); Rz(gast,R3);
-    matmul("NN",3,3,3,1.0,R1,R2,0.0,W );
-    matmul("NN",3,3,3,1.0,W ,R3,0.0,R ); /* W=Ry(-xp)*Rx(-yp) */
-    matmul("NN",3,3,3,1.0,N ,P ,0.0,NP);
-    matmul("NN",3,3,3,1.0,R ,NP,0.0,U_); /* U=W*Rz(gast)*N*P */
+    matmul("NN",3,3,3,R1,R2,W );
+    matmul("NN",3,3,3,W ,R3,R ); /* W=Ry(-xp)*Rx(-yp) */
+    matmul("NN",3,3,3,N ,P ,NP);
+    matmul("NN",3,3,3,R ,NP,U_); /* U=W*Rz(gast)*N*P */
     
     for (i=0;i<9;i++) U[i]=U_[i];
     if (gmst) *gmst=gmst_; 
@@ -3414,7 +3552,7 @@ extern void dops(int ns, const double *azel, double elmin, double *dop)
     }
     if (n<4) return;
     
-    matmul("NT",4,4,n,1.0,H,H,0.0,Q);
+    matmul("NT",4,4,n,H,H,Q);
     if (!matinv(Q,4)) {
         dop[0]=SQRT(Q[0]+Q[5]+Q[10]+Q[15]); /* GDOP */
         dop[1]=SQRT(Q[0]+Q[5]+Q[10]);       /* PDOP */
@@ -3782,8 +3920,8 @@ extern void sunmoonpos(gtime_t tutc, const double *erpv, double *rsun,
     eci2ecef(tutc,erpv,U,&gmst_);
     
     /* sun and moon position in ecef */
-    if (rsun ) matmul("NN",3,1,3,1.0,U,rs,0.0,rsun );
-    if (rmoon) matmul("NN",3,1,3,1.0,U,rm,0.0,rmoon);
+    if (rsun ) matmul("NN",3,1,3,U,rs,rsun );
+    if (rmoon) matmul("NN",3,1,3,U,rm,rmoon);
     if (gmst ) *gmst=gmst_;
 }
 /* uncompress file -------------------------------------------------------------

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1370,8 +1370,12 @@ EXPORT double norm(const double *a, int n);
 EXPORT void cross3(const double *a, const double *b, double *c);
 EXPORT int  normv3(const double *a, double *b);
 EXPORT void matcpy(double *A, const double *B, int n, int m);
-EXPORT void matmul(const char *tr, int n, int k, int m, double alpha,
-                   const double *A, const double *B, double beta, double *C);
+EXPORT void matmul(const char *tr, int n, int k, int m,
+                   const double *A, const double *B, double *C);
+EXPORT void matmulp(const char *tr, int n, int k, int m,
+                    const double *A, const double *B, double *C);
+EXPORT void matmulm(const char *tr, int n, int k, int m,
+                    const double *A, const double *B, double *C);
 EXPORT int  matinv(double *A, int n);
 EXPORT int  solve (const char *tr, const double *A, const double *Y, int n,
                    int m, double *X);

--- a/src/rtkpos.c
+++ b/src/rtkpos.c
@@ -549,9 +549,9 @@ static void udpos(rtk_t *rtk, double tt)
         }
     }
     /* x=F*x, P=F*P*F' */
-    matmul("NN",nx,1,nx,1.0,F,x,0.0,xp);
-    matmul("NN",nx,nx,nx,1.0,F,P,0.0,FP);
-    matmul("NT",nx,nx,nx,1.0,FP,F,0.0,P);
+    matmul("NN",nx,1,nx,F,x,xp);
+    matmul("NN",nx,nx,nx,F,P,FP);
+    matmul("NT",nx,nx,nx,FP,F,P);
     
     for (i=0;i<nx;i++) {
         rtk->x[ix[i]]=xp[i];
@@ -1737,13 +1737,13 @@ static int resamb_LAMBDA(rtk_t *rtk, double *bias, double *xa,int gps,int glo,in
             /* adjust non phase-bias states and covariances using fixed solution values */
             if (!matinv(Qb,nb)) {  /* returns 0 if inverse successful */
                 /* rtk->xa = rtk->x-Qab*Qb^-1*(b0-b) */
-                matmul("NN",nb,1,nb, 1.0,Qb ,y,0.0,db); /* db = Qb^-1*(b0-b) */
-                matmul("NN",na,1,nb,-1.0,Qab,db,1.0,rtk->xa); /* rtk->xa = rtk->x-Qab*db */
+                matmul("NN",nb,1,nb,Qb ,y,db); /* db = Qb^-1*(b0-b) */
+                matmulm("NN",na,1,nb,Qab,db,rtk->xa); /* rtk->xa = rtk->x-Qab*db */
                 
                 /* rtk->Pa=rtk->P-Qab*Qb^-1*Qab') */
                 /* covariance of fixed solution (Qa=Qa-Qab*Qb^-1*Qab') */
-                matmul("NN",na,nb,nb, 1.0,Qab,Qb ,0.0,QQ);  /* QQ = Qab*Qb^-1 */
-                matmul("NT",na,na,nb,-1.0,QQ ,Qab,1.0,rtk->Pa); /* rtk->Pa = rtk->P-QQ*Qab' */
+                matmul("NN",na,nb,nb,Qab,Qb ,QQ);  /* QQ = Qab*Qb^-1 */
+                matmulm("NT",na,na,nb,QQ ,Qab,rtk->Pa); /* rtk->Pa = rtk->P-QQ*Qab' */
                 
                 trace(3,"resamb : validation ok (nb=%d ratio=%.2f thresh=%.2f s=%.2f/%.2f)\n",
                       nb,s[0]==0.0?0.0:s[1]/s[0],rtk->sol.thres,s[0],s[1]);

--- a/src/tides.c
+++ b/src/tides.c
@@ -276,12 +276,12 @@ extern void tidedisp(gtime_t tutc, const double *rr, int opt, const erp_t *erp,
     }
     if ((opt&2)&&odisp) { /* ocean tide loading */
         tide_oload(tut,odisp,denu);
-        matmul("TN",3,1,3,1.0,E,denu,0.0,drt);
+        matmul("TN",3,1,3,E,denu,drt);
         for (i=0;i<3;i++) dr[i]+=drt[i];
     }
     if ((opt&4)&&erp) { /* pole tide */
         tide_pole(tut,pos,erpv,denu);
-        matmul("TN",3,1,3,1.0,E,denu,0.0,drt);
+        matmul("TN",3,1,3,E,denu,drt);
         for (i=0;i<3;i++) dr[i]+=drt[i];
     }
     trace(5,"tidedisp: dr=%.3f %.3f %.3f\n",dr[0],dr[1],dr[2]);

--- a/src/tle.c
+++ b/src/tle.c
@@ -562,12 +562,12 @@ extern int tle_pos(gtime_t time, const char *name, const char *satno,
     R1[0]=1.0; R1[4]=R1[8]=cos(-erpv[1]); R1[7]=sin(-erpv[1]); R1[5]=-R1[7];
     R2[4]=1.0; R2[0]=R2[8]=cos(-erpv[0]); R2[2]=sin(-erpv[0]); R2[6]=-R2[2];
     R3[8]=1.0; R3[0]=R3[4]=cos(gmst); R3[3]=sin(gmst); R3[1]=-R3[3];
-    matmul("NN",3,1,3,1.0,R3,rs_tle  ,0.0,rs_pef  );
-    matmul("NN",3,1,3,1.0,R3,rs_tle+3,0.0,rs_pef+3);
+    matmul("NN",3,1,3,R3,rs_tle  ,rs_pef  );
+    matmul("NN",3,1,3,R3,rs_tle+3,rs_pef+3);
     rs_pef[3]+=OMGE*rs_pef[1];
     rs_pef[4]-=OMGE*rs_pef[0];
-    matmul("NN",3,3,3,1.0,R1,R2,0.0,W);
-    matmul("NN",3,1,3,1.0,W,rs_pef  ,0.0,rs  );
-    matmul("NN",3,1,3,1.0,W,rs_pef+3,0.0,rs+3);
+    matmul("NN",3,3,3,R1,R2,W);
+    matmul("NN",3,1,3,W,rs_pef  ,rs  );
+    matmul("NN",3,1,3,W,rs_pef+3,rs+3);
     return 1;
 }


### PR DESCRIPTION
Reorder the loop iteration over the arrays to prioritise sequential linear access patterns, attempting to improving data cache efficiency.

Hoist the test for the special case of beta being zero out of the loops. This is a necessary special case, not just for performance optimization as it avoids reading from the C array.

Add a further special case for both beta and alpha being zero. This is just a performance optimization. This case occurs in some very hot code so it makes a further small improvement.

Inspired by https://github.com/rtklibexplorer/RTKLIB/pull/197 credit to @jwidauer

There are a few special cases that are very hot code, and noted in particular the following which account for most of
the time in matmul(). So it helps to optimize these by hoisting the tests and adding a further special case for alpha 1.0 and beta 0.0 
* matmul() 'NN' with alpha 1.0 and beta 0.0
* matmul() 'NT' with alpha 1.0 and beta 0.0
* matmul() 'NT' general case for alpha and beta
* matmul() 'TN' general case for alpha and beta
