### PR TITLE
consapp: normalize exit codes

### DIFF
--- a/app/consapp/convbin/convbin.c
+++ b/app/consapp/convbin/convbin.c
@@ -307,10 +307,10 @@ static int convbin(int format, rnxopt_t *opt, const char *ifile, char **file,
     
     if (!convrnx(format,opt,ifile,ofile)) {
         fprintf(stderr,"\n");
-        return -1;
+        return 0;
     }
     fprintf(stderr,"\n");
-    return 0;
+    return 1;
 }
 /* set signal mask -----------------------------------------------------------*/
 static void setmask(const char *argv, rnxopt_t *opt, int mask)
@@ -599,11 +599,11 @@ int main(int argc, char **argv)
     
     if (!*ifile) {
         fprintf(stderr,"no input file\n");
-        return -1;
+        return EXIT_FAILURE;
     }
     if (format<0) {
         fprintf(stderr,"input format can not be recognized\n");
-        return -1;
+        return EXIT_FAILURE;
     }
     sprintf(opt.prog,"%s %s %s",PRGNAME,VER_RTKLIB,PATCH_LEVEL);
     sprintf(opt.comment[0],"log: %-55.55s",ifile);
@@ -620,5 +620,5 @@ int main(int argc, char **argv)
     
     traceclose();
     
-    return stat;
+    return stat?0:EXIT_FAILURE;
 }

--- a/app/consapp/pos2kml/pos2kml.c
+++ b/app/consapp/pos2kml/pos2kml.c
@@ -85,11 +85,11 @@ int main(int argc, char **argv)
     }
     if (tcolor<0||5<tcolor||pcolor<0||5<pcolor) {
         fprintf(stderr,"pos2kml : command option error\n");
-        return -1;
+        return EXIT_FAILURE;
     }
     if (n<=0) {
         fprintf(stderr,"pos2kml : no input file\n");
-        return -1;
+        return EXIT_FAILURE;
     }
     for (i=0;i<n;i++) {
         if (gpx) {

--- a/app/consapp/rnx2rtkp/rnx2rtkp.c
+++ b/app/consapp/rnx2rtkp/rnx2rtkp.c
@@ -115,7 +115,7 @@ int main(int argc, char **argv)
     for (i=1;i<argc;i++) {
         if (!strcmp(argv[i],"-k")&&i+1<argc) {
             resetsysopts();
-            if (!loadopts(argv[++i],sysopts)) return -1;
+            if (!loadopts(argv[++i],sysopts)) return EXIT_FAILURE;
             getsysopts(&prcopt,&solopt,&filopt);
         }
     }
@@ -188,10 +188,10 @@ int main(int argc, char **argv)
     }
     if (n<=0) {
         showmsg("error : no input file");
-        return -2;
+        return EXIT_FAILURE;
     }
     ret=postpos(ts,te,tint,0.0,&prcopt,&solopt,&filopt,infile,n,outfile,"","");
     
     if (!ret) fprintf(stderr,"%40s\r","");
-    return ret;
+    return ret?EXIT_FAILURE:0;
 }

--- a/app/consapp/rtkrcv/rtkrcv.c
+++ b/app/consapp/rtkrcv/rtkrcv.c
@@ -1361,7 +1361,7 @@ static void *con_thread(void *arg)
     if (!login(con->vt)) {
         vt_close(con->vt);
         con->state=0;
-        return 0;
+        return NULL;
     }
  
     /* auto start if option set */
@@ -1428,7 +1428,7 @@ static void *con_thread(void *arg)
         }
     }
     vt_close(con->vt);
-    return 0;
+    return NULL;
 }
 /* open console --------------------------------------------------------------*/
 static con_t *con_open(int sock, const char *dev)
@@ -1683,7 +1683,7 @@ int main(int argc, char **argv)
             if (moniport>0) closemoni();
             if (outstat>0) rtkclosestat();
             traceclose();
-            return -1;
+            return EXIT_FAILURE;
         }
     } else if (start&2) { /* start without console */
         startsvr(NULL); 
@@ -1694,7 +1694,7 @@ int main(int argc, char **argv)
             if (moniport>0) closemoni();
             if (outstat>0) rtkclosestat();
             traceclose();
-            return -1;
+            return EXIT_FAILURE;
         }
     }
     signal(SIGINT, sigshut); /* keyboard interrupt */

--- a/app/consapp/str2str/str2str.c
+++ b/app/consapp/str2str/str2str.c
@@ -224,10 +224,10 @@ int main(int argc, char **argv)
     }
     for (i=1;i<argc;i++) {
         if (!strcmp(argv[i],"-in")&&i+1<argc) {
-            if (!decodepath(argv[++i],types,paths[0],fmts)) return -1;
+            if (!decodepath(argv[++i],types,paths[0],fmts)) return EXIT_FAILURE;
         }
         else if (!strcmp(argv[i],"-out")&&i+1<argc&&n<MAXSTR-1) {
-            if (!decodepath(argv[++i],types+n+1,paths[n+1],fmts+n+1)) return -1;
+            if (!decodepath(argv[++i],types+n+1,paths[n+1],fmts+n+1)) return EXIT_FAILURE;
             n++;
         }
         else if (!strcmp(argv[i],"-p")&&i+3<argc) {
@@ -274,15 +274,15 @@ int main(int argc, char **argv)
         if (fmts[i+1]<=0) continue;
         if (fmts[i+1]!=STRFMT_RTCM3) {
             fprintf(stderr,"unsupported output format\n");
-            return -1;
+            return EXIT_FAILURE;
         }
         if (fmts[0]<0) {
             fprintf(stderr,"specify input format\n");
-            return -1;
+            return EXIT_FAILURE;
         }
         if (!(conv[i]=strconvnew(fmts[0],fmts[i+1],msg,sta,sta!=0,opt))) {
             fprintf(stderr,"stream conversion error\n");
-            return -1;
+            return EXIT_FAILURE;
         }
         strcpy(buff,antinfo);
         for (p=strtok(buff,","),j=0;p&&j<3;p=strtok(NULL,",")) ant[j++]=p;
@@ -321,7 +321,7 @@ int main(int argc, char **argv)
     if (!strsvrstart(&strsvr,opts,types,paths,logs,conv,cmds,cmds_periodic,
                      stapos)) {
         fprintf(stderr,"stream server start error\n");
-        return -1;
+        return EXIT_FAILURE;
     }
     for (intrflg=0;!intrflg;) {
         


### PR DESCRIPTION
Use the standard EXIT_FAILURE as the command failure exit code rather than -1 (255) or -2 (254).

Also the rnx2rtkp command was returning the codes from the function postpos(), and now just return EXIT_FAILURE for anything but success.

This would change the exit codes, might break some script that checked for a specific code rather than just success or not-success. But the current negative codes will not pass through to the shell as is, they will be truncated to an unsigned 8 bit value. rnx2rtkp seems the only affected command in practice. Could just ignore this suggestion, it is just a standardisation suggestion.