### PR TITLE
convgpx, convkml: free the solution buffer when done.

### DIFF
--- a/src/convgpx.c
+++ b/src/convgpx.c
@@ -170,6 +170,7 @@ extern int convgpx(const char *infile, const char *outfile, gtime_t ts,
         for (i=0;i<3;i++) solbuf.rb[i]+=dr[i];
     }
     /* save gpx file */
-    return savegpx(file,&solbuf,outtrk,outpnt,outalt,outtime)?0:-4;
+    int r = savegpx(file,&solbuf,outtrk,outpnt,outalt,outtime)?0:-4;
+    freesolbuf(&solbuf);
+    return r;
 }
-

--- a/src/convkml.c
+++ b/src/convkml.c
@@ -209,5 +209,7 @@ extern int convkml(const char *infile, const char *outfile, gtime_t ts,
         for (i=0;i<3;i++) solbuf.rb[i]+=dr[i];
     }
     /* save kml file */
-    return savekml(file,&solbuf,tcolor,pcolor,outalt,outtime)?0:-4;
+    int r = savekml(file,&solbuf,tcolor,pcolor,outalt,outtime)?0:-4;
+    freesolbuf(&solbuf);
+    return r;
 }


### PR DESCRIPTION
These were leaking the solution buffer.