### PR TITLE
kepler: continue on an iteration overflow

### DIFF
--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -167,7 +167,6 @@ extern void alm2pos(gtime_t time, const alm_t *alm, double *rs, double *dts)
     }
     if (n>=MAX_ITER_KEPLER) {
         trace(2,"alm2pos: kepler iteration overflow sat=%2d\n",alm->sat);
-        return;
     }
     sinE=sin(E); cosE=cos(E);
     u=atan2(sqrt(1.0-alm->e*alm->e)*sinE,cosE-alm->e)+alm->omg;
@@ -245,7 +244,6 @@ extern void eph2pos(gtime_t time, const eph_t *eph, double *rs, double *dts,
     }
     if (n>=MAX_ITER_KEPLER) {
         trace(2,"eph2pos: kepler iteration overflow sat=%2d\n",eph->sat);
-        return;
     }
     sinE=sin(E); cosE=cos(E);
 


### PR DESCRIPTION
Rare if not typically impossible case in which uninitialized data is used.

Continue to use the iterative solution in the exceptional case of an iteration overflow, rather than returning with uninitialized function outputs.

In this exceptional case, the solution is likely as good as can be with the numerical precision.

The current return path was not setting the function outputs on that return path and the callers may be using uninitialized data in this case.