### PR TITLE
ublox: default the MAX_STD_CP and STD_SLIP values before parsing

### DIFF
--- a/src/rcv/ublox.c
+++ b/src/rcv/ublox.c
@@ -357,7 +357,7 @@ static int decode_rxmrawx(raw_t *raw)
     gtime_t time;
     char *q,tstr[64];
     double tow,P,L,D,tn,tadj=0.0,toff=0.0;
-    int i,j,k,idx,sys,prn,sat,code,slip,halfv,halfc,LLI,n=0,cpstd_valid,cpstd_slip;
+    int i,j,k,idx,sys,prn,sat,code,slip,halfv,halfc,LLI,n=0;
     int week,nmeas,ver,gnss,svid,sigid,frqid,lockt,cn0,cpstd=0,prstd=0,tstat;
     int multicode=0, rcvstds=0;
 
@@ -392,16 +392,19 @@ static int decode_rxmrawx(raw_t *raw)
         sscanf(q,"-TADJ=%lf",&tadj);
     }
     /* max valid std-dev of carrier-phase (-MAX_STD_CP) */
-    if ((q=strstr(raw->opt,"-MAX_STD_CP="))) {
-        sscanf(q,"-MAX_STD_CP=%d",&cpstd_valid);
-    }
-    else if (raw->rcvtype==1) cpstd_valid=MAX_CPSTD_VALID_GEN9;  /* F9P */
-    else cpstd_valid=MAX_CPSTD_VALID_GEN8;  /* M8T, M8P */
+    int cpstd_valid;
+    if (raw->rcvtype == 1)
+        cpstd_valid = MAX_CPSTD_VALID_GEN9; /* F9P */
+    else
+        cpstd_valid = MAX_CPSTD_VALID_GEN8; /* M8T, M8P */
+    q = strstr(raw->opt, "-MAX_STD_CP=");
+    if (q) sscanf(q, "-MAX_STD_CP=%d", &cpstd_valid);
 
     /* slip threshold of std-dev of carrier-phase (-STD_SLIP) */
-    if ((q=strstr(raw->opt,"-STD_SLIP="))) {
-        sscanf(q,"-STD_SLIP=%d",&cpstd_slip);
-    } else cpstd_slip=CPSTD_SLIP;
+    int cpstd_slip = CPSTD_SLIP;
+    q = strstr(raw->opt, "-STD_SLIP=");
+    if (q) sscanf(q, "-STD_SLIP=%d", &cpstd_slip);
+
     /* use multiple codes for each freq (-MULTICODE) */
     if ((q=strstr(raw->opt,"-MULTICODE"))) multicode=1;
     /* write rcvr stdevs to unused rinex fields */
@@ -1314,7 +1317,7 @@ static int sync_ubx(uint8_t *buff, uint8_t data)
 *          -INVCP     : invert polarity of carrier-phase
 *          -TADJ=tint : adjust time tags to multiples of tint (sec)
 *          -STD_SLIP=std: slip by std-dev of carrier phase under std
-*          -MAX_CP_STD=std: max std-dev of carrier phase
+*          -MAX_STD_CP=std: max std-dev of carrier phase
 *          -MULTICODE :  preserve multiple signal codes for single freq
 *          -RCVSTDS :  save receiver stdevs to unused rinex fields
 


### PR DESCRIPTION
Give the respective variables a default value before attempting to parse the value, just in case the parsing fails.

Also corrected a comment for the option MAX_STD_CP, assuming not MAX_STD_CP