### PR TITLE
gis read_polygon: correct malloc sizeof gis_polygon_t

### DIFF
--- a/src/gis.c
+++ b/src/gis.c
@@ -209,7 +209,7 @@ static int read_polygon(FILE *fp, double *bound, gisd_t **p)
     for (i=0;i<nt;i++) {
         nr=(i<nt-1?part[i+1]:np)-part[i];
         
-        if (!(polygon=(gis_polygon_t *)malloc(sizeof(gis_poly_t)))) {
+        if (!(polygon=(gis_polygon_t *)malloc(sizeof(gis_polygon_t)))) {
             free(part);
             return 0;
         }


### PR DESCRIPTION
Was using sizeof gis_poly_t which is at present the same size.