### PR TITLE
rtkrcv: remove the shell command execution

### DIFF
--- a/app/consapp/rtkrcv/rtkrcv.c
+++ b/app/consapp/rtkrcv/rtkrcv.c
@@ -106,8 +106,10 @@ static char proxyaddr[256]="";          /* http/ntrip proxy */
 static int nmeareq      =0;             /* nmea request type (0:off,1:lat/lon,2:single) */
 static double nmeapos[] ={0,0,0};       /* nmea position (lat/lon/height) (deg,m) */
 static char rcvcmds[3][MAXSTR]={""};    /* receiver commands files */
+#ifdef RTKSHELLCMDS
 static char startcmd[MAXSTR]="";        /* start command */
 static char stopcmd [MAXSTR]="";        /* stop command */
+#endif
 static int modflgr[256] ={0};           /* modified flags of receiver options */
 static int modflgs[256] ={0};           /* modified flags of system options */
 static int moniport     =0;             /* monitor port */
@@ -222,8 +224,10 @@ static opt_t rcvopts[]={
     {"misc-proxyaddr",  2,  (void *)proxyaddr,           ""     },
     {"misc-fswapmargin",0,  (void *)&fswapmargin,        "s"    },
     
+#ifdef RTKSHELLCMDS
     {"misc-startcmd",   2,  (void *)startcmd,            ""     },
     {"misc-stopcmd",    2,  (void *)stopcmd,             ""     },
+#endif
     
     {"file-cmdfile1",   2,  (void *)rcvcmds[0],          ""     },
     {"file-cmdfile2",   2,  (void *)rcvcmds[1],          ""     },
@@ -399,7 +403,7 @@ static int startsvr(vt_t *vt)
         strpath[6],strpath[7]
     };
     char errmsg[2048]="";
-    int i,ret,stropt[8]={0};
+    int i,stropt[8]={0};
     
     trace(3,"startsvr:\n");
     
@@ -459,11 +463,14 @@ static int startsvr(vt_t *vt)
     strsetdir(filopt.tempdir);
     strsetproxy(proxyaddr);
     
+#ifdef RTKSHELLCMDS
     /* execute start command */
+    int ret;
     if (*startcmd&&(ret=system(startcmd))) {
         trace(2,"command exec error: %s (%d)\n",startcmd,ret);
         vt_printf(vt,"command exec error: %s (%d)\n",startcmd,ret);
     }
+#endif
     solopt[0].posf=strfmt[3];
     solopt[1].posf=strfmt[4];
     
@@ -481,7 +488,7 @@ static int startsvr(vt_t *vt)
 static void stopsvr(vt_t *vt)
 {
     char s[3][MAXRCVCMD]={"","",""},*cmds[]={NULL,NULL,NULL};
-    int i,ret;
+    int i;
     
     trace(3,"stopsvr:\n");
     
@@ -498,11 +505,14 @@ static void stopsvr(vt_t *vt)
     /* stop rtk server */
     rtksvrstop(&svr,cmds);
     
+#ifdef RTKSHELLCMDS
     /* execute stop command */
+    int ret;
     if (*stopcmd&&(ret=system(stopcmd))) {
         trace(2,"command exec error: %s (%d)\n",stopcmd,ret);
         vt_printf(vt,"command exec error: %s (%d)\n",stopcmd,ret);
     }
+#endif
     if (solopt[0].geoid>0) closegeoid();
     
     vt_printf(vt,"stop rtk server\n");


### PR DESCRIPTION
Add a command line argument '-exec' to enable to feature.

Suggestion to disable the rtkrcv command shell feature by default. A telnet session over an insecure connection, with a default password 'admin', that can execute shell commands might catch someone out.

Perhaps people would want to give the argument another name.