### PR TITLE
stream decodeftppath: avoid null pointer defreference

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -2259,7 +2259,7 @@ static void decodeftppath(const char *path, char *addr, char *file, char *user,
         if ((q=strchr(buff,':'))) {
              *q='\0'; if (passwd) strcpy(passwd,q+1);
         }
-        *q='\0'; if (user) strcpy(user,buff); 
+        if (user) strcpy(user,buff);
     }
     else p=buff;
     


### PR DESCRIPTION
If there is a user name component but not a password component then the nul char was written to pointer NULL.