### PR TITLE
Setstr export

### DIFF
--- a/src/rinex.c
+++ b/src/rinex.c
@@ -157,15 +157,6 @@ typedef struct {                        /* signal index type */
     double shift[MAXOBSTYPE];           /* phase shift (cycle) */
 } sigind_t;
 
-/* set string without tail space ---------------------------------------------*/
-static void setstr(char *dst, const char *src, int n)
-{
-    char *p=dst;
-    const char *q=src;
-    while (*q&&q<src+n) *p++=*q++;
-    *p--='\0';
-    while (p>=dst&&*p==' ') *p--='\0';
-}
 /* adjust time considering week handover -------------------------------------*/
 static gtime_t adjweek(gtime_t t, gtime_t t0)
 {

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -1548,6 +1548,15 @@ extern void matprint(const double A[], int n, int m, int p, int q)
 {
     matfprint(A,n,m,p,q,stdout);
 }
+/* set string without tail space ---------------------------------------------*/
+extern void setstr(char *dst, const char *src, int n)
+{
+    char *p=dst;
+    const char *q=src;
+    while (*q&&q<src+n) *p++=*q++;
+    *p--='\0';
+    while (p>=dst&&*p==' ') *p--='\0';
+}
 /* string to number ------------------------------------------------------------
 * convert substring in string to number
 * args   : char   *s        I   string ("... nnn.nnn ...")

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -2503,7 +2503,7 @@ static int readngspcv(const char *file, pcvs_t *pcvs)
         if (buff[0]!=' ') n=0; /* start line */
         if (++n==1) {
             pcv=pcv0;
-            strncpy(pcv.type,buff,61); pcv.type[61]='\0';
+            setstr(pcv.type,buff,61);
         }
         else if (n==2) {
             if (decodef(buff,3,neu)<3) continue;
@@ -2560,9 +2560,9 @@ static int readantex(const char *file, pcvs_t *pcvs)
         if (!state) continue;
         
         if (strstr(buff+60,"TYPE / SERIAL NO")) {
-            strncpy(pcv.type,buff   ,20); pcv.type[20]='\0';
-            strncpy(pcv.code,buff+20,20); pcv.code[20]='\0';
-            if (!strncmp(pcv.code+3,"        ",8)) {
+            setstr(pcv.type,buff,20);
+            setstr(pcv.code,buff+20,20);
+            if (strlen(pcv.code)==3) {
                 pcv.sat=satid2no(pcv.code);
             }
         }

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1391,6 +1391,7 @@ EXPORT void matfprint(const double *A, int n, int m, int p, int q, FILE *fp);
 EXPORT void add_fatal(fatalfunc_t *func);
 
 /* time and string functions -------------------------------------------------*/
+EXPORT void    setstr(char *dst, const char *src, int n);
 EXPORT double  str2num(const char *s, int i, int n);
 EXPORT int     str2time(const char *s, int i, int n, gtime_t *t);
 EXPORT void    time2str(gtime_t t, char *str, int n);


### PR DESCRIPTION
The setstr() function was local to rinex.c, but it is very useful for parsing other fixed width formats. It is safe as it always nul terminates the string and keeps within the given buffer size (plus one of the nul termination). It has a role that scanf() can not do - extracting a fixed width field. Also included one example where it can be used, parsing the antenna pcv type and code.