### PR TITLE
options number of freq: limit for build NFREQ

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -440,6 +440,11 @@ static void buff2sysopts(void)
             prcopt_.snrmask.mask[i][j++]=atof(p);
         }
     }
+    /* Guard number of frequencies */
+    if (prcopt_.nf>NFREQ) {
+       fprintf(stderr,"Number of frequencies %d limited to %d, rebuild with NFREQ=%d\n",prcopt_.nf, NFREQ, prcopt_.nf);
+        prcopt_.nf=NFREQ;
+    }
     /* number of frequency (4:L1+L5) TODO ????*/
     /*if (prcopt_.nf==4) {
         prcopt_.nf=3;


### PR DESCRIPTION
Four frequencies are an option, but the common builds appear to define NFREQ to 3. Some of the data structure are defined as size NFREQ and the code iterates over them using the supplied optional number of frequencies which might be greater. So here is a suggestion to limit the optional number of frequencies to the build NFREQ, and to emit a warning if this does occur. It is possible that I am misunderstanding the intention for 4 frequencies.