### PR TITLE
rtkplot_qt Plot::UpdateObsType: correct arg to code2obs()

### DIFF
--- a/app/qtapp/rtkplot_qt/plotinfo.cpp
+++ b/app/qtapp/rtkplot_qt/plotinfo.cpp
@@ -330,7 +330,7 @@ void Plot::UpdateObsType(void)
 
     for (unsigned char c = 1; c <= MAXCODE; c++) {
         if (!cmask[c]) continue;
-        if (!*(obs=code2obs((uint8_t)i))) continue;
+        if (!*(obs=code2obs((uint8_t)c))) continue;
         codes[n++]=obs;
     }
     qsort(codes,n,sizeof(char *),_strcmp);


### PR DESCRIPTION
Windows app does not have this issue.