### PR TITLE
satno2id: consistent use of output buffer size

### DIFF
--- a/app/consapp/rtkrcv/rtkrcv.c
+++ b/app/consapp/rtkrcv/rtkrcv.c
@@ -530,7 +530,7 @@ static void prtime(vt_t *vt, gtime_t time)
 {
     double tow;
     int week;
-    char tstr[64]="";
+    char tstr[40]="";
     
     if (timetype==1) {
         time2str(gpst2utc(time),tstr,2);
@@ -539,7 +539,7 @@ static void prtime(vt_t *vt, gtime_t time)
         time2str(timeadd(gpst2utc(time),9*3600.0),tstr,2);
     }
     else if (timetype==3) {
-        tow=time2gpst(time,&week); sprintf(tstr,"  %04d %9.2f",week,tow);
+        tow=time2gpst(time,&week); snprintf(tstr,sizeof(tstr),"  %04d %9.2f",week,tow);
     }
     else time2str(time,tstr,1);
     vt_printf(vt,"%s ",tstr);
@@ -654,7 +654,7 @@ static void prstatus(vt_t *vt)
     pthread_t thread;
     int i,j,n,cycle,state,rtkstat,nsat0,nsat1,prcout,rcvcount,tmcount,timevalid,nave;
     int cputime,nb[3]={0},nmsg[3][10]={{0}};
-    char tstr[64],tmstr[64],s[1024],*p;
+    char tstr[40],tmstr[40],s[1024],*p;
     double runtime,rt[3]={0},dop[4]={0},rr[3],bl1=0.0,bl2=0.0;
     double azel[MAXSAT*2],pos[3],vel[3],*del;
     
@@ -840,7 +840,7 @@ static void prsatellite(vt_t *vt, int nf)
 static void probserv(vt_t *vt, int nf)
 {
     obsd_t obs[MAXOBS*2];
-    char tstr[64],id[8];
+    char tstr[40],id[8];
     int i,j,n=0,frq[]={1,2,5,7,8,6,9};
     
     trace(4,"probserv:\n");
@@ -985,7 +985,7 @@ static void prssr(vt_t *vt)
     gtime_t time;
     ssr_t ssr[MAXSAT];
     int i,valid;
-    char tstr[64],id[8],*p=buff;
+    char tstr[40],id[8],*p=buff;
     
     rtksvrlock(&svr);
     time=svr.rtk.sol.time;
@@ -1277,7 +1277,7 @@ static void cmd_load(char **args, int narg, vt_t *vt)
 /* save command --------------------------------------------------------------*/
 static void cmd_save(char **args, int narg, vt_t *vt)
 {
-    char file[MAXSTR]="",comment[256],s[64];
+    char file[MAXSTR]="",comment[256],s[40];
     
     trace(3,"cmd_save:\n");
     

--- a/app/consapp/rtkrcv/rtkrcv.c
+++ b/app/consapp/rtkrcv/rtkrcv.c
@@ -797,7 +797,7 @@ static void prsatellite(vt_t *vt, int nf)
 {
     rtk_t rtk;
     double az,el;
-    char id[32];
+    char id[8];
     int i,j,fix,frq[]={1,2,5,7,8,6};
     
     trace(4,"prsatellite:\n");
@@ -840,7 +840,7 @@ static void prsatellite(vt_t *vt, int nf)
 static void probserv(vt_t *vt, int nf)
 {
     obsd_t obs[MAXOBS*2];
-    char tstr[64],id[32];
+    char tstr[64],id[8];
     int i,j,n=0,frq[]={1,2,5,7,8,6,9};
     
     trace(4,"probserv:\n");
@@ -880,7 +880,7 @@ static void prnavidata(vt_t *vt)
     geph_t geph[MAXPRNGLO];
     double ion[8],utc[8];
     gtime_t time;
-    char id[32],s1[64],s2[64],s3[64];
+    char id[8],s1[64],s2[64],s3[64];
     int i,valid,prn;
     
     trace(4,"prnavidata:\n");
@@ -985,7 +985,7 @@ static void prssr(vt_t *vt)
     gtime_t time;
     ssr_t ssr[MAXSAT];
     int i,valid;
-    char tstr[64],id[32],*p=buff;
+    char tstr[64],id[8],*p=buff;
     
     rtksvrlock(&svr);
     time=svr.rtk.sol.time;

--- a/app/consapp/str2str/str2str.c
+++ b/app/consapp/str2str/str2str.c
@@ -392,9 +392,11 @@ int main(int argc, char **argv)
         
         /* show stream server status */
         for (i=0,p=buff;i<MAXSTR;i++) p+=sprintf(p,"%c",ss[stat[i]+1]);
-        
+
+        char tstr[40];
+        time2str(utc2gpst(timeget()),tstr,0);
         fprintf(stderr,"%s [%s] %10d B %7d bps %s\n",
-                time_str(utc2gpst(timeget()),0),buff,byte[0],bps[0],strmsg);
+                tstr,buff,byte[0],bps[0],strmsg);
         
         sleepms(dispint);
     }

--- a/app/qtapp/appcmn_qt/graph.cpp
+++ b/app/qtapp/appcmn_qt/graph.cpp
@@ -226,7 +226,7 @@ QString Graph::numText(double x, double dx)
 //---------------------------------------------------------------------------
 QString Graph::timeText(double x, double dx)
 {
-    char str[64];
+    char str[40];
 
     time2str(gpst2time(week, x), str, 1);
     // decide what part of the string to use

--- a/app/qtapp/appcmn_qt/timedlg.cpp
+++ b/app/qtapp/appcmn_qt/timedlg.cpp
@@ -23,7 +23,7 @@ void TimeDialog::setTime(const gtime_t &time)
     QDateTime qtime_gpst, qtime_utc;
     gtime_t utc;
     double tow, doy;
-	int week;
+    int week;
 
     utc = gpst2utc(time);
 

--- a/app/qtapp/rtknavi_qt/mondlg.cpp
+++ b/app/qtapp/rtknavi_qt/mondlg.cpp
@@ -413,7 +413,7 @@ void MonitorDialog::showRtk()
     int row, j, k, cycle, state, rtkstat, nsat0, nsat1, prcout, nave;
     int cputime, nb[3] = {0}, ne;
     unsigned int nmsg[3][10] = {{0}};
-    char tstr[64], id[32], s1[64] = "-", s2[64] = "-", s3[64] = "-";
+    char tstr[64], id[8], s1[64] = "-", s2[64] = "-", s3[64] = "-";
     char file[1024] = "";
     const QString ionoopt[] = {tr("OFF"), tr("Broadcast"), tr("SBAS"), tr("Dual-Frequency"), tr("Estimate STEC"), tr("IONEX TEC"), tr("QZSS LEX"), tr("STEC model")};
     const QString tropopt[] = {tr("OFF"), tr("Saastamoinen"), tr("SBAS"), tr("Estimate ZTD"), tr("Estimate ZTD+Grad")};
@@ -762,7 +762,7 @@ void MonitorDialog::showSat()
 	ssat_t *ssat;
     int i, j, k, n, nsat, fix, nfreq, sys = sys_tbl[ui->cBSelectNavigationSystems->currentIndex()];
     int vsat[MAXSAT] = {0};
-	char id[32];
+	char id[8];
     double az, el, cbias[MAXSAT][2];
 
     rtksvrlock(rtksvr);
@@ -1038,7 +1038,7 @@ void MonitorDialog::setObservations()
 void MonitorDialog::showObservations()
 {
     obsd_t obs[MAXOBS * 2];
-    char tstr[64], id[32], *code;
+    char tstr[64], id[8], *code;
     int i, k, n = 0, nex = ui->cBSelectObservation->currentIndex() ? NEXOBS : 0;
     int sys = sys_tbl[ui->cBSelectNavigationSystems->currentIndex()];
 
@@ -1132,7 +1132,7 @@ void MonitorDialog::showNavigationsGPS()
 	eph_t eph[MAXSAT];
 	gtime_t time;
     QString s;
-    char tstr[64], id[32];
+    char tstr[64], id[8];
     int i, k, n, nsat, prn, off = ui->cBSelectEphemeris->currentIndex();
     bool valid;
     int sys = sys_tbl[ui->cBSelectSingleNavigationSystem->currentIndex() + 1];
@@ -1246,7 +1246,7 @@ void MonitorDialog::showGlonassNavigations()
 	geph_t geph[NSATGLO];
 	gtime_t time;
     QString s;
-    char tstr[64], id[32];
+    char tstr[64], id[8];
     int i, n, nsat, valid, prn, off = ui->cBSelectEphemeris->currentIndex();
 
     geph_t geph0;
@@ -1341,7 +1341,7 @@ void MonitorDialog::showSbsNavigations()
     seph_t seph[MAXPRNSBS - MINPRNSBS + 1];
 	gtime_t time;
     int i, n, nsat, valid, prn, off = ui->cBSelectEphemeris->currentIndex();
-    char tstr[64], id[32];
+    char tstr[64], id[8];
 
     seph_t seph0;
     memset(&seph0, 0, sizeof(seph_t));
@@ -1696,7 +1696,7 @@ void MonitorDialog::showSbsLong()
 	sbssat_t sbssat;
 	gtime_t time;
     int i;
-    char tstr[64], id[32];
+    char tstr[64], id[8];
 
     rtksvrlock(rtksvr); // lock
     time = rtksvr->rtk.sol.time;
@@ -1818,7 +1818,7 @@ void MonitorDialog::showSbsFast()
 	sbssat_t sbssat;
 	gtime_t time;
     int i;
-    char tstr[64], id[32];
+    char tstr[64], id[8];
 
     rtksvrlock(rtksvr); // lock
     time = rtksvr->rtk.sol.time;
@@ -1982,7 +1982,7 @@ void MonitorDialog::showRtcmDgps()
 	gtime_t time;
 	dgps_t dgps[MAXSAT];
     int i;
-    char tstr[64], id[32];
+    char tstr[64], id[8];
 
     rtksvrlock(rtksvr);
     time = rtksvr->rtk.sol.time;
@@ -2028,7 +2028,7 @@ void MonitorDialog::showRtcmSsr()
     gtime_t time;
 	ssr_t ssr[MAXSAT];
     int i, k, n, sat[MAXSAT], sys = sys_tbl[ui->cBSelectSingleNavigationSystem->currentIndex() + 1];
-    char tstr[64], id[32];
+    char tstr[64], id[8];
     QString s;
 
     int effectiveStream = (inputStream < 0 || inputStream > 2) ? 0 : inputStream;

--- a/app/qtapp/rtknavi_qt/mondlg.cpp
+++ b/app/qtapp/rtknavi_qt/mondlg.cpp
@@ -413,7 +413,7 @@ void MonitorDialog::showRtk()
     int row, j, k, cycle, state, rtkstat, nsat0, nsat1, prcout, nave;
     int cputime, nb[3] = {0}, ne;
     unsigned int nmsg[3][10] = {{0}};
-    char tstr[64], id[8], s1[64] = "-", s2[64] = "-", s3[64] = "-";
+    char tstr[40], id[8], s1[40] = "-", s2[40] = "-", s3[40] = "-";
     char file[1024] = "";
     const QString ionoopt[] = {tr("OFF"), tr("Broadcast"), tr("SBAS"), tr("Dual-Frequency"), tr("Estimate STEC"), tr("IONEX TEC"), tr("QZSS LEX"), tr("STEC model")};
     const QString tropopt[] = {tr("OFF"), tr("Saastamoinen"), tr("SBAS"), tr("Estimate ZTD"), tr("Estimate ZTD+Grad")};
@@ -861,7 +861,7 @@ void MonitorDialog::showEstimates()
     unsigned int i, nx, na, n;
     double *x, *P = NULL, *xa = NULL, *Pa = NULL;
     QString s0 = "-";
-	char tstr[64];
+	char tstr[40];
 
     rtksvrlock(rtksvr);
 
@@ -932,7 +932,7 @@ void MonitorDialog::showCovariance()
     int i, j, nx, n, m;
     double *x, *P = NULL;
     static QString s0 = "-";
-	char tstr[64];
+	char tstr[40];
 
     rtksvrlock(rtksvr);
 
@@ -1038,7 +1038,7 @@ void MonitorDialog::setObservations()
 void MonitorDialog::showObservations()
 {
     obsd_t obs[MAXOBS * 2];
-    char tstr[64], id[8], *code;
+    char tstr[40], id[8], *code;
     int i, k, n = 0, nex = ui->cBSelectObservation->currentIndex() ? NEXOBS : 0;
     int sys = sys_tbl[ui->cBSelectNavigationSystems->currentIndex()];
 
@@ -1132,7 +1132,7 @@ void MonitorDialog::showNavigationsGPS()
 	eph_t eph[MAXSAT];
 	gtime_t time;
     QString s;
-    char tstr[64], id[8];
+    char tstr[40], id[8];
     int i, k, n, nsat, prn, off = ui->cBSelectEphemeris->currentIndex();
     bool valid;
     int sys = sys_tbl[ui->cBSelectSingleNavigationSystem->currentIndex() + 1];
@@ -1246,7 +1246,7 @@ void MonitorDialog::showGlonassNavigations()
 	geph_t geph[NSATGLO];
 	gtime_t time;
     QString s;
-    char tstr[64], id[8];
+    char tstr[40], id[8];
     int i, n, nsat, valid, prn, off = ui->cBSelectEphemeris->currentIndex();
 
     geph_t geph0;
@@ -1341,7 +1341,7 @@ void MonitorDialog::showSbsNavigations()
     seph_t seph[MAXPRNSBS - MINPRNSBS + 1];
 	gtime_t time;
     int i, n, nsat, valid, prn, off = ui->cBSelectEphemeris->currentIndex();
-    char tstr[64], id[8];
+    char tstr[40], id[8];
 
     seph_t seph0;
     memset(&seph0, 0, sizeof(seph_t));
@@ -1431,7 +1431,7 @@ void MonitorDialog::showIonUtc()
     double ion_gps[8], ion_gal[4], ion_qzs[8], ion_cmp[8], ion_irn[8];
 	gtime_t time;
     double tow = 0.0;
-	char tstr[64];
+	char tstr[40];
     int i, week = 0;
 
     Q_UNUSED(utc_glo);
@@ -1639,7 +1639,7 @@ void MonitorDialog::showSbsMessages()
         ""
 	};
     const int id[] = {0, 1, 2, 3, 4, 5, 6, 7, 9, 10, 12, 17, 18, 24, 25, 26, 27, 28, 62, 63, 43, 44, 47, 48, 49, 50, 51, -1};
-    char str[256];
+    char tstr[40];
     QString s;
     int i, k, n;
 
@@ -1662,8 +1662,8 @@ void MonitorDialog::showSbsMessages()
 
     for (i = 0; i < n; i++) {
         int j = 0;
-        time2str(gpst2time(msg[i].week, msg[i].tow), str, 0);
-        ui->tWConsole->item(i, j++)->setText(str);
+        time2str(gpst2time(msg[i].week, msg[i].tow), tstr, 0);
+        ui->tWConsole->item(i, j++)->setText(tstr);
         ui->tWConsole->item(i, j++)->setText(QString::number(msg[i].prn));
         ui->tWConsole->item(i, j++)->setText(QString("(%1)").arg(msg[i].rcv));
         int type = msg[i].msg[1] >> 2;
@@ -1696,7 +1696,7 @@ void MonitorDialog::showSbsLong()
 	sbssat_t sbssat;
 	gtime_t time;
     int i;
-    char tstr[64], id[8];
+    char tstr[40], id[8];
 
     rtksvrlock(rtksvr); // lock
     time = rtksvr->rtk.sol.time;
@@ -1758,7 +1758,7 @@ void MonitorDialog::showSbsIono()
 {
     QString s0 = "-";
     sbsion_t sbsion[MAXBAND + 1];
-	char tstr[64];
+	char tstr[40];
     int i, j, k, n = 0;
 
     rtksvrlock(rtksvr); // lock
@@ -1818,7 +1818,7 @@ void MonitorDialog::showSbsFast()
 	sbssat_t sbssat;
 	gtime_t time;
     int i;
-    char tstr[64], id[8];
+    char tstr[40], id[8];
 
     rtksvrlock(rtksvr); // lock
     time = rtksvr->rtk.sol.time;
@@ -1882,7 +1882,7 @@ void MonitorDialog::showRtcm()
     static rtcm_t rtcm;
     int i = 0, j, format;
     QString mstr1, mstr2;
-    char tstr[64] = "-";
+    char tstr[40] = "-";
 
     int effectiveStream = (inputStream < 0 || inputStream > 2) ? 0 : inputStream;
 
@@ -1982,7 +1982,7 @@ void MonitorDialog::showRtcmDgps()
 	gtime_t time;
 	dgps_t dgps[MAXSAT];
     int i;
-    char tstr[64], id[8];
+    char tstr[40], id[8];
 
     rtksvrlock(rtksvr);
     time = rtksvr->rtk.sol.time;
@@ -2028,7 +2028,7 @@ void MonitorDialog::showRtcmSsr()
     gtime_t time;
 	ssr_t ssr[MAXSAT];
     int i, k, n, sat[MAXSAT], sys = sys_tbl[ui->cBSelectSingleNavigationSystem->currentIndex() + 1];
-    char tstr[64], id[8];
+    char tstr[40], id[8];
     QString s;
 
     int effectiveStream = (inputStream < 0 || inputStream > 2) ? 0 : inputStream;
@@ -2114,7 +2114,7 @@ void MonitorDialog::showReferenceStation()
     sta_t sta;
     double pos[3] = {0};
     int i = 0, format;
-    char tstr[64] = "-";
+    char tstr[40] = "-";
 
     int effectiveStream = (inputStream < 0 || inputStream > 2) ? 0 : inputStream;
 

--- a/app/qtapp/rtknavi_qt/navimain.cpp
+++ b/app/qtapp/rtknavi_qt/navimain.cpp
@@ -1795,7 +1795,7 @@ void MainWindow::drawSnr(QPainter &c, int w, int h, int x0, int y0,
     };
     static const QColor color_sys[] = {Qt::darkGreen, Color::Orange, Color::Fuchsia, Qt::blue, Qt::red, Color::Teal, Qt::darkGray};
     int i, j, snrIdx, sysIdx, numSystems, x1, y1, height, offset, topMargin, bottomMargin, hh, barDistance, barWidth, snr[NFREQ + 1], sysMask[7] = {0};
-    char id[16], sys[] = "GREJCS", *q;
+    char id[8], sys[] = "GREJCS", *q;
 
     trace(4, "drawSnr: w=%d h=%d x0=%d y0=%d index=%d freq=%d\n", w, h, x0, y0, index, freq);
 
@@ -1876,7 +1876,7 @@ void MainWindow::drawSatellites(QPainter &c, int w, int h, int x0, int y0,
     QPoint p(w / 2, h / 2);
     double r = qMin(w * 0.95, h * 0.95) / 2, azel[MAXSAT * 2], dop[4];
     int i, j, k, sysIdx, radius, x[MAXSAT], y[MAXSAT], snr[NFREQ + 1], nsats = 0;
-    char id[16], sys[] = "GREJCIS", *q;
+    char id[8], sys[] = "GREJCIS", *q;
 
     trace(4, "drawSatellites: w=%d h=%d index=%d freq=%d\n", w, h, index, freq);
 
@@ -2400,7 +2400,7 @@ void MainWindow::saveNavigation(nav_t *nav)
 {
     QSettings settings(iniFile, QSettings::IniFormat);
     QString str;
-    char id[32];
+    char id[8];
     int i;
 
     trace(3, "saveNavigation\n");

--- a/app/qtapp/rtknavi_qt/navimain.cpp
+++ b/app/qtapp/rtknavi_qt/navimain.cpp
@@ -1457,7 +1457,7 @@ void MainWindow::updateTime()
     struct tm *t;
     double tow;
     int week;
-    char tstr[64];
+    char tstr[40];
     QString str;
 
     trace(4, "updateTime\n");

--- a/app/qtapp/rtkplot_qt/plotcmn.cpp
+++ b/app/qtapp/rtkplot_qt/plotcmn.cpp
@@ -446,7 +446,7 @@ QString Plot::timeString(gtime_t time, int n, int tsys)
 {
     struct tm *t;
     QString tstr;
-    char temp[64];
+    char temp[40];
     QString label = "";
     double tow;
     int week;

--- a/app/qtapp/rtkplot_qt/plotdata.cpp
+++ b/app/qtapp/rtkplot_qt/plotdata.cpp
@@ -938,7 +938,7 @@ void Plot::saveDop(const QString &file)
     QString data;
     double azel[MAXOBS * 2], dop[4], tow;
     int i, j, ns, week;
-    char tstr[64];
+    char tstr[40];
     QString time_label;
 
     trace(3, "saveDop: file=%s\n", qPrintable(file));
@@ -990,7 +990,7 @@ void Plot::saveSnrMp(const QString &file)
     QString obsType = ui->cBObservationTypeSNR->currentText();
     gtime_t time;
     double tow;
-    char sat[8], tstr[64], code[64];
+    char sat[8], tstr[40], code[64];
     QString data, time_label;
     int i, j, k, week;
 

--- a/app/qtapp/rtkplot_qt/plotdata.cpp
+++ b/app/qtapp/rtkplot_qt/plotdata.cpp
@@ -392,7 +392,7 @@ void Plot::generateVisibilityData()
     double tint, pos[3], rr[3], rs[6], e[3], azel[2], time_span;
     unsigned char i, j;
     int nobs = 0, per, per_=-1;
-    char name[16];
+    char name[8];
 
     trace(3, "generateVisibilityData\n");
 
@@ -990,7 +990,7 @@ void Plot::saveSnrMp(const QString &file)
     QString obsType = ui->cBObservationTypeSNR->currentText();
     gtime_t time;
     double tow;
-    char sat[32], tstr[64], code[64];
+    char sat[8], tstr[64], code[64];
     QString data, time_label;
     int i, j, k, week;
 
@@ -1227,7 +1227,7 @@ void Plot::updateObservation(int nobs)
             const int &sat = observation.data[i + k].sat;
 
             if (simulatedObservation) {
-                char name[16];
+                char name[8];
                 satno2id(sat, name);
                 if (!tle_pos(time, name, "", "", &tleData, NULL, rs)) continue;
             } else {

--- a/app/qtapp/rtkplot_qt/plotdraw.cpp
+++ b/app/qtapp/rtkplot_qt/plotdraw.cpp
@@ -1334,7 +1334,6 @@ void Plot::drawSky(QPainter &c, int level)
     double x, y, xp, yp, xs, ys, dt, dx, dy, xl[2], yl[2], radius;
     int i, j, freq, ind = observationIndex;
     int hh = (int)(QFontMetrics(plotOptDialog->getFont()).height() * 1.5);
-    char satId[8];
 
     trace(3, "drawSky: level=%d\n", level);
 

--- a/app/qtapp/rtkplot_qt/plotdraw.cpp
+++ b/app/qtapp/rtkplot_qt/plotdraw.cpp
@@ -1000,7 +1000,7 @@ void Plot::drawObservation(QPainter &c, int level)
     obsd_t *obs;
     double xs, ys, xt, xl[2], yl[2], tt[MAXSAT] = { 0 }, xp, xc, yc, yp[MAXSAT] = { 0 };
     int i, j, nSats = 0, sats[MAXSAT] = { 0 }, ind = observationIndex;
-    char id[16];
+    char id[8];
 
     trace(3, "drawObservation: level=%d\n", level);
 
@@ -1334,7 +1334,7 @@ void Plot::drawSky(QPainter &c, int level)
     double x, y, xp, yp, xs, ys, dt, dx, dy, xl[2], yl[2], radius;
     int i, j, freq, ind = observationIndex;
     int hh = (int)(QFontMetrics(plotOptDialog->getFont()).height() * 1.5);
-    char satId[16];
+    char satId[8];
 
     trace(3, "drawSky: level=%d\n", level);
 
@@ -1382,6 +1382,7 @@ void Plot::drawSky(QPainter &c, int level)
             if (p0[sat][0] != 0.0 || p0[sat][1] != 0.0) {
                 QPoint pnt;
                 if (graphSky->toPoint(p0[sat][0], p0[sat][1], pnt)) {
+                    char satId[8];
                     satno2id(sat + 1, satId);
                     drawLabel(graphSky, c, pnt, QString(satId), Graph::Alignment::Left, Graph::Alignment::Center);
                 }
@@ -1448,6 +1449,7 @@ void Plot::drawSky(QPainter &c, int level)
             x = radius * sin(azimuth[i]) * (1.0 - 2.0 * elevation[i] / PI);
             y = radius * cos(azimuth[i]) * (1.0 - 2.0 * elevation[i] / PI);
 
+            char satId[8];
             satno2id(obs->sat, satId);
 
             graphSky->drawMark(c, x, y, Graph::MarkerTypes::Dot, col, fontsize * 2 + 5, 0);
@@ -1492,6 +1494,7 @@ void Plot::drawSky(QPainter &c, int level)
             if (plotOptDialog->getHideLowSatellites() && elevation[i] < plotOptDialog->getElevationMask() * D2R) continue;
             if (plotOptDialog->getHideLowSatellites() && plotOptDialog->getElevationMaskEnabled() && elevation[i] < elevationMaskData[static_cast<int>(azimuth[i] * R2D + 0.5)]) continue;
 
+            char satId[8];
             satno2id(obs->sat, satId);
             s = QStringLiteral("%1: ").arg(satId, 3, QChar('-'));
 
@@ -2234,7 +2237,6 @@ void Plot::drawMpSky(QPainter &c, int level)
 
     // highlight selected data
     if (ui->btnShowTrack->isChecked() && 0 <= observationIndex && observationIndex < nObservation) {
-        char id[32];
         int fontsize = plotOptDialog->getFont().pointSize();
         for (int i = indexObservation[observationIndex]; i < observation.n && i < indexObservation[observationIndex + 1]; i++) {
             obsd_t *obs = observation.data+i;
@@ -2255,6 +2257,7 @@ void Plot::drawMpSky(QPainter &c, int level)
             double x = radius * sin(azimuth[i]) * (1.0 - 2.0 * elevation[i] / PI);
             double y = radius * cos(azimuth[i]) * (1.0 - 2.0 * elevation[i] / PI);
 
+            char id[8];
             satno2id(obs->sat, id);
 
             graphSky->drawMark(c, x, y, Graph::MarkerTypes::Dot, col, fontsize * 2 + 5, 0);

--- a/app/qtapp/rtkplot_qt/plotmain.cpp
+++ b/app/qtapp/rtkplot_qt/plotmain.cpp
@@ -2287,7 +2287,7 @@ void Plot::updateSatelliteMask()
 void Plot::updateSatelliteSelection()
 {
     QString satelliteList = ui->cBSatelliteList->currentText();
-    char id[16];
+    char id[8];
     int sys = 0;
 
     if (satelliteList == "G") sys = SYS_GPS;

--- a/app/qtapp/strsvr_qt/svrmain.cpp
+++ b/app/qtapp/strsvr_qt/svrmain.cpp
@@ -395,7 +395,7 @@ void MainForm::updateServerStat()
     static const QString statusStr[] = {tr("Error"), tr("Closed"), tr("Waiting..."), tr("Connected"), tr("Active")};
     gtime_t time = utc2gpst(timeget());
     int stat[MAXSTR] = {0}, byte[MAXSTR] = {0}, bps[MAXSTR] = {0}, log_stat[MAXSTR] = {0};
-    char msg[MAXSTRMSG * MAXSTR] = "", str[256];
+    char msg[MAXSTRMSG * MAXSTR] = "";
     double ctime, t[4], pos;
 
     strsvrstat(&strsvr, stat, log_stat, byte, bps, msg);
@@ -413,8 +413,9 @@ void MainForm::updateServerStat()
     ui->pBProgress->setValue(!stat[0] ? 0 : qMin((int)pos, 100));
 
     // update time
-    time2str(time, str, 0);
-    ui->lblTime->setText(tr("%1 GPST").arg(str));
+    char tstr[40];
+    time2str(time, tstr, 0);
+    ui->lblTime->setText(tr("%1 GPST").arg(tstr));
 
     if (ui->panelStreams->isEnabled())
         ctime = timediff(endTime, startTime);

--- a/app/winapp/appcmn/graph.cpp
+++ b/app/winapp/appcmn/graph.cpp
@@ -195,7 +195,7 @@ AnsiString TGraph::NumText(double x, double dx)
 AnsiString TGraph::TimeText(double x, double dx)
 {
     AnsiString s;
-    char str[64];
+    char str[40];
     time2str(gpst2time(Week,x),str,1);
     int b=dx<86400.0?11:(dx<86400.0*30?5:2),w=dx<60.0?(dx<1.0?10:8):5;
     return s.sprintf("%*.*s",w,w,str+b);

--- a/app/winapp/appcmn/timedlg.cpp
+++ b/app/winapp/appcmn/timedlg.cpp
@@ -18,7 +18,7 @@ void __fastcall TTimeDialog::FormShow(TObject *Sender)
 	gtime_t utc;
 	double tow,doy;
 	int week;
-	char msg[1024],s1[64],s2[64],*p=msg;
+	char msg[1024],s1[40],s2[40],*p=msg;
 	utc=gpst2utc(Time);
 	time2str(Time,s1,0);
 	time2str(utc,s2,0);

--- a/app/winapp/appcmn/tspandlg.cpp
+++ b/app/winapp/appcmn/tspandlg.cpp
@@ -29,7 +29,7 @@ __fastcall TSpanDialog::TSpanDialog(TComponent* Owner)
 //---------------------------------------------------------------------------
 void __fastcall TSpanDialog::FormShow(TObject *Sender)
 {
-	char ts[64],te[64];
+	char ts[40],te[40];
 	AnsiString s;
 	TimeStartF->Checked=TimeEna[0];
 	TimeEndF  ->Checked=TimeEna[1];

--- a/app/winapp/rtkconv/convmain.cpp
+++ b/app/winapp/rtkconv/convmain.cpp
@@ -848,7 +848,7 @@ void __fastcall TMainWindow::ConvertFile(void)
 	AnsiString OutFile9_Text=OutFile9->Text;
 	int i,format,sat;
 	char file[1024]="",*ofile[9],ofile_[9][1024]={""},msg[256],*p;
-	char buff[256],tstr[32];
+	char buff[256],tstr[40];
 	int RNXVER[]={210,211,212,300,301,302,303,304};
 	FILE *fp;
 	

--- a/app/winapp/rtkconv/startdlg.cpp
+++ b/app/winapp/rtkconv/startdlg.cpp
@@ -22,7 +22,7 @@ void __fastcall TStartDialog::FormShow(TObject *Sender)
 	FILE *fp;
 	uint32_t time=0;
 	uint8_t buff[80]={0};
-	char tstr[64],path_tag[1024],path[1024],*paths[1];
+	char tstr[40],path_tag[1024],path[1024],*paths[1];
     
 	if (Time.time==0) {
 	    Time=utc2gpst(timeget());

--- a/app/winapp/rtknavi/mondlg.cpp
+++ b/app/winapp/rtknavi/mondlg.cpp
@@ -365,7 +365,7 @@ void __fastcall TMonitorDialog::ShowRtk(void)
 	double azel[MAXSAT*2],pos[3],vel[3],rr[3]={0},enu[3]={0};
 	int i,j,k,thread,cycle,state,rtkstat,nsat0,nsat1,prcout,nave;
 	int cputime,nb[3]={0},nmsg[3][10]={{0}},ne;
-	char tstr[64],*ant,id[8],s1[64]="-",s2[64]="-",s3[64]="-";
+	char tstr[40],*ant,id[8],s1[40]="-",s2[40]="-",s3[40]="-";
 	char file[1024]="";
 	const char *ionoopt[]={"OFF","Broadcast","SBAS","Dual-Frequency","Estimate STEC","IONEX TEC","QZSS LEX",""};
 	const char *tropopt[]={"OFF","Saastamoinen","SBAS","Estimate ZTD","Estimate ZTD+Grad",""};
@@ -807,7 +807,7 @@ void __fastcall TMonitorDialog::ShowEst(void)
 	int i,nx,na,n;
 	double *x,*P=NULL,*xa=NULL,*Pa=NULL;
 	AnsiString s,s0="-";
-	char tstr[64];
+	char tstr[40];
 
 	rtksvrlock(&rtksvr);
 	
@@ -875,7 +875,7 @@ void __fastcall TMonitorDialog::ShowCov(void)
 	int i,j,nx,n,m;
 	double *x,*P=NULL;
 	AnsiString s,s0="-";
-	char tstr[64];
+	char tstr[40];
 
 	rtksvrlock(&rtksvr);
 	
@@ -973,7 +973,7 @@ void __fastcall TMonitorDialog::ShowObs(void)
 {
 	AnsiString s;
 	obsd_t obs[MAXOBS*2];
-	char tstr[64],id[8],*code;
+	char tstr[40],id[8],*code;
 	int i,j,k,n=0,nex=ObsMode?NEXOBS:0,sys=sys_tbl[SelSys->ItemIndex];
 	
 	rtksvrlock(&rtksvr);
@@ -1050,7 +1050,7 @@ void __fastcall TMonitorDialog::ShowNav(void)
 	eph_t eph[MAXSAT];
 	gtime_t time;
 	AnsiString s;
-	char tstr[64],id[8];
+	char tstr[40],id[8];
 	int i,j,k,n,valid,prn,off=SelEph->ItemIndex*MAXSAT;
 	int sys=sys_tbl[SelSys2->ItemIndex+1];
 	
@@ -1163,7 +1163,7 @@ void __fastcall TMonitorDialog::ShowGnav(void)
 	geph_t geph[NSATGLO];
 	gtime_t time;
 	AnsiString s;
-	char tstr[64],id[8];
+	char tstr[40],id[8];
 	int i,j,n,valid,prn,off=SelEph->ItemIndex?NSATGLO:0;
 	
 	rtksvrlock(&rtksvr);
@@ -1245,7 +1245,7 @@ void __fastcall TMonitorDialog::ShowSbsNav(void)
 	seph_t seph[MAXPRNSBS-MINPRNSBS+1]={0};
 	gtime_t time;
 	int i,j,n,valid,prn,off=SelEph->ItemIndex?NSATSBS:0;
-	char tstr[64],id[8];
+	char tstr[40],id[8];
 	
 	rtksvrlock(&rtksvr); // lock
 	time=rtksvr.rtk.sol.time;
@@ -1323,7 +1323,7 @@ void __fastcall TMonitorDialog::ShowIonUtc(void)
 	gtime_t time;
 	AnsiString s;
 	double tow=0.0;
-	char tstr[64];
+	char tstr[40];
 	int i,j,k,leaps,week=0;
 	
 	rtksvrlock(&rtksvr);
@@ -1603,7 +1603,7 @@ void __fastcall TMonitorDialog::ShowSbsLong(void)
 	sbssatp_t *satp;
 	gtime_t time;
 	int i,j,n,valid;
-	char tstr[64],id[8];
+	char tstr[40],id[8];
 	
 	rtksvrlock(&rtksvr); // lock
 	time=rtksvr.rtk.sol.time;
@@ -1656,7 +1656,7 @@ void __fastcall TMonitorDialog::ShowSbsIono(void)
 {
 	AnsiString s,s0="-";
 	sbsion_t sbsion[MAXBAND+1],*ion;
-	char tstr[64];
+	char tstr[40];
 	int i,j,k,n=0;
 	
 	rtksvrlock(&rtksvr); // lock
@@ -1705,7 +1705,7 @@ void __fastcall TMonitorDialog::ShowSbsFast(void)
 	sbssatp_t *satp;
 	gtime_t time;
 	int i,j,n,valid;
-	char tstr[64],id[8];
+	char tstr[40],id[8];
 	
 	rtksvrlock(&rtksvr); // lock
 	time=rtksvr.rtk.sol.time;
@@ -1754,7 +1754,7 @@ void __fastcall TMonitorDialog::ShowRtcm(void)
 	static rtcm_t rtcm;
 	double pos[3]={0};
 	int i=1,j,format;
-	char tstr[64]="-",mstr1[1024]="",mstr2[1024]="",*p1=mstr1,*p2=mstr2;
+	char tstr[40]="-",mstr1[1024]="",mstr2[1024]="",*p1=mstr1,*p2=mstr2;
 	
 	rtksvrlock(&rtksvr);
 	format=rtksvr.format[Str1];
@@ -1853,7 +1853,7 @@ void __fastcall TMonitorDialog::ShowRtcmDgps(void)
 	gtime_t time;
 	dgps_t dgps[MAXSAT];
 	int i,j,valid;
-	char tstr[64],id[8];
+	char tstr[40],id[8];
 	
 	rtksvrlock(&rtksvr);
 	time=rtksvr.rtk.sol.time;
@@ -1906,7 +1906,7 @@ void __fastcall TMonitorDialog::ShowRtcmSsr(void)
 	gtime_t time;
 	ssr_t ssr[MAXSAT];
 	int i,j,k,n,valid,sat[MAXSAT],sys=sys_tbl[SelSys2->ItemIndex+1];
-	char tstr[64],id[8],buff[256]="",*p;
+	char tstr[40],id[8],buff[256]="",*p;
 
 	rtksvrlock(&rtksvr);
 	time=rtksvr.rtk.sol.time;
@@ -1979,7 +1979,7 @@ void __fastcall TMonitorDialog::ShowRefSta(void)
 	sta_t sta;
 	double pos[3]={0};
 	int i=1,format;
-	char tstr[64]="-";
+	char tstr[40]="-";
 	
 	rtksvrlock(&rtksvr);
 	format=rtksvr.format[Str1];

--- a/app/winapp/rtknavi/mondlg.cpp
+++ b/app/winapp/rtknavi/mondlg.cpp
@@ -365,7 +365,7 @@ void __fastcall TMonitorDialog::ShowRtk(void)
 	double azel[MAXSAT*2],pos[3],vel[3],rr[3]={0},enu[3]={0};
 	int i,j,k,thread,cycle,state,rtkstat,nsat0,nsat1,prcout,nave;
 	int cputime,nb[3]={0},nmsg[3][10]={{0}},ne;
-	char tstr[64],*ant,id[32],s1[64]="-",s2[64]="-",s3[64]="-";
+	char tstr[64],*ant,id[8],s1[64]="-",s2[64]="-",s3[64]="-";
 	char file[1024]="";
 	const char *ionoopt[]={"OFF","Broadcast","SBAS","Dual-Frequency","Estimate STEC","IONEX TEC","QZSS LEX",""};
 	const char *tropopt[]={"OFF","Saastamoinen","SBAS","Estimate ZTD","Estimate ZTD+Grad",""};
@@ -706,7 +706,7 @@ void __fastcall TMonitorDialog::ShowSat(void)
 	AnsiString s;
 	int i,j,k,n,fix,prn,pmode,nfreq,sys=sys_tbl[SelSys->ItemIndex];
 	int vsat[MAXSAT]={0};
-	char id[32];
+	char id[8];
 	double az,el,cbias[MAXSAT][2];
 	
 	SetSat();
@@ -973,7 +973,7 @@ void __fastcall TMonitorDialog::ShowObs(void)
 {
 	AnsiString s;
 	obsd_t obs[MAXOBS*2];
-	char tstr[64],id[32],*code;
+	char tstr[64],id[8],*code;
 	int i,j,k,n=0,nex=ObsMode?NEXOBS:0,sys=sys_tbl[SelSys->ItemIndex];
 	
 	rtksvrlock(&rtksvr);
@@ -1050,7 +1050,7 @@ void __fastcall TMonitorDialog::ShowNav(void)
 	eph_t eph[MAXSAT];
 	gtime_t time;
 	AnsiString s;
-	char tstr[64],id[32];
+	char tstr[64],id[8];
 	int i,j,k,n,valid,prn,off=SelEph->ItemIndex*MAXSAT;
 	int sys=sys_tbl[SelSys2->ItemIndex+1];
 	
@@ -1163,7 +1163,7 @@ void __fastcall TMonitorDialog::ShowGnav(void)
 	geph_t geph[NSATGLO];
 	gtime_t time;
 	AnsiString s;
-	char tstr[64],id[32];
+	char tstr[64],id[8];
 	int i,j,n,valid,prn,off=SelEph->ItemIndex?NSATGLO:0;
 	
 	rtksvrlock(&rtksvr);
@@ -1245,7 +1245,7 @@ void __fastcall TMonitorDialog::ShowSbsNav(void)
 	seph_t seph[MAXPRNSBS-MINPRNSBS+1]={0};
 	gtime_t time;
 	int i,j,n,valid,prn,off=SelEph->ItemIndex?NSATSBS:0;
-	char tstr[64],id[32];
+	char tstr[64],id[8];
 	
 	rtksvrlock(&rtksvr); // lock
 	time=rtksvr.rtk.sol.time;
@@ -1603,7 +1603,7 @@ void __fastcall TMonitorDialog::ShowSbsLong(void)
 	sbssatp_t *satp;
 	gtime_t time;
 	int i,j,n,valid;
-	char tstr[64],id[32];
+	char tstr[64],id[8];
 	
 	rtksvrlock(&rtksvr); // lock
 	time=rtksvr.rtk.sol.time;
@@ -1705,7 +1705,7 @@ void __fastcall TMonitorDialog::ShowSbsFast(void)
 	sbssatp_t *satp;
 	gtime_t time;
 	int i,j,n,valid;
-	char tstr[64],id[32];
+	char tstr[64],id[8];
 	
 	rtksvrlock(&rtksvr); // lock
 	time=rtksvr.rtk.sol.time;
@@ -1853,7 +1853,7 @@ void __fastcall TMonitorDialog::ShowRtcmDgps(void)
 	gtime_t time;
 	dgps_t dgps[MAXSAT];
 	int i,j,valid;
-	char tstr[64],id[32];
+	char tstr[64],id[8];
 	
 	rtksvrlock(&rtksvr);
 	time=rtksvr.rtk.sol.time;
@@ -1906,7 +1906,7 @@ void __fastcall TMonitorDialog::ShowRtcmSsr(void)
 	gtime_t time;
 	ssr_t ssr[MAXSAT];
 	int i,j,k,n,valid,sat[MAXSAT],sys=sys_tbl[SelSys2->ItemIndex+1];
-	char tstr[64],id[32],buff[256]="",*p;
+	char tstr[64],id[8],buff[256]="",*p;
 
 	rtksvrlock(&rtksvr);
 	time=rtksvr.rtk.sol.time;

--- a/app/winapp/rtknavi/navimain.cpp
+++ b/app/winapp/rtknavi/navimain.cpp
@@ -1793,7 +1793,7 @@ void __fastcall TMainForm::DrawSnr(TCanvas *c, int w, int h, int x0, int y0,
     };
     UTF8String s; 
     int i,j,k,l,n,x1,x2,y1,y2,y3,k1,tm,bm,hh,ww,www,snr[NFREQ+1],mask[7]={0};
-    char id[16],sys[]="GREJCIS",*q;
+    char id[8],sys[]="GREJCIS",*q;
     
     trace(4,"DrawSnr: w=%d h=%d x0=%d y0=%d index=%d freq=%d\n",w,h,x0,y0,index,freq);
     
@@ -1869,7 +1869,7 @@ void __fastcall TMainForm::DrawSat(TCanvas *c, int w, int h, int x0, int y0,
     TPoint p(w/2,h/2);
     double r=MIN(w*0.95,h*0.95)/2,azel[MAXSAT*2],dop[4];
     int i,j,k,l,d,x[MAXSAT],y[MAXSAT],snr[NFREQ+1],ns=0;
-    char id[16],sys[]="GREJCIS",*q;
+    char id[8],sys[]="GREJCIS",*q;
     
     trace(4,"DrawSat: w=%d h=%d index=%d freq=%d\n",w,h,index,freq);
     
@@ -2345,7 +2345,7 @@ void __fastcall TMainForm::SaveNav(nav_t *nav)
 {
     TIniFile *ini=new TIniFile(IniFile);
     AnsiString str,s;
-    char id[32];
+    char id[8];
     int i;
     
     trace(3,"SaveNav\n");

--- a/app/winapp/rtknavi/navimain.cpp
+++ b/app/winapp/rtknavi/navimain.cpp
@@ -1478,7 +1478,7 @@ void __fastcall TMainForm::UpdateTime(void)
     struct tm *t;
     double tow;
     int week;
-    char tstr[64];
+    char tstr[40];
     
     trace(4,"UpdateTime\n");
     
@@ -1487,9 +1487,9 @@ void __fastcall TMainForm::UpdateTime(void)
     else if (TimeSys==2) {
         time=gpst2utc(time);
         if (!(t=localtime(&time.time))) strcpy(tstr,"2000/01/01 00:00:00.0");
-        else sprintf(tstr,"%04d/%02d/%02d %02d:%02d:%02d.%d",t->tm_year+1900,
-                     t->tm_mon+1,t->tm_mday,t->tm_hour,t->tm_min,t->tm_sec,
-                     (int)(time.sec*10));
+        else snprintf(tstr,sizeof(tstr),"%04d/%02d/%02d %02d:%02d:%02d.%d",t->tm_year+1900,
+                      t->tm_mon+1,t->tm_mday,t->tm_hour,t->tm_min,t->tm_sec,
+                      (int)(time.sec*10));
     }
     else if (TimeSys==3) {
         tow=time2gpst(time,&week); sprintf(tstr,"week %04d %8.1f s",week,tow);

--- a/app/winapp/rtknavi/naviopt.cpp
+++ b/app/winapp/rtknavi/naviopt.cpp
@@ -679,7 +679,7 @@ void __fastcall TOptDialog::LoadOpt(AnsiString file)
 	TEdit *editu[]={RovPos1,RovPos2,RovPos3};
 	TEdit *editr[]={RefPos1,RefPos2,RefPos3};
 	AnsiString s;
-	char buff[1024]="",*p,id[32];
+	char buff[1024]="",*p,id[8];
 	int sat;
 	prcopt_t prcopt=prcopt_default;
 	solopt_t solopt=solopt_default;

--- a/app/winapp/rtknavi/naviopt.cpp
+++ b/app/winapp/rtknavi/naviopt.cpp
@@ -871,7 +871,7 @@ void __fastcall TOptDialog::SaveOpt(AnsiString file)
     int otype[]={STR_SERIAL,STR_TCPCLI,STR_TCPSVR,STR_NTRIPSVR,STR_NTRIPCAS,STR_FILE};
 	TEdit *editu[]={RovPos1,RovPos2,RovPos3};
 	TEdit *editr[]={RefPos1,RefPos2,RefPos3};
-	char buff[1024],*p,*q,id[32],comment[256],s[64];
+	char buff[1024],*p,*q,id[32],comment[256],s[40];
 	int sat,ex;
 	prcopt_t prcopt=prcopt_default;
 	solopt_t solopt=solopt_default;

--- a/app/winapp/rtkplot/plotcmn.cpp
+++ b/app/winapp/rtkplot/plotcmn.cpp
@@ -438,17 +438,17 @@ int __fastcall TPlot::SearchPos(int x, int y)
     return -1;
 }
 // generate time-string -----------------------------------------------------
-void __fastcall TPlot::TimeStr(gtime_t time, int n, int tsys, char *str)
+void __fastcall TPlot::TimeStr(gtime_t time, int n, int tsys, char str[48])
 {
     struct tm *t;
-    char tstr[64];
+    char tstr[40];
     const char *label="";
     double tow;
     int week;
     
     if (TimeLabel==0) { // www/ssss
         tow=time2gpst(time,&week);
-        sprintf(tstr,"%4d/%*.*fs",week,(n>0?6:5)+n,n,tow);
+        snprintf(tstr,sizeof(tstr),"%4d/%*.*fs",week,(n>0?6:5)+n,n,tow);
     }
     else if (TimeLabel==1) { // gpst
         time2str(time,tstr,n);
@@ -461,12 +461,12 @@ void __fastcall TPlot::TimeStr(gtime_t time, int n, int tsys, char *str)
     else { // lt
         time=gpst2utc(time);
         if (!(t=localtime(&time.time))) strcpy(tstr,"2000/01/01 00:00:00.0");
-        else sprintf(tstr,"%04d/%02d/%02d %02d:%02d:%02d.%0*d",t->tm_year+1900,
-                     t->tm_mon+1,t->tm_mday,t->tm_hour,t->tm_min,t->tm_sec,
-                     n,(int)(time.sec*pow(10.0,n)));
+        else snprintf(tstr,sizeof(tstr),"%04d/%02d/%02d %02d:%02d:%02d.%0*d",t->tm_year+1900,
+                      t->tm_mon+1,t->tm_mday,t->tm_hour,t->tm_min,t->tm_sec,
+                      n,(int)(time.sec*pow(10.0,n)));
         label=" LT";
     }
-    sprintf(str,"%s%s",tstr,label);
+    snprintf(str,48,"%s%s",tstr,label);
 }
 // latitude/longitude/height string -----------------------------------------
 UTF8String __fastcall TPlot::LatLonStr(const double *pos, int ndec)

--- a/app/winapp/rtkplot/plotdata.cpp
+++ b/app/winapp/rtkplot/plotdata.cpp
@@ -953,7 +953,7 @@ void __fastcall TPlot::SaveDop(AnsiString file)
     gtime_t time;
     double azel[MAXOBS*2],dop[4],tow;
     int i,j,ns,week;
-    char tstr[64];
+    char tstr[40];
     const char *tlabel;
     
     trace(3,"SaveDop: file=%s\n",file.c_str());
@@ -982,7 +982,7 @@ void __fastcall TPlot::SaveDop(AnsiString file)
         time=Obs.data[IndexObs[i]].time;
         if (TimeLabel==0) {
             tow=time2gpst(time,&week);
-            sprintf(tstr,"%4d %8.1f ",week,tow);
+            snprintf(tstr,sizeof(tstr),"%4d %8.1f ",week,tow);
         }
         else if (TimeLabel==1) {
             time2str(time,tstr,1);
@@ -1005,7 +1005,7 @@ void __fastcall TPlot::SaveSnrMp(AnsiString file)
     AnsiString ObsTypeText=ObsType2->Text;
     gtime_t time;
     double tow;
-    char sat[8],mp[32],tstr[64],*code=ObsTypeText.c_str()+1;
+    char sat[8],mp[32],tstr[40],*code=ObsTypeText.c_str()+1;
     const char *tlabel;
     int i,j,k,week;
     
@@ -1035,7 +1035,7 @@ void __fastcall TPlot::SaveSnrMp(AnsiString file)
             
             if (TimeLabel==0) {
                 tow=time2gpst(time,&week);
-                sprintf(tstr,"%4d %9.1f ",week,tow);
+                snprintf(tstr,sizeof(tstr),"%4d %9.1f ",week,tow);
             }
             else if (TimeLabel==1) {
                 time2str(time,tstr,1);

--- a/app/winapp/rtkplot/plotdata.cpp
+++ b/app/winapp/rtkplot/plotdata.cpp
@@ -368,7 +368,7 @@ void __fastcall TPlot::GenVisData(void)
     sta_t sta={0};
     double tint,r,pos[3],rr[3],rs[6],e[3],azel[2];
     int i,j,nobs=0;
-    char name[16];
+    char name[8];
     
     trace(3,"GenVisData\n");
     
@@ -1005,7 +1005,7 @@ void __fastcall TPlot::SaveSnrMp(AnsiString file)
     AnsiString ObsTypeText=ObsType2->Text;
     gtime_t time;
     double tow;
-    char sat[32],mp[32],tstr[64],*code=ObsTypeText.c_str()+1;
+    char sat[8],mp[32],tstr[64],*code=ObsTypeText.c_str()+1;
     const char *tlabel;
     int i,j,k,week;
     
@@ -1240,7 +1240,7 @@ void __fastcall TPlot::UpdateObs(int nobs)
             int sat=Obs.data[i+k].sat;
             
             if (SimObs) {
-                char name[16];
+                char name[8];
                 satno2id(sat,name);
                 if (!tle_pos(time,name,"","",&TLEData,NULL,rs)) continue;
             }

--- a/app/winapp/rtkplot/plotdraw.cpp
+++ b/app/winapp/rtkplot/plotdraw.cpp
@@ -901,7 +901,7 @@ void __fastcall TPlot::DrawObs(int level)
     obsd_t *obs;
     double xs,ys,xt,xl[2],yl[2],tt[MAXSAT]={0},xp,xc,yc,yp[MAXSAT]={0};
     int i,j,m=0,sats[MAXSAT]={0},ind=ObsIndex,prn;
-    char id[16];
+    char id[8];
     
     trace(3,"DrawObs: level=%d\n",level);
     
@@ -1240,7 +1240,7 @@ void __fastcall TPlot::DrawSky(int level)
             if (p0[i][0]!=0.0||p0[i][1]!=0.0) {
                 TPoint pnt;
                 if (GraphS->ToPoint(p0[i][0],p0[i][1],pnt)) {
-                    char id[16];
+                    char id[8];
                     satno2id(i+1,id);
                     UTF8String ustr=id;
                     DrawLabel(GraphS,pnt,ustr,1,0);
@@ -1295,7 +1295,7 @@ void __fastcall TPlot::DrawSky(int level)
             x=r*sin(Az[i])*(1.0-2.0*El[i]/PI);
             y=r*cos(Az[i])*(1.0-2.0*El[i]/PI);
             
-            char id[16];
+            char id[8];
             satno2id(obs->sat,id);
             UTF8String ustr=id;
             GraphS->DrawMark(x,y,0,col,Disp->Font->Size*2+5,0);
@@ -1318,7 +1318,7 @@ void __fastcall TPlot::DrawSky(int level)
     // show statistics
     if (ShowStats&&BtnShowTrack->Down&&0<=ind&&ind<NObs&&!SimObs) {
         UTF8String ustr,ss;
-        char id[16];
+        char id[8];
         
         if (!strcmp(obstype,"ALL")) {
             ustr.sprintf("%3s: %*s %*s%*s %*s","SAT",NFREQ,"PR",NFREQ,"CP",
@@ -1968,7 +1968,7 @@ void __fastcall TPlot::DrawMpS(int level)
             double x=r*sin(Az[i])*(1.0-2.0*El[i]/PI);
             double y=r*cos(Az[i])*(1.0-2.0*El[i]/PI);
             UTF8String ustr;
-            char id[32];
+            char id[8];
             satno2id(obs->sat,id);
             ustr=id;
             GraphS->DrawMark(x,y,0,col,Disp->Font->Size*2+5,0);

--- a/app/winapp/rtkplot/plotinfo.cpp
+++ b/app/winapp/rtkplot/plotinfo.cpp
@@ -32,7 +32,7 @@ void __fastcall TPlot::UpdateTimeObs(void)
     UTF8String msg,msgs[8],s;
     double azel[MAXOBS*2],dop[4]={0};
     int i,ns=0,no=0,ind=ObsIndex;
-    char tstr[64];
+    char tstr[48];
     
     trace(3,"UpdateTimeObs\n");
     
@@ -86,7 +86,7 @@ void __fastcall TPlot::UpdateTimeSol(void)
     sol_t *data;
     double xyz[3],pos[3],r,az,el;
     int sel=BtnSol1->Down||!BtnSol2->Down?0:1,ind=SolIndex[sel];
-    char tstr[64];
+    char tstr[48];
     
     trace(3,"UpdateTimeSol\n");
     
@@ -139,7 +139,7 @@ void __fastcall TPlot::UpdateInfoObs(void)
     UTF8String msg,msgs[8];
     gtime_t ts={0},te={0},t,tp={0};
     int i,n=0,ne=0;
-    char s1[64],s2[64],*p;
+    char s1[48],s2[48],*p;
     
     trace(3,"UpdateInfoObs:\n");
     
@@ -185,7 +185,7 @@ void __fastcall TPlot::UpdateInfoSol(void)
     gtime_t ts={0},te={0};
     double r[3],b,bl[2]={1E9,0.0};
     int i,j,n=0,nq[8]={0},sel=BtnSol1->Down||!BtnSol2->Down?0:1;
-    char s1[64],s2[64],*p;
+    char s1[48],s2[48],*p;
     
     trace(3,"UpdateInfoSol:\n");
     
@@ -369,7 +369,7 @@ void __fastcall TPlot::UpdatePoint(int x, int y)
     TPoint p(x,y);
     double enu[3]={0},rr[3],pos[3],xx,yy,r,xl[2],yl[2],q[2],az,el,snr;
     int i;
-    char tstr[64];
+    char tstr[48];
     UTF8String msg;
     
     trace(4,"UpdatePoint: x=%d y=%d\n",x,y);

--- a/app/winapp/rtkplot/plotmain.cpp
+++ b/app/winapp/rtkplot/plotmain.cpp
@@ -2243,7 +2243,7 @@ void __fastcall TPlot::UpdateSatMask(void)
 void __fastcall TPlot::UpdateSatSel(void)
 {
     AnsiString SatListText=SatList->Text;
-    char id[16];
+    char id[8];
     int i,sys=0;
     
     if      (SatListText=="G") sys=SYS_GPS;

--- a/app/winapp/rtkplot/plotmain.cpp
+++ b/app/winapp/rtkplot/plotmain.cpp
@@ -1855,7 +1855,7 @@ void __fastcall TPlot::TimerTimer(TObject *Sender)
     double tint=TimeEna[2]?TimeInt:0.0,pos[3],ep[6];
     int i,j,n,inb,inr,cycle,nmsg[2]={0},stat,istat;
     int sel=!BtnSol1->Down&&BtnSol2->Down?1:0;
-    char msg[MAXSTRMSG]="",tstr[32];
+    char msg[MAXSTRMSG]="",tstr[40];
     
     trace(4,"TimeTimer\n");
     

--- a/app/winapp/rtkpost/postopt.cpp
+++ b/app/winapp/rtkpost/postopt.cpp
@@ -620,7 +620,7 @@ int ppp=PosMode->ItemIndex>=PMODE_PPP_KINEMA;
 	TEdit *editu[]={RovPos1,RovPos2,RovPos3};
 	TEdit *editr[]={RefPos1,RefPos2,RefPos3};
 	AnsiString s;
-	char buff[1024]="",*p,id[32];
+	char buff[1024]="",*p,id[8];
 	int sat;
 	prcopt_t prcopt=prcopt_default;
 	solopt_t solopt=solopt_default;

--- a/app/winapp/rtkpost/postopt.cpp
+++ b/app/winapp/rtkpost/postopt.cpp
@@ -784,7 +784,7 @@ int ppp=PosMode->ItemIndex>=PMODE_PPP_KINEMA;
 	AnsiString PPPOpts_Text=PPPOpts->Text;
 	TEdit *editu[]={RovPos1,RovPos2,RovPos3};
 	TEdit *editr[]={RefPos1,RefPos2,RefPos3};
-	char buff[1024],*p,id[32],comment[256],s[64];
+	char buff[1024],*p,id[32],comment[256],s[40];
 	int sat,ex;
 	prcopt_t prcopt=prcopt_default;
 	solopt_t solopt=solopt_default;

--- a/app/winapp/strsvr/svrmain.cpp
+++ b/app/winapp/strsvr/svrmain.cpp
@@ -375,9 +375,10 @@ void __fastcall TMainForm::Timer1Timer(TObject *Sender)
 	}
 	pos=fmod(byte[0]/1e3/MAX(ProgBarRange,1),1.0)*110.0;
 	Progress->Position=!stat[0]?0:MIN((int)pos,100);
-	
-	time2str(time,s1,0);
-	Time->Caption=s.sprintf("%s GPST",s1);
+
+        char tstr[40];
+	time2str(time,tstr,0);
+	Time->Caption=s.sprintf("%s GPST",tstr);
 	
 	if (Panel1->Enabled) {
 		ctime=timediff(EndTime,StartTime);

--- a/src/convrnx.c
+++ b/src/convrnx.c
@@ -279,7 +279,8 @@ static int input_strfile(strfile_t *str)
     if (!str->tstart.time&&str->time.time) {
         str->tstart=str->time;
     }
-    trace(4,"input_strfile: time=%s type=%d\n",time_str(str->time,3),type);
+    char tstr[40];
+    trace(4,"input_strfile: time=%s type=%d\n",time2str(str->time,tstr,3),type);
     return type;
 }
 /* open stream file ----------------------------------------------------------*/
@@ -786,9 +787,11 @@ static int scan_file(char **files, int nf, rnxopt_t *opt, strfile_t *str,
             }
             if (++c%11) continue;
             
-            sprintf(msg,"scanning: %s %s%s%s%s%s%s%s",time_str(str->time,0),
-                    n[0]?"G":"",n[1]?"R":"",n[2]?"E":"",n[3]?"J":"",
-                    n[4]?"S":"",n[5]?"C":"",n[6]?"I":"");
+            char tstr[40];
+            snprintf(msg,sizeof(msg),"scanning: %s %s%s%s%s%s%s%s",
+                     time2str(str->time,tstr,0),
+                     n[0]?"G":"",n[1]?"R":"",n[2]?"E":"",n[3]?"J":"",
+                     n[4]?"S":"",n[5]?"C":"",n[6]?"I":"");
             if ((abort=showmsg(msg))) break;
         }
         close_strfile(str);

--- a/src/convrnx.c
+++ b/src/convrnx.c
@@ -680,7 +680,7 @@ static void dump_halfc(const strfile_t *str)
 {
 #if 0 /* for debug */
     halfc_t *p;
-    char s0[32],s1[32],s2[32],*stats[]={"ADD","SUB","NON"};
+    char s0[8],s1[32],s2[32],*stats[]={"ADD","SUB","NON"};
     int i,j;
     
     trace(2,"# HALF-CYCLE AMBIGUITY CORRECTIONS\n");

--- a/src/convrnx.c
+++ b/src/convrnx.c
@@ -484,7 +484,7 @@ static void setopt_phshift(rnxopt_t *opt)
 static void setopt_sta_list(const strfile_t *str, rnxopt_t *opt)
 {
     const stas_t *p;
-    char s1[32],s2[32];
+    char s1[40],s2[40];
     int n=0;
 
     for (p=str->stas;p;p=p->next) {
@@ -605,7 +605,7 @@ static void dump_stas(const strfile_t *str)
 #if 1 /* for debug */
     stas_t *p;
     double pos[3];
-    char s1[32],s2[32];
+    char s1[40],s2[40];
 
     trace(2,"# STATION LIST\n");
     trace(2,"# %17s %19s %5s %6s %16s %16s %12s %13s %9s %2s %6s %6s %6s\n",
@@ -680,7 +680,7 @@ static void dump_halfc(const strfile_t *str)
 {
 #if 0 /* for debug */
     halfc_t *p;
-    char s0[8],s1[32],s2[32],*stats[]={"ADD","SUB","NON"};
+    char s0[8],s1[40],s2[40],*stats[]={"ADD","SUB","NON"};
     int i,j;
     
     trace(2,"# HALF-CYCLE AMBIGUITY CORRECTIONS\n");
@@ -1226,7 +1226,7 @@ static void setopt_apppos(strfile_t *str, rnxopt_t *opt)
 static int showstat(int sess, gtime_t ts, gtime_t te, int *n)
 {
     const char type[]="ONGHQLCISET";
-    char msg[1024]="",*p=msg,s[64];
+    char msg[1024]="",*p=msg,s[40];
     int i;
     
     if (sess>0) {

--- a/src/download.c
+++ b/src/download.c
@@ -849,9 +849,10 @@ extern void dl_test(gtime_t ts, gtime_t te, double ti, const url_t *urls,
     int i,j,n,m,*nc,*nt,week,flag,abort=0;
     
     if (ncol<1) ncol=1; else if (ncol>200) ncol=200;
-     
+
+    char tstr[40];
     fprintf(fp,"** LOCAL DATA AVAILABILITY (%s, %s) **\n\n",
-            time_str(timeget(),0),*dir?dir:"*");
+            time2str(timeget(),tstr,0),*dir?dir:"*");
     
     for (i=n=0;i<nurl;i++) {
         n+=strstr(urls[i].path,"%s")||strstr(urls[i].path,"%S")?nsta:1;

--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -151,7 +151,8 @@ extern void alm2pos(gtime_t time, const alm_t *alm, double *rs, double *dts)
     double tk,M,E,Ek,sinE,cosE,u,r,i,O,x,y,sinO,cosO,cosi,mu;
     int n;
 
-    trace(4,"alm2pos : time=%s sat=%2d\n",time_str(time,3),alm->sat);
+    char tstr[40];
+    trace(4,"alm2pos : time=%s sat=%2d\n",time2str(time,tstr,3),alm->sat);
 
     tk=timediff(time,alm->toa);
 
@@ -192,7 +193,8 @@ extern double eph2clk(gtime_t time, const eph_t *eph)
     double t,ts;
     int i;
 
-    trace(4,"eph2clk : time=%s sat=%2d\n",time_str(time,3),eph->sat);
+    char tstr[40];
+    trace(4,"eph2clk : time=%s sat=%2d\n",time2str(time,tstr,3),eph->sat);
 
     t=ts=timediff(time,eph->toc);
 
@@ -224,7 +226,8 @@ extern void eph2pos(gtime_t time, const eph_t *eph, double *rs, double *dts,
     double xg,yg,zg,sino,coso;
     int n,sys,prn;
 
-    trace(4,"eph2pos : time=%s sat=%2d\n",time_str(time,3),eph->sat);
+    char tstr[40];
+    trace(4,"eph2pos : time=%s sat=%2d\n",time2str(time,tstr,3),eph->sat);
 
     if (eph->A<=0.0) {
         rs[0]=rs[1]=rs[2]=*dts=*var=0.0;
@@ -330,7 +333,8 @@ extern double geph2clk(gtime_t time, const geph_t *geph)
     double t,ts;
     int i;
 
-    trace(4,"geph2clk: time=%s sat=%2d\n",time_str(time,3),geph->sat);
+    char tstr[40];
+    trace(4,"geph2clk: time=%s sat=%2d\n",time2str(time,tstr,3),geph->sat);
 
     t=ts=timediff(time,geph->toe);
 
@@ -357,7 +361,8 @@ extern void geph2pos(gtime_t time, const geph_t *geph, double *rs, double *dts,
     double t,tt,x[6];
     int i;
 
-    trace(4,"geph2pos: time=%s sat=%2d\n",time_str(time,3),geph->sat);
+    char tstr[40];
+    trace(4,"geph2pos: time=%s sat=%2d\n",time2str(time,tstr,3),geph->sat);
 
     t=timediff(time,geph->toe);
 
@@ -388,7 +393,8 @@ extern double seph2clk(gtime_t time, const seph_t *seph)
     double t;
     int i;
 
-    trace(4,"seph2clk: time=%s sat=%2d\n",time_str(time,3),seph->sat);
+    char tstr[40];
+    trace(4,"seph2clk: time=%s sat=%2d\n",time2str(time,tstr,3),seph->sat);
 
     t=timediff(time,seph->t0);
 
@@ -413,7 +419,8 @@ extern void seph2pos(gtime_t time, const seph_t *seph, double *rs, double *dts,
     double t;
     int i;
 
-    trace(4,"seph2pos: time=%s sat=%2d\n",time_str(time,3),seph->sat);
+    char tstr[40];
+    trace(4,"seph2pos: time=%s sat=%2d\n",time2str(time,tstr,3),seph->sat);
 
     t=timediff(time,seph->t0);
 
@@ -430,7 +437,8 @@ static eph_t *seleph(gtime_t time, int sat, int iode, const nav_t *nav)
     double t,tmax,tmin;
     int i,j=-1,sys,sel=0;
 
-    trace(4,"seleph  : time=%s sat=%2d iode=%d\n",time_str(time,3),sat,iode);
+    char tstr[40];
+    trace(4,"seleph  : time=%s sat=%2d iode=%d\n",time2str(time,tstr,3),sat,iode);
 
     sys=satsys(sat,NULL);
     switch (sys) {
@@ -461,7 +469,7 @@ static eph_t *seleph(gtime_t time, int sat, int iode, const nav_t *nav)
         if (t<=tmin) {j=i; tmin=t;} /* toe closest to time */
     }
     if (iode>=0||j<0) {
-        trace(2,"no broadcast ephemeris: %s sat=%2d iode=%3d\n",time_str(time,0),
+        trace(2,"no broadcast ephemeris: %s sat=%2d iode=%3d\n",time2str(time,tstr,0),
               sat,iode);
         return NULL;
     }
@@ -474,7 +482,8 @@ static geph_t *selgeph(gtime_t time, int sat, int iode, const nav_t *nav)
     double t,tmax=MAXDTOE_GLO,tmin=tmax+1.0;
     int i,j=-1;
 
-    trace(4,"selgeph : time=%s sat=%2d iode=%2d\n",time_str(time,3),sat,iode);
+    char tstr[40];
+    trace(4,"selgeph : time=%s sat=%2d iode=%2d\n",time2str(time,tstr,3),sat,iode);
 
     for (i=0;i<nav->ng;i++) {
         if (nav->geph[i].sat!=sat) continue;
@@ -484,7 +493,7 @@ static geph_t *selgeph(gtime_t time, int sat, int iode, const nav_t *nav)
         if (t<=tmin) {j=i; tmin=t;} /* toe closest to time */
     }
     if (iode>=0||j<0) {
-        trace(3,"no glonass ephemeris  : %s sat=%2d iode=%2d\n",time_str(time,0),
+        trace(3,"no glonass ephemeris  : %s sat=%2d iode=%2d\n",time2str(time,tstr,0),
               sat,iode);
         return NULL;
     }
@@ -497,7 +506,8 @@ static seph_t *selseph(gtime_t time, int sat, const nav_t *nav)
     double t,tmax=MAXDTOE_SBS,tmin=tmax+1.0;
     int i,j=-1;
 
-    trace(4,"selseph : time=%s sat=%2d\n",time_str(time,3),sat);
+    char tstr[40];
+    trace(4,"selseph : time=%s sat=%2d\n",time2str(time,tstr,3),sat);
 
     for (i=0;i<nav->ns;i++) {
         if (nav->seph[i].sat!=sat) continue;
@@ -505,7 +515,7 @@ static seph_t *selseph(gtime_t time, int sat, const nav_t *nav)
         if (t<=tmin) {j=i; tmin=t;} /* toe closest to time */
     }
     if (j<0) {
-        trace(3,"no sbas ephemeris     : %s sat=%2d\n",time_str(time,0),sat);
+        trace(3,"no sbas ephemeris     : %s sat=%2d\n",time2str(time,tstr,0),sat);
         return NULL;
     }
     return nav->seph+j;
@@ -519,7 +529,8 @@ static int ephclk(gtime_t time, gtime_t teph, int sat, const nav_t *nav,
     seph_t *seph;
     int sys;
 
-    trace(4,"ephclk  : time=%s sat=%2d\n",time_str(time,3),sat);
+    char tstr[40];
+    trace(4,"ephclk  : time=%s sat=%2d\n",time2str(time,tstr,3),sat);
 
     sys=satsys(sat,NULL);
 
@@ -550,7 +561,8 @@ static int ephpos(gtime_t time, gtime_t teph, int sat, const nav_t *nav,
     double rst[3],dtst[1],tt=1E-3;
     int i,sys;
 
-    trace(4,"ephpos  : time=%s sat=%2d iode=%d\n",time_str(time,3),sat,iode);
+    char tstr[40];
+    trace(4,"ephpos  : time=%s sat=%2d iode=%d\n",time2str(time,tstr,3),sat,iode);
 
     sys=satsys(sat,NULL);
 
@@ -592,7 +604,8 @@ static int satpos_sbas(gtime_t time, gtime_t teph, int sat, const nav_t *nav,
     const sbssatp_t *sbs=NULL;
     int i;
 
-    trace(4,"satpos_sbas: time=%s sat=%2d\n",time_str(time,3),sat);
+    char tstr[40];
+    trace(4,"satpos_sbas: time=%s sat=%2d\n",time2str(time,tstr,3),sat);
 
     /* search sbas satellite correction */
     for (i=0;i<nav->sbssat.nsat;i++) {
@@ -600,7 +613,7 @@ static int satpos_sbas(gtime_t time, gtime_t teph, int sat, const nav_t *nav,
         if (sbs->sat==sat) break;
     }
     if (i>=nav->sbssat.nsat) {
-        trace(2,"no sbas, use brdcast: %s sat=%2d\n",time_str(time,0),sat);
+        trace(2,"no sbas, use brdcast: %s sat=%2d\n",time2str(time,tstr,0),sat);
         if (!ephpos(time,teph,sat,nav,-1,rs,dts,var,svh)) return 0;
         /* *svh=-1; */ /* use broadcast if no sbas */
         return 1;
@@ -622,22 +635,23 @@ static int satpos_ssr(gtime_t time, gtime_t teph, int sat, const nav_t *nav,
     double t1,t2,t3,er[3],ea[3],ec[3],rc[3],deph[3],dclk,dant[3]={0},tk;
     int i,sys;
 
-    trace(4,"satpos_ssr: time=%s sat=%2d\n",time_str(time,3),sat);
+    char tstr[40];
+    trace(4,"satpos_ssr: time=%s sat=%2d\n",time2str(time,tstr,3),sat);
 
     ssr=nav->ssr+sat-1;
 
     if (!ssr->t0[0].time) {
-        trace(2,"no ssr orbit correction: %s sat=%2d\n",time_str(time,0),sat);
+        trace(2,"no ssr orbit correction: %s sat=%2d\n",time2str(time,tstr,0),sat);
         return 0;
     }
     if (!ssr->t0[1].time) {
-        trace(2,"no ssr clock correction: %s sat=%2d\n",time_str(time,0),sat);
+        trace(2,"no ssr clock correction: %s sat=%2d\n",time2str(time,tstr,0),sat);
         return 0;
     }
     /* inconsistency between orbit and clock correction */
     if (ssr->iod[0]!=ssr->iod[1]) {
         trace(2,"inconsist ssr correction: %s sat=%2d iod=%d %d\n",
-              time_str(time,0),sat,ssr->iod[0],ssr->iod[1]);
+              time2str(time,tstr,0),sat,ssr->iod[0],ssr->iod[1]);
         *svh=-1;
         return 0;
     }
@@ -647,7 +661,7 @@ static int satpos_ssr(gtime_t time, gtime_t teph, int sat, const nav_t *nav,
 
     /* ssr orbit and clock correction (ref [4]) */
     if (fabs(t1)>MAXAGESSR||fabs(t2)>MAXAGESSR) {
-        trace(2,"age of ssr error: %s sat=%2d t=%.0f %.0f\n",time_str(time,0),
+        trace(2,"age of ssr error: %s sat=%2d t=%.0f %.0f\n",time2str(time,tstr,0),
               sat,t1,t2);
         *svh=-1;
         return 0;
@@ -664,7 +678,7 @@ static int satpos_ssr(gtime_t time, gtime_t teph, int sat, const nav_t *nav,
     }
     if (norm(deph,3)>MAXECORSSR||fabs(dclk)>MAXCCORSSR) {
         trace(3,"invalid ssr correction: %s deph=%.1f dclk=%.1f\n",
-              time_str(time,0),norm(deph,3),dclk);
+              time2str(time,tstr,0),norm(deph,3),dclk);
         *svh=-1;
         return 0;
     }
@@ -707,7 +721,7 @@ static int satpos_ssr(gtime_t time, gtime_t teph, int sat, const nav_t *nav,
     *var=var_urassr(ssr->ura);
 
     trace(5,"satpos_ssr: %s sat=%2d deph=%6.3f %6.3f %6.3f er=%6.3f %6.3f %6.3f dclk=%6.3f var=%6.3f\n",
-          time_str(time,2),sat,deph[0],deph[1],deph[2],er[0],er[1],er[2],dclk,*var);
+          time2str(time,tstr,2),sat,deph[0],deph[1],deph[2],er[0],er[1],er[2],dclk,*var);
 
     return 1;
 }
@@ -731,7 +745,8 @@ extern int satpos(gtime_t time, gtime_t teph, int sat, int ephopt,
                   const nav_t *nav, double *rs, double *dts, double *var,
                   int *svh)
 {
-    trace(4,"satpos  : time=%s sat=%2d ephopt=%d\n",time_str(time,3),sat,ephopt);
+    char tstr[40];
+    trace(4,"satpos  : time=%s sat=%2d ephopt=%d\n",time2str(time,tstr,3),sat,ephopt);
 
     *svh=0;
 
@@ -777,7 +792,8 @@ extern void satposs(gtime_t teph, const obsd_t *obs, int n, const nav_t *nav,
     double dt,pr;
     int i,j;
 
-    trace(3,"satposs : teph=%s n=%d ephopt=%d\n",time_str(teph,3),n,ephopt);
+    char tstr[40];
+    trace(3,"satposs : teph=%s n=%d ephopt=%d\n",time2str(teph,tstr,3),n,ephopt);
 
     for (i=0;i<n&&i<2*MAXOBS;i++) {
         for (j=0;j<6;j++) rs [j+i*6]=0.0;
@@ -788,7 +804,7 @@ extern void satposs(gtime_t teph, const obsd_t *obs, int n, const nav_t *nav,
         for (j=0,pr=0.0;j<NFREQ;j++) if ((pr=obs[i].P[j])!=0.0) break;
 
         if (j>=NFREQ) {
-            trace(2,"no pseudorange %s sat=%2d\n",time_str(obs[i].time,3),obs[i].sat);
+            trace(2,"no pseudorange %s sat=%2d\n",time2str(obs[i].time,tstr,3),obs[i].sat);
             continue;
         }
         /* transmission time by satellite clock */
@@ -796,7 +812,7 @@ extern void satposs(gtime_t teph, const obsd_t *obs, int n, const nav_t *nav,
 
         /* satellite clock bias by broadcast ephemeris */
         if (!ephclk(time[i],teph,obs[i].sat,nav,&dt)) {
-            trace(3,"no broadcast clock %s sat=%2d\n",time_str(time[i],3),obs[i].sat);
+            trace(3,"no broadcast clock %s sat=%2d\n",time2str(time[i],tstr,3),obs[i].sat);
             continue;
         }
         time[i]=timeadd(time[i],-dt);
@@ -804,7 +820,7 @@ extern void satposs(gtime_t teph, const obsd_t *obs, int n, const nav_t *nav,
         /* satellite position and clock at transmission time */
         if (!satpos(time[i],teph,obs[i].sat,ephopt,nav,rs+i*6,dts+i*2,var+i,
                     svh+i)) {
-            trace(3,"no ephemeris %s sat=%2d\n",time_str(time[i],3),obs[i].sat);
+            trace(3,"no ephemeris %s sat=%2d\n",time2str(time[i],tstr,3),obs[i].sat);
             continue;
         }
         /* if no precise clock available, use broadcast clock instead */
@@ -820,7 +836,7 @@ extern void satposs(gtime_t teph, const obsd_t *obs, int n, const nav_t *nav,
     }
     for (i=0;i<n&&i<2*MAXOBS;i++) {
         trace(4,"%s sat=%2d rs=%13.3f %13.3f %13.3f dts=%12.3f var=%7.3f svh=%02X\n",
-              time_str(time[i],9),obs[i].sat,rs[i*6],rs[1+i*6],rs[2+i*6],
+              time2str(time[i],tstr,9),obs[i].sat,rs[i*6],rs[1+i*6],rs[2+i*6],
               dts[i*2]*1E9,var[i],svh[i]);
     }
 }

--- a/src/ionex.c
+++ b/src/ionex.c
@@ -98,7 +98,7 @@ static tec_t *addtec(const double *lats, const double *lons, const double *hgts,
 static void readionexdcb(FILE *fp, double *dcb, double *rms)
 {
     int i,sat;
-    char buff[1024],id[32],*label;
+    char buff[1024],id[8],*label;
     
     trace(3,"readionexdcb:\n");
     

--- a/src/ionex.c
+++ b/src/ionex.c
@@ -384,7 +384,8 @@ static int iondelay(gtime_t time, const tec_t *tec, const double *pos,
     double fs,posp[3]={0},vtec,rms,hion,rp;
     int i;
     
-    trace(3,"iondelay: time=%s pos=%.1f %.1f azel=%.1f %.1f\n",time_str(time,0),
+    char tstr[40];
+    trace(3,"iondelay: time=%s pos=%.1f %.1f azel=%.1f %.1f\n",time2str(time,tstr,0),
           pos[0]*R2D,pos[1]*R2D,azel[0]*R2D,azel[1]*R2D);
     
     *delay=*var=0.0;
@@ -436,7 +437,8 @@ extern int iontec(gtime_t time, const nav_t *nav, const double *pos,
     double dels[2],vars[2],a,tt;
     int i,stat[2];
     
-    trace(3,"iontec  : time=%s pos=%.1f %.1f azel=%.1f %.1f\n",time_str(time,0),
+    char tstr[40];
+    trace(3,"iontec  : time=%s pos=%.1f %.1f azel=%.1f %.1f\n",time2str(time,tstr,0),
           pos[0]*R2D,pos[1]*R2D,azel[0]*R2D,azel[1]*R2D);
     
     if (azel[1]<MIN_EL||pos[2]<MIN_HGT) {
@@ -448,7 +450,7 @@ extern int iontec(gtime_t time, const nav_t *nav, const double *pos,
         if (timediff(nav->tec[i].time,time)>0.0) break;
     }
     if (i==0||i>=nav->nt) {
-        trace(2,"%s: tec grid out of period\n",time_str(time,0));
+        trace(2,"%s: tec grid out of period\n",time2str(time,tstr,0));
         return 0;
     }
     if ((tt=timediff(nav->tec[i].time,nav->tec[i-1].time))==0.0) {
@@ -461,7 +463,7 @@ extern int iontec(gtime_t time, const nav_t *nav, const double *pos,
     
     if (!stat[0]&&!stat[1]) {
         trace(2,"%s: tec grid out of area pos=%6.2f %7.2f azel=%6.1f %5.1f\n",
-              time_str(time,0),pos[0]*R2D,pos[1]*R2D,azel[0]*R2D,azel[1]*R2D);
+              time2str(time,tstr,0),pos[0]*R2D,pos[1]*R2D,azel[0]*R2D,azel[1]*R2D);
         return 0;
     }
     if (stat[0]&&stat[1]) { /* linear interpolation by time */

--- a/src/pntpos.c
+++ b/src/pntpos.c
@@ -483,7 +483,7 @@ static int raim_fde(const obsd_t *obs, int n, const double *rs,
 {
     obsd_t *obs_e;
     sol_t sol_e={{0}};
-    char tstr[32],name[16],msg_e[128];
+    char tstr[32],name[8],msg_e[128];
     double *rs_e,*dts_e,*vare_e,*azel_e,*resp_e,rms_e,rms=100.0;
     int i,j,k,nvsat,stat=0,*svh_e,*vsat_e,sat=0;
     

--- a/src/pntpos.c
+++ b/src/pntpos.c
@@ -214,8 +214,9 @@ extern int ionocorr(gtime_t time, const nav_t *nav, int sat, const double *pos,
 {
     int err=0;
 
+    char tstr[40];
     trace(4,"ionocorr: time=%s opt=%d sat=%2d pos=%.3f %.3f azel=%.3f %.3f\n",
-          time_str(time,3),ionoopt,sat,pos[0]*R2D,pos[1]*R2D,azel[0]*R2D,
+          time2str(time,tstr,3),ionoopt,sat,pos[0]*R2D,pos[1]*R2D,azel[0]*R2D,
           azel[1]*R2D);
     
     /* SBAS ionosphere model */
@@ -258,8 +259,9 @@ extern int ionocorr(gtime_t time, const nav_t *nav, int sat, const double *pos,
 extern int tropcorr(gtime_t time, const nav_t *nav, const double *pos,
                     const double *azel, int tropopt, double *trp, double *var)
 {
+    char tstr[40];
     trace(4,"tropcorr: time=%s opt=%d pos=%.3f %.3f azel=%.3f %.3f\n",
-          time_str(time,3),tropopt,pos[0]*R2D,pos[1]*R2D,azel[0]*R2D,
+          time2str(time,tstr,3),tropopt,pos[0]*R2D,pos[1]*R2D,azel[0]*R2D,
           azel[1]*R2D);
     
     /* Saastamoinen model */
@@ -303,7 +305,8 @@ static int rescode(int iter, const obsd_t *obs, int n, const double *rs,
         
         /* reject duplicated observation data */
         if (i<n-1&&i<MAXOBS-1&&sat==obs[i+1].sat) {
-            trace(2,"duplicated obs data %s sat=%d\n",time_str(time,3),sat);
+            char tstr[40];
+            trace(2,"duplicated obs data %s sat=%d\n",time2str(time,tstr,3),sat);
             i++;
             continue;
         }
@@ -487,7 +490,7 @@ static int raim_fde(const obsd_t *obs, int n, const double *rs,
     double *rs_e,*dts_e,*vare_e,*azel_e,*resp_e,rms_e,rms=100.0;
     int i,j,k,nvsat,stat=0,*svh_e,*vsat_e,sat=0;
     
-    trace(3,"raim_fde: %s n=%2d\n",time_str(obs[0].time,0),n);
+    trace(3,"raim_fde: %s n=%2d\n",time2str(obs[0].time,tstr,0),n);
     
     if (!(obs_e=(obsd_t *)malloc(sizeof(obsd_t)*n))) return 0;
     rs_e = mat(6,n); dts_e = mat(2,n); vare_e=mat(1,n); azel_e=zeros(2,n);
@@ -541,10 +544,12 @@ static int raim_fde(const obsd_t *obs, int n, const double *rs,
         vsat[i]=0;
         strcpy(msg,msg_e);
     }
+#ifdef TRACE
     if (stat) {
         time2str(obs[0].time,tstr,2); satno2id(sat,name);
         trace(2,"%s: %s excluded by raim\n",tstr+11,name);
     }
+#endif
     free(obs_e);
     free(rs_e ); free(dts_e ); free(vare_e); free(azel_e);
     free(svh_e); free(vsat_e); free(resp_e);
@@ -656,7 +661,8 @@ extern int pntpos(const obsd_t *obs, int n, const nav_t *nav,
     double *rs,*dts,*var,*azel_,*resp;
     int i,stat,vsat[MAXOBS]={0},svh[MAXOBS];
     
-    trace(3,"pntpos  : tobs=%s n=%d\n",time_str(obs[0].time,3),n);
+    char tstr[40];
+    trace(3,"pntpos  : tobs=%s n=%d\n",time2str(obs[0].time,tstr,3),n);
     
     sol->stat=SOLQ_NONE;
     

--- a/src/pntpos.c
+++ b/src/pntpos.c
@@ -483,7 +483,7 @@ static int raim_fde(const obsd_t *obs, int n, const double *rs,
 {
     obsd_t *obs_e;
     sol_t sol_e={{0}};
-    char tstr[32],name[8],msg_e[128];
+    char tstr[40],name[8],msg_e[128];
     double *rs_e,*dts_e,*vare_e,*azel_e,*resp_e,rms_e,rms=100.0;
     int i,j,k,nvsat,stat=0,*svh_e,*vsat_e,sat=0;
     

--- a/src/postpos.c
+++ b/src/postpos.c
@@ -260,7 +260,8 @@ static int inputobs(obsd_t *obs, int solq, const prcopt_t *popt)
 
     if (0<=iobsu&&iobsu<obss.n) {
         settime((time=obss.data[iobsu].time));
-        if (checkbrk("processing : %s Q=%d",time_str(time,0),solq)) {
+        char tstr[40];
+        if (checkbrk("processing : %s Q=%d",time2str(time,tstr,0),solq)) {
             aborts=1; showmsg("aborted"); return -1;
         }
     }
@@ -720,7 +721,8 @@ static int readobsnav(gtime_t ts, gtime_t te, double ti, const char **infile,
 {
     int i,j,ind=0,nobs=0,rcv=1;
 
-    trace(3,"readobsnav: ts=%s n=%d\n",time_str(ts,0),n);
+    char tstr[40];
+    trace(3,"readobsnav: ts=%s n=%d\n",time2str(ts,tstr,0),n);
 
     obs->data=NULL; obs->n =obs->nmax =0;
     nav->eph =NULL; nav->n =nav->nmax =0;
@@ -1425,7 +1427,8 @@ extern int postpos(gtime_t ts, gtime_t te, double ti, double tu,
 
             strcpy(proc_rov ,"");
             strcpy(proc_base,"");
-            if (checkbrk("reading    : %s",time_str(tts,0))) {
+            char tstr[40];
+            if (checkbrk("reading    : %s",time2str(tts,tstr,0))) {
                 stat=1;
                 break;
             }

--- a/src/postpos.c
+++ b/src/postpos.c
@@ -948,7 +948,7 @@ static void setpcv(gtime_t time, prcopt_t *popt, nav_t *nav, const pcvs_t *pcvs,
     pcv_t *pcv,pcv0={0};
     double pos[3],del[3];
     int i,j,mode=PMODE_DGPS<=popt->mode&&popt->mode<=PMODE_FIXED;
-    char id[64];
+    char id[8];
 
     /* set satellite antenna parameters */
     for (i=0;i<MAXSAT;i++) {

--- a/src/postpos.c
+++ b/src/postpos.c
@@ -258,6 +258,7 @@ static int inputobs(obsd_t *obs, int solq, const prcopt_t *popt)
 
     if (0<=iobsu&&iobsu<obss.n) {
         gtime_t time = obss.data[iobsu].time;
+        settime(time);
         char tstr[40];
         if (checkbrk("processing : %s Q=%d",time2str(time,tstr,0),solq)) {
             aborts=1;

--- a/src/postpos.c
+++ b/src/postpos.c
@@ -139,7 +139,7 @@ static void outheader(FILE *fp, const char **file, int n, const prcopt_t *popt,
     gtime_t ts,te;
     double t1,t2;
     int i,j,w1,w2;
-    char s2[32],s3[32];
+    char s2[40],s3[40];
 
     trace(3,"outheader: n=%d\n",n);
 
@@ -503,7 +503,7 @@ static int valcomb(const sol_t *solf, const sol_t *solb, double *rbf,
 {
     double dr[3],var[3];
     int i;
-    char tstr[32];
+    char tstr[40];
 
     trace(4,"valcomb :\n");
 

--- a/src/ppp.c
+++ b/src/ppp.c
@@ -129,7 +129,7 @@ extern int pppoutstat(rtk_t *rtk, char *buff)
     ssat_t *ssat;
     double tow,pos[3],vel[3],acc[3],*x;
     int i,j,week;
-    char id[32],*p=buff;
+    char id[8],*p=buff;
 
     if (!rtk->sol.stat) return 0;
 

--- a/src/ppp.c
+++ b/src/ppp.c
@@ -226,7 +226,8 @@ static void testeclipse(const obsd_t *obs, int n, const nav_t *nav, double *rs)
         /* test eclipse */
         if (ang<PI/2.0||r*sin(ang)>RE_WGS84) continue;
 
-        trace(3,"eclipsing sat excluded %s sat=%2d\n",time_str(obs[0].time,0),
+        char tstr[40];
+        trace(3,"eclipsing sat excluded %s sat=%2d\n",time2str(obs[0].time,tstr,0),
               obs[i].sat);
 
         for (j=0;j<3;j++) rs[j+i*6]=0.0;
@@ -781,8 +782,9 @@ static void udbias_ppp(rtk_t *rtk, const obsd_t *obs, int n, const nav_t *nav)
                 j=IB(i+1,f,&rtk->opt);
                 if (rtk->x[j]!=0.0) rtk->x[j]+=offset/k;
             }
+            char tstr[40];
             trace(2,"phase-code jump corrected: %s n=%2d dt=%12.9fs\n",
-                  time_str(rtk->sol.time,0),k,offset/k/CLIGHT);
+                  time2str(rtk->sol.time,tstr,0),k,offset/k/CLIGHT);
         }
         for (i=0;i<n&&i<MAXOBS;i++) {
             sat=obs[i].sat;

--- a/src/ppp.c
+++ b/src/ppp.c
@@ -938,7 +938,7 @@ static int ppp_res(int post, const obsd_t *obs, int n, const double *rs,
     double var[MAXOBS*2*NFREQ],dtrp=0.0,dion=0.0,vart=0.0,vari=0.0,dcb,freq;
     double dantr[NFREQ]={0},dants[NFREQ]={0};
     double ve[MAXOBS*2*NFREQ]={0},vmax=0;
-    char str[32];
+    char str[40];
     int ne=0,obsi[MAXOBS*2*NFREQ]={0},frqi[MAXOBS*2*NFREQ],maxobs,maxfrq,rej;
     int i,j,k,sat,sys,nv=0,nx=rtk->nx,stat=1,frq,code;
 
@@ -1181,7 +1181,7 @@ extern void pppos(rtk_t *rtk, const obsd_t *obs, int n, const nav_t *nav)
 {
     const prcopt_t *opt=&rtk->opt;
     double *rs,*dts,*var,*v,*H,*R,*azel,*xp,*Pp,dr[3]={0},std[3];
-    char str[32];
+    char str[40];
     int i,j,nv,info,svh[MAXOBS],exc[MAXOBS]={0},stat=SOLQ_SINGLE;
 
     time2str(obs[0].time,str,2);

--- a/src/preceph.c
+++ b/src/preceph.c
@@ -359,7 +359,8 @@ extern int readsap(const char *file, gtime_t time, nav_t *nav)
     pcv_t pcv0={0},*pcv;
     int i;
 
-    trace(3,"readsap : file=%s time=%s\n",file,time_str(time,0));
+    char tstr[40];
+    trace(3,"readsap : file=%s time=%s\n",file,time2str(time,tstr,0));
 
     if (!readpcv(file,&pcvs)) return 0;
 
@@ -559,14 +560,15 @@ static int pephpos(gtime_t time, int sat, const nav_t *nav, double *rs,
     double t[NMAX+1],p[3][NMAX+1],c[2],*pos,std=0.0,s[3],sinl,cosl;
     int i,j,k,index;
 
-    trace(4,"pephpos : time=%s sat=%2d\n",time_str(time,3),sat);
+    char tstr[40];
+    trace(4,"pephpos : time=%s sat=%2d\n",time2str(time,tstr,3),sat);
 
     rs[0]=rs[1]=rs[2]=dts[0]=0.0;
 
     if (nav->ne<NMAX+1||
         timediff(time,nav->peph[0].time)<-MAXDTE||
         timediff(time,nav->peph[nav->ne-1].time)>MAXDTE) {
-        trace(3,"no prec ephem %s sat=%2d\n",time_str(time,0),sat);
+        trace(3,"no prec ephem %s sat=%2d\n",time2str(time,tstr,0),sat);
         return 0;
     }
     /* binary search */
@@ -583,7 +585,7 @@ static int pephpos(gtime_t time, int sat, const nav_t *nav, double *rs,
     for (j=0;j<=NMAX;j++) {
         t[j]=timediff(nav->peph[i+j].time,time);
         if (norm(nav->peph[i+j].pos[sat-1],3)<=0.0) {
-            trace(3,"prec ephem outage %s sat=%2d\n",time_str(time,0),sat);
+            trace(3,"prec ephem outage %s sat=%2d\n",time2str(time,tstr,0),sat);
             return 0;
         }
     }
@@ -642,12 +644,13 @@ static int pephclk(gtime_t time, int sat, const nav_t *nav, double *dts,
     double t[2],c[2],std;
     int i,j,k,index;
 
-    trace(4,"pephclk : time=%s sat=%2d\n",time_str(time,3),sat);
+    char tstr[40];
+    trace(4,"pephclk : time=%s sat=%2d\n",time2str(time,tstr,3),sat);
 
     if (nav->nc<2||
         timediff(time,nav->pclk[0].time)<-MAXDTE||
         timediff(time,nav->pclk[nav->nc-1].time)>MAXDTE) {
-        trace(3,"no prec clock %s sat=%2d\n",time_str(time,0),sat);
+        trace(3,"no prec clock %s sat=%2d\n",time2str(time,tstr,0),sat);
         return 1;
     }
     /* binary search */
@@ -677,7 +680,7 @@ static int pephclk(gtime_t time, int sat, const nav_t *nav, double *dts,
         std=nav->pclk[index+i].std[sat-1][0]*CLIGHT+EXTERR_CLK*fabs(t[i]);
     }
     else {
-        trace(3,"prec clock outage %s sat=%2d\n",time_str(time,0),sat);
+        trace(3,"prec clock outage %s sat=%2d\n",time2str(time,tstr,0),sat);
         return 0;
     }
     if (varc) *varc=SQR(std);
@@ -708,7 +711,8 @@ extern void satantoff(gtime_t time, const double *rs, int sat, const nav_t *nav,
     double C1,C2,dant1,dant2;
     int i,sys;
 
-    trace(4,"satantoff: time=%s sat=%2d\n",time_str(time,3),sat);
+    char tstr[40];
+    trace(4,"satantoff: time=%s sat=%2d\n",time2str(time,tstr,3),sat);
 
     dant[0]=dant[1]=dant[2]=0.0;
 
@@ -783,7 +787,8 @@ extern int peph2pos(gtime_t time, int sat, const nav_t *nav, int opt,
     double rss[3],rst[3],dtss[1],dtst[1],dant[3]={0},vare=0.0,varc=0.0,tt=1E-3;
     int i;
 
-    trace(4,"peph2pos: time=%s sat=%2d opt=%d\n",time_str(time,3),sat,opt);
+    char tstr[40];
+    trace(4,"peph2pos: time=%s sat=%2d opt=%d\n",time2str(time,tstr,3),sat,opt);
 
     if (sat<=0||MAXSAT<sat) return 0;
 

--- a/src/rcv/binex.c
+++ b/src/rcv/binex.c
@@ -168,7 +168,8 @@ static int decode_bnx_00(raw_t *raw, uint8_t *buff, int len)
     
     msg=raw->msgtype+strlen(raw->msgtype);
     if (raw->outtype) {
-        msg+=sprintf(msg," time=%s src=%u",time_str(raw->time,0),src);
+        char tstr[40];
+        msg+=sprintf(msg," time=%s src=%u",time2str(raw->time,tstr,0),src);
     }
     while (p-buff<len) {
         p+=getbnxi(p,&fid);
@@ -1092,7 +1093,8 @@ static int decode_bnx_7f(raw_t *raw, uint8_t *buff, int len)
     
     if (raw->outtype) {
         msg=raw->msgtype+strlen(raw->msgtype);
-        sprintf(msg," subrec=%02X time%s",srec,time_str(raw->time,3));
+        char tstr[40];
+        sprintf(msg," subrec=%02X time%s",srec,time2str(raw->time,tstr,3));
     }
     switch (srec) {
         case 0x00: return decode_bnx_7f_00(raw,buff+7,len-7);

--- a/src/rcv/comnav.c
+++ b/src/rcv/comnav.c
@@ -867,8 +867,9 @@ static int decode_galfnavrawpageb(raw_t *raw)
         buff[i]=U1(p); p+=1;
     }
     page=getbitu(buff,0,6);
-    
-    trace(3,"%s E%2d FNAV     (%2d) ",time_str(raw->time,0),satid,page);
+
+    char tstr[40];
+    trace(3,"%s E%2d FNAV     (%2d) ",time2str(raw->time,tstr,0),satid,page);
     traceb(3,buff,27);
     
     return 0;
@@ -907,7 +908,8 @@ static int decode_galinavrawwordb(raw_t *raw)
         tow =getbitu(buff,108,20);
         time=gst2time(week,tow);
     }
-    trace(3,"%s E%2d INAV-%s (%2d) ",time_str(time,0),satid,sig,type);
+    char tstr[40];
+    trace(3,"%s E%2d INAV-%s (%2d) ",time2str(time,tstr,0),satid,sig,type);
     traceb(3,buff,16);
     
     return 0;
@@ -932,7 +934,8 @@ static int decode_rawcnavframeb(raw_t *raw)
     for (i=0;i<38;i++) {
         buff[i]=U1(p); p+=1;
     }
-    trace(3,"%s PRN=%3d FRMID=%2d ",time_str(raw->time,0),prn,frmid);
+    char tstr[40];
+    trace(3,"%s PRN=%3d FRMID=%2d ",time2str(raw->time,tstr,0),prn,frmid);
     traceb(3,buff,38);
     
     return 0;
@@ -1027,8 +1030,9 @@ static int decode_cnav(raw_t *raw)
     raw->time=gpst2time(week,tow);
     
     if (raw->outtype) {
+        char tstr[40];
         sprintf(raw->msgtype,"CNAV %4d (%4d): msg=%d %s",type,raw->len,msg,
-                time_str(gpst2time(week,tow),2));
+                time2str(gpst2time(week,tow),tstr,2));
     }
     if (msg!=0) return 0; /* message type: 0=binary,1=ascii */
     

--- a/src/rcv/crescent.c
+++ b/src/rcv/crescent.c
@@ -71,7 +71,7 @@ static int decode_crespos(raw_t *raw)
 {
     int ns,week,mode;
     double tow,pos[3],vel[3],std;
-    char tstr[64];
+    char tstr[40];
     uint8_t *p=raw->buff+8;
     
     trace(4,"decode_crespos: len=%d\n",raw->len);

--- a/src/rcv/javad.c
+++ b/src/rcv/javad.c
@@ -201,7 +201,7 @@ static gtime_t adjday(gtime_t time, double tod)
 /* set time tag --------------------------------------------------------------*/
 static int settag(obsd_t *data, gtime_t time)
 {
-    char s1[64],s2[64];
+    char s1[40],s2[40];
     
     if (data->time.time!=0&&fabs(timediff(data->time,time))>5E-4) {
         time2str(data->time,s1,4); time2str(time,s2,4);

--- a/src/rcv/javad.c
+++ b/src/rcv/javad.c
@@ -266,11 +266,12 @@ static int decode_RT(raw_t *raw)
     if (raw->tbase>=1) time=utc2gpst(time); /* UTC->GPST */
     raw->time=time;
     
-    trace(3,"decode_RT: time=%s\n",time_str(time,3));
+    char tstr[40];
+    trace(3,"decode_RT: time=%s\n",time2str(time,tstr,3));
     
     if (raw->outtype) {
         msg=raw->msgtype+strlen(raw->msgtype);
-        sprintf(msg," %s",time_str(time,3));
+        sprintf(msg," %s",time2str(time,tstr,3));
     }
     /* flush observation data buffer */
     return flushobuf(raw);
@@ -328,7 +329,8 @@ static int decode_RD(raw_t *raw)
     raw->time=timeadd(epoch2time(ep),raw->tod*0.001);
     if (raw->tbase>=1) raw->time=utc2gpst(raw->time); /* UTC->GPST */
     
-    trace(3,"decode_RD: time=%s\n",time_str(raw->time,3));
+    char tstr[40];
+    trace(3,"decode_RD: time=%s\n",time2str(raw->time,tstr,3));
     
     return 0;
 }
@@ -1660,12 +1662,13 @@ static int decode_TC(raw_t *raw)
         sat=raw->obuf.data[i].sat;
         tt_p=(uint16_t)raw->lockt[sat-1][0];
         
-        trace(4,"%s: sat=%2d tt=%6d->%6d\n",time_str(raw->time,3),sat,tt_p,tt);
+        char tstr[40];
+        trace(4,"%s: sat=%2d tt=%6d->%6d\n",time2str(raw->time,tstr,3),sat,tt_p,tt);
         
         /* loss-of-lock detected by lock-time counter */
         if (tt==0||tt<tt_p) {
             trace(3,"decode_TC: loss-of-lock detected: t=%s sat=%2d tt=%6d->%6d\n",
-                  time_str(raw->time,3),sat,tt_p,tt);
+                  time2str(raw->time,tstr,3),sat,tt_p,tt);
             raw->obuf.data[i].LLI[0]|=1;
         }
         raw->lockt[sat-1][0]=tt;

--- a/src/rcv/novatel.c
+++ b/src/rcv/novatel.c
@@ -1267,7 +1267,7 @@ static int decode_utcb(raw_t *raw)
 static int decode_oem4(raw_t *raw)
 {
     double tow;
-    char tstr[32];
+    char tstr[40];
     int msg,stat,week,type=U2(raw->buff+4);
     
     trace(3,"decode_oem4: type=%3d len=%d\n",type,raw->len);

--- a/src/rcv/nvs.c
+++ b/src/rcv/nvs.c
@@ -73,7 +73,7 @@ static int decode_xf5raw(raw_t *raw)
     uint8_t rcvTimeScaleCorr, sys, carrNo;
     int i,j,prn,sat,n=0,nsat,week;
     uint8_t *p=raw->buff+2;
-    char *q,tstr[32],flag;
+    char *q,tstr[40],flag;
     
     trace(4,"decode_xf5raw: len=%d\n",raw->len);
     

--- a/src/rcv/tersus.c
+++ b/src/rcv/tersus.c
@@ -353,8 +353,9 @@ static int decode_rangecmpb(raw_t *raw)
             raw->obs.data[index].code[pos]=code;
         }
 #if 0 /* for debug */
+        char tstr[40];
         trace(3,"sys=%d prn=%3d cp=%12.5f lli=%2d plock=%2d clock=%2d lockt=%4.2f halfc=%2d parity=%2d ts=%s\n",
-              sys,prn,adr,lli,plock,clock,lockt,halfc,parity,time_str(raw->tobs,3));
+              sys,prn,adr,lli,plock,clock,lockt,halfc,parity,time2str(raw->tobs,tstr,3));
 #endif
 
     }
@@ -614,8 +615,9 @@ static int decode_tersus(raw_t *raw)
     raw->time=gpst2time(week,tow);
     
     if (raw->outtype) {
+        char tstr[40];
         sprintf(raw->msgtype,"TERSUS%4d (%4d): msg=%d %s",type,raw->len,msg,
-                time_str(gpst2time(week,tow),2));
+                time2str(gpst2time(week,tow),tstr,2));
     }
     switch (type) {
         case ID_RANGE         : return decode_rangeb       (raw);

--- a/src/rcv/ublox.c
+++ b/src/rcv/ublox.c
@@ -356,7 +356,7 @@ static int decode_rxmrawx(raw_t *raw)
 {
     uint8_t *p=raw->buff+6;
     gtime_t time;
-    char *q,tstr[64];
+    char *q,tstr[40];
     double tow,P,L,D,tn,tadj=0.0,toff=0.0;
     int i,j,k,idx,sys,prn,sat,code,slip,halfv,halfc,LLI,n=0;
     int week,nmeas,ver,gnss,svid,sigid,frqid,lockt,cn0,cpstd=0,prstd=0,tstat;

--- a/src/rcv/ublox.c
+++ b/src/rcv/ublox.c
@@ -740,7 +740,8 @@ static int decode_trkd5(raw_t *raw)
     else if (tr>t+302400.0) week--;
     time=gpst2time(week,tr);
     
-    trace(4,"time=%s\n",time_str(time,0));
+    char tstr[40];
+    trace(4,"time=%s\n",time2str(time,tstr,0));
     
     for (i=0,p=raw->buff+off;p-raw->buff<raw->len-2;i++,p+=len) {
         

--- a/src/rcv/unicore.c
+++ b/src/rcv/unicore.c
@@ -834,7 +834,7 @@ static int decode_obsvmb(raw_t* raw)
 static int decode_unicore(raw_t* raw)
 {
     double tow;
-    char tstr[32];
+    char tstr[40];
     int stat, week, type = U2(raw->buff + 4);
 
     trace(3, "decode_unicore: type=%3d len=%d\n", type, raw->len);

--- a/src/rinex.c
+++ b/src/rinex.c
@@ -770,7 +770,8 @@ static int decode_obsepoch(FILE *fp, char *buff, double ver, gtime_t *time,
             return 0;
         }
     }
-    trace(4,"decode_obsepoch: time=%s flag=%d\n",time_str(*time,3),*flag);
+    char tstr[40];
+    trace(4,"decode_obsepoch: time=%s flag=%d\n",time2str(*time,tstr,3),*flag);
     return n;
 }
 /* decode observation data ---------------------------------------------------*/
@@ -909,7 +910,8 @@ static int decode_obsdata(FILE *fp, char *buff, double ver, int mask,
         trace(4, "obs: i=%d f=%d P=%14.3f L=%14.3f LLI=%d code=%d\n",i,p[i],obs->P[p[i]],
         obs->L[p[i]],obs->LLI[p[i]],obs->code[p[i]]);
     }
-    trace(4,"decode_obsdata: time=%s sat=%2d\n",time_str(obs->time,0),obs->sat);
+    char tstr[40];
+    trace(4,"decode_obsdata: time=%s sat=%2d\n",time2str(obs->time,tstr,0),obs->sat);
     return 1;
 }
 /* save cycle slips ----------------------------------------------------------*/

--- a/src/rinex.c
+++ b/src/rinex.c
@@ -183,15 +183,15 @@ static gtime_t adjday(gtime_t t, gtime_t t0)
     return t;
 }
 /* time string for ver.3 (yyyymmdd hhmmss UTC) -------------------------------*/
-static void timestr_rnx(char *str)
+static void timestr_rnx(char str[32])
 {
     gtime_t time;
     double ep[6];
     time=timeget();
     time.sec=0.0;
     time2epoch(time,ep);
-    sprintf(str,"%04.0f%02.0f%02.0f %02.0f%02.0f%02.0f UTC",ep[0],ep[1],ep[2],
-            ep[3],ep[4],ep[5]);
+    snprintf(str,32,"%04.0f%02.0f%02.0f %02.0f%02.0f%02.0f UTC",ep[0],ep[1],ep[2],
+             ep[3],ep[4],ep[5]);
 }
 /* satellite to satellite code -----------------------------------------------*/
 static int sat2code(int sat, char *code)
@@ -2606,7 +2606,7 @@ static void out_leaps(FILE *fp, int sys, const rnxopt_t *opt, const nav_t *nav)
 extern int outrnxnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 {
     int i;
-    char date[64],*sys;
+    char date[32],*sys;
 
     trace(3,"outrnxnavh:\n");
 
@@ -2773,7 +2773,7 @@ extern int outrnxnavb(FILE *fp, const rnxopt_t *opt, const eph_t *eph)
 extern int outrnxgnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 {
     int i;
-    char date[64];
+    char date[32];
 
     trace(3,"outrnxgnavh:\n");
 
@@ -2871,7 +2871,7 @@ extern int outrnxgnavb(FILE *fp, const rnxopt_t *opt, const geph_t *geph)
 extern int outrnxhnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 {
     int i;
-    char date[64];
+    char date[32];
 
     trace(3,"outrnxhnavh:\n");
 
@@ -2961,7 +2961,7 @@ extern int outrnxhnavb(FILE *fp, const rnxopt_t *opt, const seph_t *seph)
 extern int outrnxlnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 {
     int i;
-    char date[64];
+    char date[32];
 
     trace(3,"outrnxlnavh:\n");
 
@@ -2995,7 +2995,7 @@ extern int outrnxlnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 extern int outrnxqnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 {
     int i;
-    char date[64];
+    char date[32];
 
     trace(3,"outrnxqnavh:\n");
 
@@ -3029,7 +3029,7 @@ extern int outrnxqnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 extern int outrnxcnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 {
     int i;
-    char date[64];
+    char date[32];
 
     trace(3,"outrnxcnavh:\n");
 
@@ -3063,7 +3063,7 @@ extern int outrnxcnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 extern int outrnxinavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 {
     int i;
-    char date[64];
+    char date[32];
 
     trace(3,"outrnxinavh:\n");
 

--- a/src/rinex.c
+++ b/src/rinex.c
@@ -787,7 +787,7 @@ static int decode_obsdata(FILE *fp, char *buff, double ver, int mask,
     trace(4,"decode_obsdata: ver=%.2f\n",ver);
 
     if (ver>2.99) { /* ver.3 */
-        sprintf(satid,"%.3s",buff);
+        snprintf(satid,8,"%.3s",buff);
         obs->sat=(uint8_t)satid2no(satid);
     }
     if (!obs->sat) {
@@ -1393,7 +1393,7 @@ static int readrnxnavb(FILE *fp, const char *opt, double ver, int sys,
 
             /* decode satellite field */
             if (ver>=3.0||sys==SYS_GAL||sys==SYS_QZS) { /* ver.3 or GAL/QZS */
-                sprintf(id,"%.3s",buff);
+                snprintf(id,8,"%.3s",buff);
                 sat=satid2no(id);
                 sp=4;
                 if (ver>=3.0) {

--- a/src/rtcm3.c
+++ b/src/rtcm3.c
@@ -268,7 +268,7 @@ static int test_staid(rtcm_t *rtcm, int staid)
 static int decode_head1001(rtcm_t *rtcm, int *sync)
 {
     double tow;
-    char *msg,tstr[64];
+    char *msg,tstr[40];
     int i=24,staid,nsat,type;
     
     type=getbitu(rtcm->buff,i,12); i+=12;
@@ -576,7 +576,7 @@ static int decode_type1008(rtcm_t *rtcm)
 static int decode_head1009(rtcm_t *rtcm, int *sync)
 {
     double tod;
-    char *msg,tstr[64];
+    char *msg,tstr[40];
     int i=24,staid,nsat,type;
     
     type=getbitu(rtcm->buff,i,12); i+=12;
@@ -1460,7 +1460,7 @@ static int decode_ssr_epoch(rtcm_t *rtcm, int sys, int subtype)
 static int decode_ssr1_head(rtcm_t *rtcm, int sys, int subtype, int *sync,
                             int *iod, double *udint, int *refd, int *hsize)
 {
-    char *msg,tstr[64];
+    char *msg,tstr[40];
     int i=24+12,nsat,udi,provid=0,solid=0,ns;
     
     if (subtype==0) { /* RTCM SSR */
@@ -1502,7 +1502,7 @@ static int decode_ssr1_head(rtcm_t *rtcm, int sys, int subtype, int *sync,
 static int decode_ssr2_head(rtcm_t *rtcm, int sys, int subtype, int *sync,
                             int *iod, double *udint, int *hsize)
 {
-    char *msg,tstr[64];
+    char *msg,tstr[40];
     int i=24+12,nsat,udi,provid=0,solid=0,ns;
     
     if (subtype==0) { /* RTCM SSR */
@@ -1844,7 +1844,7 @@ static int decode_ssr7_head(rtcm_t *rtcm, int sys, int subtype, int *sync,
                             int *iod, double *udint, int *dispe, int *mw,
                             int *hsize)
 {
-    char *msg,tstr[64];
+    char *msg,tstr[40];
     int i=24+12,nsat,udi,provid=0,solid=0,ns;
     
     if (subtype==0) { /* RTCM SSR */
@@ -2104,7 +2104,7 @@ static int decode_msm_head(rtcm_t *rtcm, int sys, int *sync, int *iod,
 {
     msm_h_t h0={0};
     double tow,tod;
-    char *msg,tstr[64];
+    char *msg,tstr[40];
     int i=24,j,dow,mask,staid,type,ncell=0;
     
     type=getbitu(rtcm->buff,i,12); i+=12;

--- a/src/rtcm3e.c
+++ b/src/rtcm3e.c
@@ -2127,8 +2127,9 @@ static int encode_msm_int_rrng(rtcm_t *rtcm, int i, const double *rrng,
             int_ms=255;
         }
         else if (rrng[j]<0.0||rrng[j]>RANGE_MS*255.0) {
+            char tstr[40];
             trace(2,"msm rough range overflow %s rrng=%.3f\n",
-                 time_str(rtcm->time,0),rrng[j]);
+                  time2str(rtcm->time,tstr,0),rrng[j]);
             int_ms=255;
         }
         else {
@@ -2173,8 +2174,9 @@ static int encode_msm_rrate(rtcm_t *rtcm, int i, const double *rrate, int nsat)
     
     for (j=0;j<nsat;j++) {
         if (fabs(rrate[j])>8191.0) {
+            char tstr[40];
             trace(2,"msm rough phase-range-rate overflow %s rrate=%.4f\n",
-                 time_str(rtcm->time,0),rrate[j]);
+                 time2str(rtcm->time,tstr,0),rrate[j]);
             rrate_val=-8192;
         }
         else {
@@ -2194,8 +2196,9 @@ static int encode_msm_psrng(rtcm_t *rtcm, int i, const double *psrng, int ncell)
             psrng_val=-16384;
         }
         else if (fabs(psrng[j])>292.7) {
+            char tstr[40];
             trace(2,"msm fine pseudorange overflow %s psrng=%.3f\n",
-                 time_str(rtcm->time,0),psrng[j]);
+                 time2str(rtcm->time,tstr,0),psrng[j]);
             psrng_val=-16384;
         }
         else {
@@ -2216,8 +2219,9 @@ static int encode_msm_psrng_ex(rtcm_t *rtcm, int i, const double *psrng,
             psrng_val=-524288;
         }
         else if (fabs(psrng[j])>292.7) {
+            char tstr[40];
             trace(2,"msm fine pseudorange ext overflow %s psrng=%.3f\n",
-                 time_str(rtcm->time,0),psrng[j]);
+                 time2str(rtcm->time,tstr,0),psrng[j]);
             psrng_val=-524288;
         }
         else {
@@ -2237,8 +2241,9 @@ static int encode_msm_phrng(rtcm_t *rtcm, int i, const double *phrng, int ncell)
             phrng_val=-2097152;
         }
         else if (fabs(phrng[j])>1171.0) {
+            char tstr[40];
             trace(2,"msm fine phase-range overflow %s phrng=%.3f\n",
-                 time_str(rtcm->time,0),phrng[j]);
+                 time2str(rtcm->time,tstr,0),phrng[j]);
             phrng_val=-2097152;
         }
         else {
@@ -2259,8 +2264,9 @@ static int encode_msm_phrng_ex(rtcm_t *rtcm, int i, const double *phrng,
             phrng_val=-8388608;
         }
         else if (fabs(phrng[j])>1171.0) {
+            char tstr[40];
             trace(2,"msm fine phase-range ext overflow %s phrng=%.3f\n",
-                 time_str(rtcm->time,0),phrng[j]);
+                 time2str(rtcm->time,tstr,0),phrng[j]);
             phrng_val=-8388608;
         }
         else {
@@ -2336,8 +2342,9 @@ static int encode_msm_rate(rtcm_t *rtcm, int i, const double *rate, int ncell)
             rate_val=-16384;
         }
         else if (fabs(rate[j])>1.6384) {
+            char tstr[40];
             trace(2,"msm fine phase-range-rate overflow %s rate=%.3f\n",
-                 time_str(rtcm->time,0),rate[j]);
+                 time2str(rtcm->time,tstr,0),rate[j]);
             rate_val=-16384;
         }
         else {

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -1987,19 +1987,6 @@ extern char *time2str(gtime_t t, char s[40], int n)
              ep[3],ep[4],n<=0?2:n+3,n<=0?0:n,ep[5]);
     return s;
 }
-/* get time string -------------------------------------------------------------
-* get time string
-* args   : gtime_t t        I   gtime_t struct
-*          int    n         I   number of decimals
-* return : time string
-* notes  : not reentrant, do not use multiple in a function
-*-----------------------------------------------------------------------------*/
-extern char *time_str(gtime_t t, int n)
-{
-    static char buff[64];
-    time2str(t,buff,n);
-    return buff;
-}
 /* time to day of year ---------------------------------------------------------
 * convert time to day of year
 * args   : gtime_t t        I   gtime_t struct
@@ -2396,7 +2383,8 @@ extern void eci2ecef(gtime_t tutc, const double *erpv, double *U, double *gmst)
     double R1[9],R2[9],R3[9],R[9],W[9],N[9],P[9],NP[9];
     int i;
 
-    trace(4,"eci2ecef: tutc=%s\n",time_str(tutc,3));
+    char tstr[40];
+    trace(4,"eci2ecef: tutc=%s\n",time2str(tutc,tstr,3));
 
     if (fabs(timediff(tutc,tutc_))<0.01) { /* read cache */
         for (i=0;i<9;i++) U[i]=U_[i];
@@ -3869,7 +3857,8 @@ static void sunmoonpos_eci(gtime_t tut, double *rsun, double *rmoon)
     const double ep2000[]={2000,1,1,12,0,0};
     double t,f[5],eps,Ms,ls,rs,lm,pm,rm,sine,cose,sinp,cosp,sinl,cosl;
 
-    trace(4,"sunmoonpos_eci: tut=%s\n",time_str(tut,3));
+    char tstr[40];
+    trace(4,"sunmoonpos_eci: tut=%s\n",time2str(tut,tstr,3));
 
     t=timediff(tut,epoch2time(ep2000))/86400.0/36525.0;
 
@@ -3924,7 +3913,8 @@ extern void sunmoonpos(gtime_t tutc, const double *erpv, double *rsun,
     gtime_t tut;
     double rs[3],rm[3],U[9],gmst_;
 
-    trace(4,"sunmoonpos: tutc=%s\n",time_str(tutc,3));
+    char tstr[40];
+    trace(4,"sunmoonpos: tutc=%s\n",time2str(tutc,tstr,3));
 
     tut=timeadd(tutc,erpv[2]); /* utc -> ut1 */
 

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -1972,19 +1972,20 @@ extern double utc2gmst(gtime_t t, double ut1_utc)
 /* time to string --------------------------------------------------------------
 * convert gtime_t struct to string
 * args   : gtime_t t        I   gtime_t struct
-*          char   *s        O   string ("yyyy/mm/dd hh:mm:ss.ssss")
+*          char   [40]      O   string ("yyyy/mm/dd hh:mm:ss.ssss")
 *          int    n         I   number of decimals
-* return : none
+* return : time string
 *-----------------------------------------------------------------------------*/
-extern void time2str(gtime_t t, char *s, int n)
+extern char *time2str(gtime_t t, char s[40], int n)
 {
     double ep[6];
 
     if (n<0) n=0; else if (n>12) n=12;
     if (1.0-t.sec<0.5/pow(10.0,n)) {t.time++; t.sec=0.0;};
     time2epoch(t,ep);
-    sprintf(s,"%04.0f/%02.0f/%02.0f %02.0f:%02.0f:%0*.*f",ep[0],ep[1],ep[2],
-            ep[3],ep[4],n<=0?2:n+3,n<=0?0:n,ep[5]);
+    snprintf(s,40,"%04.0f/%02.0f/%02.0f %02.0f:%02.0f:%0*.*f",ep[0],ep[1],ep[2],
+             ep[3],ep[4],n<=0?2:n+3,n<=0?0:n,ep[5]);
+    return s;
 }
 /* get time string -------------------------------------------------------------
 * get time string

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -505,18 +505,18 @@ extern int satid2no(const char *id)
 *          char   *id       O   satellite id (Gnn,Rnn,Enn,Jnn,Cnn,Inn or nnn)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void satno2id(int sat, char *id)
+extern void satno2id(int sat, char id[8])
 {
     int prn;
     switch (satsys(sat,&prn)) {
-        case SYS_GPS: sprintf(id,"G%02d",prn-MINPRNGPS+1); return;
-        case SYS_GLO: sprintf(id,"R%02d",prn-MINPRNGLO+1); return;
-        case SYS_GAL: sprintf(id,"E%02d",prn-MINPRNGAL+1); return;
-        case SYS_QZS: sprintf(id,"J%02d",prn-MINPRNQZS+1); return;
-        case SYS_CMP: sprintf(id,"C%02d",prn-MINPRNCMP+1); return;
-        case SYS_IRN: sprintf(id,"I%02d",prn-MINPRNIRN+1); return;
-        case SYS_LEO: sprintf(id,"L%02d",prn-MINPRNLEO+1); return;
-        case SYS_SBS: sprintf(id,"%03d" ,prn); return;
+        case SYS_GPS: snprintf(id,8,"G%02d",prn-MINPRNGPS+1); return;
+        case SYS_GLO: snprintf(id,8,"R%02d",prn-MINPRNGLO+1); return;
+        case SYS_GAL: snprintf(id,8,"E%02d",prn-MINPRNGAL+1); return;
+        case SYS_QZS: snprintf(id,8,"J%02d",prn-MINPRNQZS+1); return;
+        case SYS_CMP: snprintf(id,8,"C%02d",prn-MINPRNCMP+1); return;
+        case SYS_IRN: snprintf(id,8,"I%02d",prn-MINPRNIRN+1); return;
+        case SYS_LEO: snprintf(id,8,"L%02d",prn-MINPRNLEO+1); return;
+        case SYS_SBS: snprintf(id,8,"%03d" ,prn); return;
     }
     strcpy(id,"");
 }
@@ -3136,7 +3136,7 @@ extern int savenav(const char *file, const nav_t *nav)
 {
     FILE *fp;
     int i;
-    char id[32];
+    char id[8];
 
     trace(3,"savenav: file=%s\n",file);
 

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1428,7 +1428,6 @@ EXPORT gtime_t gst2time(int week, double sec);
 EXPORT double  time2gst(gtime_t t, int *week);
 EXPORT gtime_t bdt2time(int week, double sec);
 EXPORT double  time2bdt(gtime_t t, int *week);
-EXPORT char    *time_str(gtime_t t, int n);
 
 EXPORT gtime_t timeadd  (gtime_t t, double sec);
 EXPORT double  timediff (gtime_t t1, gtime_t t2);

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1418,7 +1418,7 @@ EXPORT void add_fatal(fatalfunc_t *func);
 /* time and string functions -------------------------------------------------*/
 EXPORT double  str2num(const char *s, int i, int n);
 EXPORT int     str2time(const char *s, int i, int n, gtime_t *t);
-EXPORT void    time2str(gtime_t t, char *str, int n);
+EXPORT char    *time2str(gtime_t t, char str[40], int n);
 EXPORT gtime_t epoch2time(const double *ep);
 EXPORT void    time2epoch(gtime_t t, double *ep);
 EXPORT void    time2epoch_n(gtime_t t, double *ep, int n);

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1371,7 +1371,7 @@ EXPORT extern opt_t sysopts[];              /* system options table */
 EXPORT int  satno   (int sys, int prn);
 EXPORT int  satsys  (int sat, int *prn);
 EXPORT int  satid2no(const char *id);
-EXPORT void satno2id(int sat, char *id);
+EXPORT void satno2id(int sat, char id[8]);
 EXPORT uint8_t obs2code(const char *obs);
 EXPORT char *code2obs(uint8_t code);
 EXPORT double code2freq(int sys, uint8_t code, int fcn);

--- a/src/rtkpos.c
+++ b/src/rtkpos.c
@@ -365,7 +365,7 @@ static void outsolstat(rtk_t *rtk,const nav_t *nav)
 /* save error message --------------------------------------------------------*/
 static void errmsg(rtk_t *rtk, const char *format, ...)
 {
-    char buff[256],tstr[32];
+    char buff[256],tstr[40];
     int n;
     va_list ap;
     time2str(rtk->sol.time,tstr,2);

--- a/src/rtkpos.c
+++ b/src/rtkpos.c
@@ -2303,7 +2303,8 @@ extern int rtkpos(rtk_t *rtk, const obsd_t *obs, int n, const nav_t *nav)
     int i,nu,nr;
     char msg[128]="";
 
-    trace(3,"rtkpos  : time=%s n=%d\n",time_str(obs[0].time,3),n);
+    char tstr[40];
+    trace(3,"rtkpos  : time=%s n=%d\n",time2str(obs[0].time,tstr,3),n);
     trace(4,"obs=\n"); traceobs(4,obs,n);
     /*trace(5,"nav=\n"); tracenav(5,nav);*/
 

--- a/src/rtksvr.c
+++ b/src/rtksvr.c
@@ -1123,7 +1123,7 @@ extern void rtksvrsstat(rtksvr_t *svr, int *sstat, char *msg)
 *-----------------------------------------------------------------------------*/
 extern int rtksvrmark(rtksvr_t *svr, const char *name, const char *comment)
 {
-    char buff[MAXSOLMSG+1],tstr[32],*p,*q;
+    char buff[MAXSOLMSG+1],tstr[40],*p,*q;
     double tow,pos[3];
     int i,sum,week;
     

--- a/src/rtksvr.c
+++ b/src/rtksvr.c
@@ -373,8 +373,9 @@ static int decoderaw(rtksvr_t *svr, int index)
         }
 #if 0 /* record for receiving tick for debug */
         if (ret==1) {
+            char tstr[40];
             trace(0,"%d %10d T=%s NS=%2d\n",index,tickget(),
-                  time_str(obs->data[0].time,0),obs->n);
+                  time2str(obs->data[0].time,tstr,0),obs->n);
         }
 #endif
         /* update rtk server */

--- a/src/sbas.c
+++ b/src/sbas.c
@@ -795,8 +795,9 @@ static int sbslongcorr(gtime_t time, int sat, const sbssat_t *sbssat,
         if (p->sat!=sat||p->lcorr.t0.time==0) continue;
         t=timediff(time,p->lcorr.t0);
         if (fabs(t)>MAXSBSAGEL) {
+            char tstr[40];
             trace(2,"sbas long-term correction expired: %s sat=%2d t=%5.0f\n",
-                  time_str(time,0),sat,t);
+                  time2str(time,tstr,0),sat,t);
             return 0;
         }
         for (i=0;i<3;i++) drs[i]=p->lcorr.dpos[i]+p->lcorr.dvel[i]*t;
@@ -810,7 +811,8 @@ static int sbslongcorr(gtime_t time, int sat, const sbssat_t *sbssat,
     /* if sbas satellite without correction, no correction applied */
     if (satsys(sat,NULL)==SYS_SBS) return 1;
     
-    trace(2,"no sbas long-term correction: %s sat=%2d\n",time_str(time,0),sat);
+    char tstr[40];
+    trace(2,"no sbas long-term correction: %s sat=%2d\n",time2str(time,tstr,0),sat);
     return 0;
 }
 /* fast correction -----------------------------------------------------------*/
@@ -841,7 +843,8 @@ static int sbsfastcorr(gtime_t time, int sat, const sbssat_t *sbssat,
               *prc,sqrt(*var),t);
         return 1;
     }
-    trace(2,"no sbas fast correction: %s sat=%2d\n",time_str(time,0),sat);
+    char tstr[40];
+    trace(2,"no sbas fast correction: %s sat=%2d\n",time2str(time,tstr,0),sat);
     return 0;
 }
 /* sbas satellite ephemeris and clock correction -------------------------------

--- a/src/solution.c
+++ b/src/solution.c
@@ -229,9 +229,10 @@ static int decode_nmearmc(char **val, int n, sol_t *sol)
     sol->ns=0;
     
     sol->type=0; /* position type = xyz */
-    
+
+    char tstr[40];
     trace(5,"decode_nmearmc: %s rr=%.3f %.3f %.3f stat=%d ns=%d vel=%.2f dir=%.0f ang=%.0f mew=%c mode=%c\n",
-          time_str(sol->time,0),sol->rr[0],sol->rr[1],sol->rr[2],sol->stat,sol->ns,
+          time2str(sol->time,tstr,0),sol->rr[0],sol->rr[1],sol->rr[2],sol->stat,sol->ns,
           vel,dir,ang,mew,mode);
     
     return 2; /* update time */
@@ -256,7 +257,8 @@ static int decode_nmeazda(char **val, int n, sol_t *sol)
     sol->time=utc2gpst(epoch2time(ep));
     sol->ns=0;
     
-    trace(5,"decode_nmeazda: %s\n",time_str(sol->time,0));
+    char tstr[40];
+    trace(5,"decode_nmeazda: %s\n",time2str(sol->time,tstr,0));
     
     return 2; /* update time */
 }
@@ -314,8 +316,9 @@ static int decode_nmeagga(char **val, int n, sol_t *sol)
     
     sol->type=0; /* position type = xyz */
     
+    char tstr[40];
     trace(5,"decode_nmeagga: %s rr=%.3f %.3f %.3f stat=%d ns=%d hdop=%.1f ua=%c um=%c\n",
-          time_str(sol->time,0),sol->rr[0],sol->rr[1],sol->rr[2],sol->stat,sol->ns,
+          time2str(sol->time,tstr,0),sol->rr[0],sol->rr[1],sol->rr[2],sol->stat,sol->ns,
           hdop,ua,um);
     
     return 1;

--- a/src/solution.c
+++ b/src/solution.c
@@ -1631,7 +1631,7 @@ extern int outsols(uint8_t *buff, const sol_t *sol, const double *rb,
     double gpst;
     int week,timeu;
     const char *sep=opt2sep(opt);
-    char s[64];
+    char s[40];
     uint8_t *p=buff;
     
     trace(4,"outsols :\n");

--- a/src/solution.c
+++ b/src/solution.c
@@ -1050,7 +1050,7 @@ static int decode_solstat(char *buff, solstat_t *stat)
     static const solstat_t stat0={{0}};
     double tow,az,el,resp,resc,snr;
     int n,week,sat,frq,vsat,fix,slip,lock,outc,slipc,rejc;
-    char id[32]="",*p;
+    char id[8]="",*p;
     
     trace(4,"decode_solstat: buff=%s\n",buff);
     
@@ -1058,7 +1058,7 @@ static int decode_solstat(char *buff, solstat_t *stat)
     
     for (p=buff;*p;p++) if (*p==',') *p=' ';
     
-    n=sscanf(buff,"$SAT%d%lf%31s%d%lf%lf%lf%lf%d%lf%d%d%d%d%d%d",
+    n=sscanf(buff,"$SAT%d%lf%7s%d%lf%lf%lf%lf%d%lf%d%d%d%d%d%d",
              &week,&tow,id,&frq,&az,&el,&resp,&resc,&vsat,&snr,&fix,&slip,
              &lock,&outc,&slipc,&rejc);
     

--- a/src/stream.c
+++ b/src/stream.c
@@ -594,7 +594,8 @@ static int openfile_(file_t *file, gtime_t time, char *msg)
     char *rw,tagpath[MAXSTRPATH+4]="";
     char tagh[TIMETAGH_LEN+1]="";
     
-    tracet(3,"openfile_: path=%s time=%s\n",file->path,time_str(time,0));
+    char tstr[40];
+    tracet(3,"openfile_: path=%s time=%s\n",file->path,time2str(time,tstr,0));
     
     file->time=utc2gpst(timeget());
     file->tick=file->tick_f=tickget();
@@ -750,7 +751,8 @@ static void swapfile(file_t *file, gtime_t time, char *msg)
 {
     char openpath[MAXSTRPATH];
     
-    tracet(3,"swapfile: fp=%d time=%s\n",file->fp,time_str(time,0));
+    char tstr[40];
+    tracet(3,"swapfile: fp=%d time=%s\n",file->fp,time2str(time,tstr,0));
     
     /* return if old swap file open */
     if (file->fp_tmp||file->fp_tag_tmp) return;
@@ -1887,7 +1889,8 @@ static void send_srctbl(ntripc_t *ntripc, socket_t sock)
             NTRIP_RSP_TBLEND);
     p+=sprintf(p,"%s",NTRIP_RSP_SRCTBL);
     p+=sprintf(p,"Server: %s %s %s\r\n","RTKLIB",VER_RTKLIB,PATCH_LEVEL);
-    p+=sprintf(p,"Date: %s UTC\r\n",time_str(timeget(),0));
+    char tstr[40];
+    p+=sprintf(p,"Date: %s UTC\r\n",time2str(timeget(),tstr,0));
     p+=sprintf(p,"Connection: close\r\n");
     p+=sprintf(p,"Content-Type: text/plain\r\n");
     p+=sprintf(p,"Content-Length: %d\r\n\r\n",(int)strlen(srctbl));

--- a/src/stream.c
+++ b/src/stream.c
@@ -786,7 +786,7 @@ static int statefile(file_t *file)
 /* get extended state file ---------------------------------------------------*/
 static int statexfile(file_t *file, char *msg)
 {
-    char *p=msg,tstr1[32],tstr2[32];
+    char *p=msg,tstr1[40],tstr2[40];
     int state=file?2:0;
     
     p+=sprintf(p,"file:\n");

--- a/src/tides.c
+++ b/src/tides.c
@@ -243,7 +243,8 @@ extern void tidedisp(gtime_t tutc, const double *rr, int opt, const erp_t *erp,
     int year,mon,day;
 #endif
     
-    trace(3,"tidedisp: tutc=%s\n",time_str(tutc,0));
+    char tstr[40];
+    trace(3,"tidedisp: tutc=%s\n",time2str(tutc,tstr,0));
     
     if (erp) {
         geterp(erp,utc2gpst(tutc),erpv);

--- a/src/trace.c
+++ b/src/trace.c
@@ -93,7 +93,7 @@ extern void tracemat_impl(int level, const double *A, int n, int m, int p,
 }
 extern void traceobs_impl(int level, const obsd_t *obs, int n)
 {
-    char str[64], id[16];
+    char str[64], id[8];
     int i;
 
     if (!fp_trace || level > level_trace) return;
@@ -112,7 +112,7 @@ extern void traceobs_impl(int level, const obsd_t *obs, int n)
 }
 extern void tracenav_impl(int level, const nav_t *nav)
 {
-    char s1[64], s2[64], id[16];
+    char s1[64], s2[64], id[8];
     int i;
 
     if (!fp_trace || level > level_trace) return;
@@ -132,7 +132,7 @@ extern void tracenav_impl(int level, const nav_t *nav)
 }
 extern void tracegnav_impl(int level, const nav_t *nav)
 {
-    char s1[64], s2[64], id[16];
+    char s1[64], s2[64], id[8];
     int i;
 
     if (!fp_trace || level > level_trace) return;
@@ -147,7 +147,7 @@ extern void tracegnav_impl(int level, const nav_t *nav)
 }
 extern void tracehnav_impl(int level, const nav_t *nav)
 {
-    char s1[64], s2[64], id[16];
+    char s1[64], s2[64], id[8];
     int i;
 
     if (!fp_trace || level > level_trace) return;
@@ -161,7 +161,7 @@ extern void tracehnav_impl(int level, const nav_t *nav)
 }
 extern void tracepeph_impl(int level, const nav_t *nav)
 {
-    char s[64], id[16];
+    char s[64], id[8];
     int i, j;
 
     if (!fp_trace || level > level_trace) return;
@@ -183,7 +183,7 @@ extern void tracepeph_impl(int level, const nav_t *nav)
 }
 extern void tracepclk_impl(int level, const nav_t *nav)
 {
-    char s[64], id[16];
+    char s[64], id[8];
     int i, j;
 
     if (!fp_trace || level > level_trace) return;

--- a/src/trace.c
+++ b/src/trace.c
@@ -93,7 +93,7 @@ extern void tracemat_impl(int level, const double *A, int n, int m, int p,
 }
 extern void traceobs_impl(int level, const obsd_t *obs, int n)
 {
-    char str[64], id[8];
+    char str[40], id[8];
     int i;
 
     if (!fp_trace || level > level_trace) return;
@@ -112,7 +112,7 @@ extern void traceobs_impl(int level, const obsd_t *obs, int n)
 }
 extern void tracenav_impl(int level, const nav_t *nav)
 {
-    char s1[64], s2[64], id[8];
+    char s1[40], s2[40], id[8];
     int i;
 
     if (!fp_trace || level > level_trace) return;
@@ -132,7 +132,7 @@ extern void tracenav_impl(int level, const nav_t *nav)
 }
 extern void tracegnav_impl(int level, const nav_t *nav)
 {
-    char s1[64], s2[64], id[8];
+    char s1[40], s2[40], id[8];
     int i;
 
     if (!fp_trace || level > level_trace) return;
@@ -147,7 +147,7 @@ extern void tracegnav_impl(int level, const nav_t *nav)
 }
 extern void tracehnav_impl(int level, const nav_t *nav)
 {
-    char s1[64], s2[64], id[8];
+    char s1[40], s2[40], id[8];
     int i;
 
     if (!fp_trace || level > level_trace) return;
@@ -161,7 +161,7 @@ extern void tracehnav_impl(int level, const nav_t *nav)
 }
 extern void tracepeph_impl(int level, const nav_t *nav)
 {
-    char s[64], id[8];
+    char s[40], id[8];
     int i, j;
 
     if (!fp_trace || level > level_trace) return;
@@ -183,7 +183,7 @@ extern void tracepeph_impl(int level, const nav_t *nav)
 }
 extern void tracepclk_impl(int level, const nav_t *nav)
 {
-    char s[64], id[8];
+    char s[40], id[8];
     int i, j;
 
     if (!fp_trace || level > level_trace) return;

--- a/test/utest/t_gloeph.c
+++ b/test/utest/t_gloeph.c
@@ -132,7 +132,7 @@ void utest4(void)
 /* readsap() */
 void utest5(void)
 {
-    char *file="../../data/ant/igs14.atx",id[32];
+    char *file="../../data/ant/igs14.atx",id[8];
     double ep[]={2009,4,1,0,0,0};
     gtime_t time=epoch2time(ep);
     nav_t nav={0};

--- a/test/utest/t_gloeph.c
+++ b/test/utest/t_gloeph.c
@@ -7,7 +7,7 @@
 
 static void dumpgeph(geph_t *geph, int n)
 {
-    char s1[64],s2[64];
+    char s1[40],s2[40];
     int i;
     for (i=0;i<n;i++) {
         time2str(geph[i].toe,s1,0);

--- a/test/utest/t_ionex.c
+++ b/test/utest/t_ionex.c
@@ -8,7 +8,7 @@
 static void dumptec(const tec_t *tec, int n, int level)
 {
     const tec_t *p;
-    char s[64];
+    char s[40];
     int i,j,k,m;
     
     for (i=0;i<n;i++) {

--- a/test/utest/t_preceph.c
+++ b/test/utest/t_preceph.c
@@ -7,7 +7,7 @@
 
 static void dumpeph(peph_t *peph, int n)
 {
-    char s[64];
+    char s[40];
     int i,j;
     for (i=0;i<n;i++) {
         time2str(peph[i].time,s,3);
@@ -21,7 +21,7 @@ static void dumpeph(peph_t *peph, int n)
 }
 static void dumpclk(pclk_t *pclk, int n)
 {
-    char s[64];
+    char s[40];
     int i,j;
     for (i=0;i<n;i++) {
         time2str(pclk[i].time,s,3);

--- a/test/utest/t_rinex.c
+++ b/test/utest/t_rinex.c
@@ -9,7 +9,7 @@ static void dumpobs(obs_t *obs)
 {
     gtime_t time={0};
     int i;
-    char str[64];
+    char str[40];
     printf("obs : n=%d\n",obs->n);
     for (i=0;i<obs->n;i++) {
         time2str(obs->data[i].time,str,3);
@@ -28,7 +28,7 @@ static void dumpobs(obs_t *obs)
 static void dumpnav(nav_t *nav)
 {
     int i;
-    char str[64],s1[64],s2[64];
+    char str[40],s1[40],s2[40];
     printf("nav : n=%d\n",nav->n);
     for (i=0;i<nav->n;i++) {
         time2str(nav->eph[i].toe,str,3);

--- a/test/utest/t_time.c
+++ b/test/utest/t_time.c
@@ -234,7 +234,7 @@ void utest9(void)
     double ep0[]={1970,12,31,23,59,59.1234567890123456};
     double ep1[]={2004, 1, 1, 0, 0, 0.0000000000000000};
     double ep2[]={2006, 2,28,23,59,59.9999995000000000};
-    char s[128];
+    char s[40];
     int ret;
     time2str(epoch2time(ep0),s,0);
         ret=strcmp(s,"1970/12/31 23:59:59");
@@ -266,7 +266,7 @@ void utest9(void)
 /* timeget() */
 void utest10(void)
 {
-    char s1[64],s2[64];
+    char s1[40],s2[40];
     gtime_t time1,time2;
     int i,j;
     time1=timeget();

--- a/test/utest/t_tle.c
+++ b/test/utest/t_tle.c
@@ -102,7 +102,7 @@ static void utest3(void)
     erp_t erp={0};
     tle_t tle={0};
     gtime_t time;
-    char sat[32];
+    char sat[8];
     double rs1[6],rs2[6],ds[6],dts[2],var;
     int i,j,k,stat,svh;
 

--- a/test/utest/t_tle.c
+++ b/test/utest/t_tle.c
@@ -18,7 +18,9 @@ static void dumptle(FILE *fp, const tle_t *tle)
         fprintf(fp,"(%2d) satno= %s\n",     i+1,tle->data[i].satno);
         fprintf(fp,"(%2d) class= %c\n",     i+1,tle->data[i].satclass);
         fprintf(fp,"(%2d) desig= %s\n",     i+1,tle->data[i].desig);
-        fprintf(fp,"(%2d) epoch= %s\n",     i+1,time_str(tle->data[i].epoch,0));
+        char tstr[40];
+        time2str(tle->data[i].epoch,tstr,0);
+        fprintf(fp,"(%2d) epoch= %s\n",     i+1,tstr);
         fprintf(fp,"(%2d) etype= %d\n",     i+1,tle->data[i].etype);
         fprintf(fp,"(%2d) eleno= %d\n",     i+1,tle->data[i].eleno);
         fprintf(fp,"(%2d) ndot = %19.12e\n",i+1,tle->data[i].ndot );

--- a/util/geniono/gengrid.c
+++ b/util/geniono/gengrid.c
@@ -38,7 +38,7 @@ static void out_iono(gtime_t time, int sat, int brk, double iono, double rate,
                      double var, FILE *fp)
 {
     double tow;
-    char id[64];
+    char id[8];
     int week;
     
     tow=time2gpst(time,&week);

--- a/util/geniono/geniono.c
+++ b/util/geniono/geniono.c
@@ -251,7 +251,7 @@ static void out_iono(gtime_t time, const ekf_t *ekf, const sstat_t *sstat,
                      FILE *fp)
 {
     double tow;
-    char id[64];
+    char id[8];
     int sat,week;
     
     tow=time2gpst(time,&week);

--- a/util/geniono/genstec.c
+++ b/util/geniono/genstec.c
@@ -250,7 +250,7 @@ static void out_iono(gtime_t time, const ekf_t *ekf, const sstat_t *sstat,
                      FILE *fp)
 {
     double tow;
-    char id[64];
+    char id[8];
     int sat,week;
     
     tow=time2gpst(time,&week);

--- a/util/geniono/rcvdcb.c
+++ b/util/geniono/rcvdcb.c
@@ -228,7 +228,7 @@ static void out_iono(gtime_t time, const ekf_t *ekf, const sstat_t *sstat,
                      const double *pos, FILE *fp)
 {
     double tow;
-    char id[64];
+    char id[8];
     int sat,week;
     
     tow=time2gpst(time,&week);

--- a/util/rnx2rtcm/rnx2rtcm.c
+++ b/util/rnx2rtcm/rnx2rtcm.c
@@ -231,7 +231,8 @@ static int conv_rtcm(const int *type, int n, const char *opt, const char *outfil
     // Generate RTCM nav data messages
     gen_rtcm_nav(rtcm.time, &rtcm, nav, index, type, n, fp);
 
-    fprintf(stderr, "%s: NOBS=%2d\r", time_str(rtcm.time, 0), rtcm.obs.n);
+    char tstr[40];
+    fprintf(stderr, "%s: NOBS=%2d\r", time2str(rtcm.time, tstr, 0), rtcm.obs.n);
   }
   // Generate RTCM nav data messages
   gtime_t time0 = {0};

--- a/util/simobs/simobs.c
+++ b/util/simobs/simobs.c
@@ -176,7 +176,7 @@ static int simobs(simopt_t simopt, rnxopt_t rnxopt, nav_t *nav, obs_t *obs) {
   double    epr,ecp;
   int       i,j,k,n,m,ns,sys,prn;
   int       iSys;
-  char      s[64];
+  char      s[40];
   double    f0,fk;
 
   trace(3,"simobs:nnav=%d ngnav=%d\n",nav->n,nav->ng);

--- a/util/testeph/diffeph.c
+++ b/util/testeph/diffeph.c
@@ -214,7 +214,8 @@ int main(int argc, char **argv)
     for (i=0;i<(int)(tspan*3600.0/tint);i++) {
        time=timeadd(t0,tint*i);
        
-       fprintf(stderr,"time=%s\r",time_str(time,0));
+       char tstr[40];
+       fprintf(stderr,"time=%s\r",time2str(time,tstr,0));
        
        /* update ephemeris in navigation data */
        if (fp) {

--- a/util/testeph/diffeph.c
+++ b/util/testeph/diffeph.c
@@ -39,7 +39,7 @@ static void prusage(void)
 /* update rtcm struct --------------------------------------------------------*/
 static void updatertcm(gtime_t time, rtcm_t *rtcm, nav_t *nav, FILE *fp)
 {
-    char s1[32],s2[32];
+    char s1[40],s2[40];
     int i;
     
     while (input_rtcm3f(rtcm,fp)>=0) {
@@ -71,7 +71,7 @@ static void printephdiff(gtime_t time, int sat, int eph1, int eph2,
     double drs[3],drss[3],rc[3],er[3],ea[3],ec[3];
     double rr[3],e[3],rr1[3],rr2[3],r1,r2,azel[2];
     int i,week,svh1,svh2;
-    char tstr[32];
+    char tstr[40];
     
     if (!satpos(time,time,sat,eph1,nav1,rs1,dts1,&var1,&svh1)) return;
     if (!satpos(time,time,sat,eph2,nav2,rs2,dts2,&var2,&svh2)) return;

--- a/util/testeph/dumpssr.c
+++ b/util/testeph/dumpssr.c
@@ -32,7 +32,7 @@ static void printssrmsg(int sat, const ssr_t *ssr, int topt, int mopt)
 {
     double tow;
     int week;
-    char tstr[32],id[16];
+    char tstr[32],id[8];
     
     if (topt) {
         time2str(ssr->t0,tstr,0);

--- a/util/testeph/dumpssr.c
+++ b/util/testeph/dumpssr.c
@@ -32,7 +32,7 @@ static void printssrmsg(int sat, const ssr_t *ssr, int topt, int mopt)
 {
     double tow;
     int week;
-    char tstr[32],id[8];
+    char tstr[40],id[8];
     
     if (topt) {
         time2str(ssr->t0,tstr,0);

--- a/util/testlex/dumpssr.c
+++ b/util/testlex/dumpssr.c
@@ -32,7 +32,7 @@ static void printssrmsg(int sat, const ssr_t *ssr, int topt, int mopt)
 {
     double tow;
     int week;
-    char tstr[32],id[16];
+    char tstr[32],id[8];
     
     if (topt) {
         time2str(ssr->t0,tstr,0);

--- a/util/testlex/dumpssr.c
+++ b/util/testlex/dumpssr.c
@@ -32,7 +32,7 @@ static void printssrmsg(int sat, const ssr_t *ssr, int topt, int mopt)
 {
     double tow;
     int week;
-    char tstr[32],id[8];
+    char tstr[40],id[8];
     
     if (topt) {
         time2str(ssr->t0,tstr,0);

--- a/util/testlex/outlexion.c
+++ b/util/testlex/outlexion.c
@@ -13,7 +13,8 @@ static int updatelex(int index, gtime_t time, lex_t *lex, nav_t *nav)
     
     for (;index<lex->n;index++) {
         if (!lexupdatecorr(lex->msgs+index,nav,&tof)) continue;
-        fprintf(stderr,"%6d: tof=%s\r",index,time_str(tof,0));
+        char tstr[40];
+        fprintf(stderr,"%6d: tof=%s\r",index,time2str(tof,tstr,0));
         if (timediff(tof,time)>=0.0) break;
     }
     return index;
@@ -37,7 +38,8 @@ static void printtec(int index, gtime_t time, double sec, const nav_t *nav,
         for (i=0;i<nlat;i++) fprintf(fp,"%.1f%s",lat0-dpos*i,i<nlat-1?" ":"");
         fprintf(fp,"];\n\n");
     }
-    fprintf(fp,"%% %s\n",time_str(time,0));
+    char tstr[40];
+    fprintf(fp,"%% %s\n",time2str(time,tstr,0));
     fprintf(fp,"time(%d)=%.0f;\n",index,sec);
     fprintf(fp,"tec(:,:,%d)=[\n",index);
     for (i=0;i<nlat;i++) {
@@ -113,7 +115,8 @@ int main(int argc, char **argv)
     for (i=0;i<(int)(tspan*3600.0/tint);i++) {
        time=timeadd(t0,tint*i);
        
-       fprintf(stderr,"time=%s\r",time_str(time,0));
+       char tstr[40];
+       fprintf(stderr,"time=%s\r",time2str(time,tstr,0));
        
        index=updatelex(index,time,&lex,&nav);
        


### PR DESCRIPTION
The satno2id() target buffer varied over the code, from 8 to 64 bytes. Consistently use 8 bytes. Also note this minimum size in function prototype. Did not spot any issues in the current code, the buffers appeared to be more than large enough.

Use an output size of 8 bytes, more than adequate.

Use snprintf rather than sprintf when writing to these buffers.