### PR TITLE
convrnx: antenna xyz delta handling due to no position

### DIFF
--- a/src/convrnx.c
+++ b/src/convrnx.c
@@ -557,7 +557,7 @@ static void setopt_sta(const strfile_t *str, rnxopt_t *opt)
         ;
     }
     else if (norm(sta->del,3)>0.0) {
-        if (!sta->deltype&&norm(sta->del,3)>0.0) { /* enu */
+        if (!sta->deltype) { /* enu */
             opt->antdel[0]=sta->del[2]; /* h */
             opt->antdel[1]=sta->del[0]; /* e */
             opt->antdel[2]=sta->del[1]; /* n */
@@ -568,6 +568,8 @@ static void setopt_sta(const strfile_t *str, rnxopt_t *opt)
             opt->antdel[0]=enu[2]; /* h */
             opt->antdel[1]=enu[0]; /* e */
             opt->antdel[2]=enu[1]; /* n */
+        } else {
+            trace(2,"failed to update RINEX option antenna delta from xyz due to no station position\n");
         }
     }
     else {
@@ -931,7 +933,7 @@ static void outrnxevent(FILE *fp, const rnxopt_t *opt, gtime_t time, int event,
         
         /* antenna delta */
         if (norm(p->sta.del,3)>0.0) {
-            if (!p->sta.deltype&&norm(p->sta.del,3)>0.0) { /* enu */
+            if (!p->sta.deltype) { /* enu */
                 del[0]=p->sta.del[2]; /* h */
                 del[1]=p->sta.del[0]; /* e */
                 del[2]=p->sta.del[1]; /* n */
@@ -942,6 +944,9 @@ static void outrnxevent(FILE *fp, const rnxopt_t *opt, gtime_t time, int event,
                 del[0]=enu[2]; /* h */
                 del[1]=enu[0]; /* e */
                 del[2]=enu[1]; /* n */
+            } else {
+                trace(2,"failed to output RINEX option antenna delta from xyz due to no station position\n");
+                del[0]=del[1]=del[2]=0.0;
             }
         }
         else {


### PR DESCRIPTION
The case in which a station antenna xyz delta fails to be set due to a lack of a station position was not be handled, and in outrnxevent() was leading to the use of uninitialized data.

Also omit a redundant checkout for the station antenna delta.

Noted a compiler warning here, and there does appear to be a path in which uninitialized data might be used. Not sure of the appropriate handling in this case but it does appear to be an error path so have it emit a trace warning and in setopt_sta() not update the options and in outrnxevent() default to a delta of zero even ignoring a station height.
