### PR TITLE
Add -no-pie compilation flag

### DIFF
--- a/app/qtapp/qtapp.pri
+++ b/app/qtapp/qtapp.pri
@@ -19,3 +19,5 @@ QMAKE_RPATHDIR *= $${ROOT_DIRECTORY}/lib
 PRE_TARGETDEPS = $${ROOT_DIRECTORY}/src/rtklib.h
 
 CONFIG += c++11 debug
+
+QMAKE_LFLAGS += -no-pie

--- a/app/qtapp/rtklaunch_qt/rtklaunch_qt.pro
+++ b/app/qtapp/rtklaunch_qt/rtklaunch_qt.pro
@@ -30,3 +30,5 @@ RESOURCES += \
 RC_FILE = rtklaunch_qt.rc
 
 CONFIG += c++11
+
+QMAKE_LFLAGS += -no-pie


### PR DESCRIPTION
Add -no-pie compilation flag to prevent qt programs to compile as shared library on Linux systems.