### PR TITLE
sbas decode_sbstype6: avoid oob read from iodf[]

### DIFF
--- a/src/sbas.c
+++ b/src/sbas.c
@@ -196,7 +196,8 @@ static int decode_sbstype6(const sbsmsg_t *msg, sbssat_t *sbssat)
     for (i=0;i<4;i++) {
         iodf[i]=getbitu(msg->msg,14+i*2,2);
     }
-    for (i=0;i<sbssat->nsat&&i<MAXSAT;i++) {
+    /* Limited to 51 to avoid overflow of iodf[] */
+    for (i=0;i<sbssat->nsat&&i<=51;i++) {
         if (sbssat->sat[i].fcorr.iodf!=iodf[i/13]) continue;
         udre=getbitu(msg->msg,22+i*4,4);
         sbssat->sat[i].fcorr.udre=udre+1;


### PR DESCRIPTION
No expert in this area, but there appears a possibility of an oob read from iodf[] that might be best guarded against. See also https://github.com/tomojitakasu/RTKLIB/issues/747

Just guarding indexing into iodf[] in decode_sbstype6() rather than limiting sbssat->nsat in decode_sbstype1().

Seems to concur with Annex 10 3.5.4.1 of the Convention on International Civil Aviation "The [PRN] mask shall set up to 51 of the 210 PRN mask values"