### PR TITLE
stream writeserial: patch writes for non-WIN32 platforms

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -525,6 +525,7 @@ static int readserial(serial_t *serial, uint8_t *buff, int n, char *msg)
     
     /* write received stream to tcp server port */
     if (serial->tcpsvr&&nr>0) {
+        /* TODO handle no-blocking write ? */
         writetcpsvr(serial->tcpsvr,buff,(int)nr,msg_tcp);
     }
     return nr;
@@ -540,7 +541,12 @@ static int writeserial(serial_t *serial, uint8_t *buff, int n, char *msg)
 #ifdef WIN32
     if ((ns=writeseribuff(serial,buff,n))<n) serial->error=1;
 #else
-    if (write(serial->dev,buff,n)<n) {
+    ns=write(serial->dev,buff,n);
+    if (ns<0) {
+        if (errno==EAGAIN) {
+            /* TODO ?? */
+        }
+        ns = 0;
         serial->error=1;
     }
 #endif


### PR DESCRIPTION
The non-WIN32 path was always returning 0 indicating an error.

Further it was flagging an error if not all the buffer was written.

The serial connection is opened non-blocking. So the write can return less than the full amount requested. This function appears intended to be non-blocking, so in this case return the amount written rather than flagging an error.

This is not a complete fix which might be more extensive. The write can also return zero which is not necessarily an error, and it might also return -1 and set errno to EAGAIN if it would have blocked.