### PR TITLE
scanf string maximum widths

### DIFF
--- a/app/winapp/rtkget/getmain.cpp
+++ b/app/winapp/rtkget/getmain.cpp
@@ -752,7 +752,7 @@ void __fastcall TMainForm::GetTime(gtime_t *ts, gtime_t *te, double *ti)
     *ti=86400.0;
     
     str=TimeInt->Text;
-    if (sscanf(str.c_str(),"%lf%s",&val,unit)>=1) {
+    if (sscanf(str.c_str(),"%lf%31s",&val,unit)>=1) {
         if      (!strcmp(unit,"day")) *ti=val*86400.0;
         else if (!strcmp(unit,"min")) *ti=val*60.0;
         else                          *ti=val*3600.0;

--- a/app/winapp/rtkplot/plotdata.cpp
+++ b/app/winapp/rtkplot/plotdata.cpp
@@ -936,7 +936,7 @@ void __fastcall TPlot::ReadStaPos(const char *file, const char *sta,
             }
         }
         else {
-            if (sscanf(buff,"%lf %lf %lf %s",pos,pos+1,pos+2,code)<4) continue;
+            if (sscanf(buff,"%lf %lf %lf %255s",pos,pos+1,pos+2,code)<4) continue;
             if (strcmp(code,sta)) continue;
             pos[0]*=D2R;
             pos[1]*=D2R;

--- a/app/winapp/rtkplot/plotmain.cpp
+++ b/app/winapp/rtkplot/plotmain.cpp
@@ -1197,7 +1197,7 @@ void __fastcall TPlot::RangeListClick(TObject *Sender)
     if ((i=RangeList->ItemIndex)<0) return;
     
     str=RangeList->Items->Strings[i];
-    if (sscanf(str.c_str(),"%lf%s",&YRange,unit)<1) return;
+    if (sscanf(str.c_str(),"%lf%31s",&YRange,unit)<1) return;
     if      (!strcmp(unit,"cm")) YRange*=0.01;
     else if (!strcmp(unit,"km")) YRange*=1000.0;
     

--- a/src/postpos.c
+++ b/src/postpos.c
@@ -825,7 +825,7 @@ static int getstapos(const char *file, char *name, double *r)
     while (fgets(buff,sizeof(buff),fp)) {
         if ((p=strchr(buff,'%'))) *p='\0';
         
-        if (sscanf(buff,"%lf %lf %lf %s",pos,pos+1,pos+2,sname)<4) continue;
+        if (sscanf(buff,"%lf %lf %lf %255s",pos,pos+1,pos+2,sname)<4) continue;
         
         for (p=sname,q=name;*p&&*q;p++,q++) {
             if (toupper((int)*p)!=toupper((int)*q)) break;

--- a/src/preceph.c
+++ b/src/preceph.c
@@ -391,7 +391,8 @@ static int readdcbf(const char *file, nav_t *nav, const sta_t *sta)
         if      (strstr(buff,"DIFFERENTIAL (P1-C1) CODE BIASES")) type=1;
         else if (strstr(buff,"DIFFERENTIAL (P2-C2) CODE BIASES")) type=2;
 
-        if (!type||sscanf(buff,"%s %s",str1,str2)<1) continue;
+        str2[0]='\0';
+        if (!type||sscanf(buff,"%31s %31s",str1,str2)<1) continue;
 
         if ((cbias=str2num(buff,26,9))==0.0) continue;
 

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -1840,7 +1840,7 @@ static int read_leaps_usno(FILE *fp)
     rewind(fp);
     
     while (fgets(buff,sizeof(buff),fp)&&n<MAXLEAPS) {
-        if (sscanf(buff,"%d %s %d =JD %lf TAI-UTC= %lf",&y,month,&d,&jd,
+        if (sscanf(buff,"%d %31s %d =JD %lf TAI-UTC= %lf",&y,month,&d,&jd,
                    &tai_utc)<5) continue;
         if (y<1980) continue;
         for (m=1;m<=12;m++) if (!strcmp(months[m-1],month)) break;
@@ -2698,7 +2698,7 @@ extern void readpos(const char *file, const char *rcv, double *pos)
     }
     while (np<2048&&fgets(buff,sizeof(buff),fp)) {
         if (buff[0]=='%'||buff[0]=='#') continue;
-        if (sscanf(buff,"%lf %lf %lf %s",&poss[np][0],&poss[np][1],&poss[np][2],
+        if (sscanf(buff,"%lf %lf %lf %255s",&poss[np][0],&poss[np][1],&poss[np][2],
                    str)<4) continue;
         sprintf(stas[np++],"%.15s",str);
     }
@@ -2738,10 +2738,10 @@ static int readblqrecord(FILE *fp, double *odisp)
 extern int readblq(const char *file, const char *sta, double *odisp)
 {
     FILE *fp;
-    char buff[256],staname[32]="",name[32],*p;
+    char buff[256],staname[17]="",name[17],*p;
     
     /* station name to upper case */
-    (void)sscanf(sta,"%16s",staname);
+    if (sscanf(sta,"%16s",staname)<1) return 0;
     for (p=staname;(*p=(char)toupper((int)(*p)));p++) ;
     
     if (!(fp=fopen(file,"r"))) {
@@ -2775,7 +2775,6 @@ extern int readerp(const char *file, erp_t *erp)
 {
     FILE *fp;
     erpd_t *erp_data;
-    double v[14]={0};
     char buff[256];
     
     trace(3,"readerp: file=%s\n",file);
@@ -2785,6 +2784,7 @@ extern int readerp(const char *file, erp_t *erp)
         return 0;
     }
     while (fgets(buff,sizeof(buff),fp)) {
+        double v[14]={0};
         if (sscanf(buff,"%lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf",
                    v,v+1,v+2,v+3,v+4,v+5,v+6,v+7,v+8,v+9,v+10,v+11,v+12,v+13)<5) {
             continue;

--- a/src/solution.c
+++ b/src/solution.c
@@ -1055,7 +1055,7 @@ static int decode_solstat(char *buff, solstat_t *stat)
     
     for (p=buff;*p;p++) if (*p==',') *p=' ';
     
-    n=sscanf(buff,"$SAT%d%lf%s%d%lf%lf%lf%lf%d%lf%d%d%d%d%d%d",
+    n=sscanf(buff,"$SAT%d%lf%31s%d%lf%lf%lf%lf%d%lf%d%d%d%d%d%d",
              &week,&tow,id,&frq,&az,&el,&resp,&resc,&vsat,&snr,&fix,&slip,
              &lock,&outc,&slipc,&rejc);
     

--- a/src/stream.c
+++ b/src/stream.c
@@ -377,7 +377,7 @@ static serial_t *openserial(const char *path, int mode, char *msg)
     
     if ((p=strchr(path,':'))) {
         strncpy(port,path,p-path); port[p-path]='\0';
-        sscanf(p,":%d:%d:%c:%d:%s",&brate,&bsize,&parity,&stopb,fctr);
+        sscanf(p,":%d:%d:%c:%d:%63s",&brate,&bsize,&parity,&stopb,fctr);
     }
     else strcpy(port,path);
     

--- a/src/tle.c
+++ b/src/tle.c
@@ -470,7 +470,7 @@ extern int tle_name_read(const char *file, tle_t *tle)
 
         desig[0]='\0';
 
-        if (sscanf(buff,"%s %s %s",name,satno,desig)<2) continue;
+        if (sscanf(buff,"%255s %255s %255s",name,satno,desig)<2) continue;
         satno[5]='\0';
 
         for (i=0;i<tle->n;i++) {


### PR DESCRIPTION
Include a maximum width on scanf string input, to avoid an overflow of the target string buffer.

Also initialized scanf optional values, for the case in which they are not supplied.