### PR TITLE
satpos_sbas: check the return value of ephpos()

### DIFF
--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -603,7 +603,7 @@ static int satpos_sbas(gtime_t time, gtime_t teph, int sat, const nav_t *nav,
     }
     if (i>=nav->sbssat.nsat) {
         trace(2,"no sbas, use brdcast: %s sat=%2d\n",time_str(time,0),sat);
-        ephpos(time,teph,sat,nav,-1,rs,dts,var,svh);
+        if (!ephpos(time,teph,sat,nav,-1,rs,dts,var,svh)) return 0;
         /* *svh=-1; */ /* use broadcast if no sbas */
         return 1;
     }


### PR DESCRIPTION
Return 0, an error, in the case that a fallback call to ephpos() returns an error, rather than returning success in this case.

Btw find it a little hard to follow the logic here with the satellite health return value svh, but have not touched that assuming that if a correction is not expected then not to mark the result as uncorrected, not to set svh to -1?