### PR TITLE
Rework the implementation of the position options

### DIFF
--- a/app/consapp/rnx2rtkp/rnx2rtkp.c
+++ b/app/consapp/rnx2rtkp/rnx2rtkp.c
@@ -105,7 +105,7 @@ int main(int argc, char **argv)
     
     prcopt.mode  =PMODE_KINEMA;
     prcopt.navsys=0;
-    prcopt.refpos=1;
+    prcopt.refpos=POSOPT_SINGLE;
     prcopt.glomodear=1;
     solopt.timef=0;
     sprintf(solopt.prog ,"%s ver.%s %s",PROGNAME,VER_RTKLIB,PATCH_LEVEL);
@@ -167,12 +167,12 @@ int main(int argc, char **argv)
             for (j=0;j<2;j++) prcopt.baseline[j]=atof(argv[++i]);
         }
         else if (!strcmp(argv[i],"-r")&&i+3<argc) {
-            prcopt.refpos=prcopt.rovpos=0;
+            prcopt.refpos=prcopt.rovpos=POSOPT_POS_XYZ;
             for (j=0;j<3;j++) prcopt.rb[j]=atof(argv[++i]);
             matcpy(prcopt.ru,prcopt.rb,3,1);
         }
         else if (!strcmp(argv[i],"-l")&&i+3<argc) {
-            prcopt.refpos=prcopt.rovpos=0;
+            prcopt.refpos=prcopt.rovpos=POSOPT_POS_LLH;
             for (j=0;j<3;j++) pos[j]=atof(argv[++i]);
             for (j=0;j<2;j++) pos[j]*=D2R;
             pos2ecef(pos,prcopt.rb);

--- a/app/consapp/rtkrcv/rtkrcv.c
+++ b/app/consapp/rtkrcv/rtkrcv.c
@@ -426,7 +426,7 @@ static int startsvr(vt_t *vt)
             if (strtype[i]==STR_FILE&&!confwrite(vt,strpath[i])) return 0;
         }
     }
-    if (prcopt.refpos==4) { /* rtcm */
+    if (prcopt.refpos==POSOPT_RTCM) { /* rtcm */
         for (i=0;i<3;i++) prcopt.rb[i]=0.0;
     }
     pos[0]=nmeapos[0]*D2R;

--- a/app/qtapp/rtknavi_qt/navimain.cpp
+++ b/app/qtapp/rtknavi_qt/navimain.cpp
@@ -1074,7 +1074,7 @@ void MainWindow::SvrStart(void)
     }
 
     if (RovPosTypeF <= 2) { // LLH,XYZ
-        PrcOpt.rovpos = POSOPT_POS;
+        PrcOpt.rovpos = RovPosTypeF < 2 ? POSOPT_POS_LLH : POSOPT_POS_XYZ;
         PrcOpt.ru[0] = RovPos[0];
         PrcOpt.ru[1] = RovPos[1];
         PrcOpt.ru[2] = RovPos[2];
@@ -1083,7 +1083,7 @@ void MainWindow::SvrStart(void)
         for (i = 0; i < 3; i++) PrcOpt.ru[i] = 0.0;
     }
     if (RefPosTypeF <= 2) { // LLH,XYZ
-        PrcOpt.refpos = POSOPT_POS;
+        PrcOpt.refpos = RefPosTypeF < 2 ? POSOPT_POS_LLH : POSOPT_POS_XYZ;
         PrcOpt.rb[0] = RefPos[0];
         PrcOpt.rb[1] = RefPos[1];
         PrcOpt.rb[2] = RefPos[2];

--- a/app/qtapp/rtknavi_qt/naviopt.cpp
+++ b/app/qtapp/rtknavi_qt/naviopt.cpp
@@ -835,9 +835,20 @@ void OptDialog::LoadOpt(const QString &file)
     MaxAveEp->setValue(prcopt.maxaveep);
 
     RovPosTypeP->setCurrentIndex(0);
+    if (prcopt.rovpos == POSOPT_POS_LLH)
+      RovPosTypeP->setCurrentIndex(0);
+    else if (prcopt.rovpos == POSOPT_POS_XYZ)
+      RovPosTypeP->setCurrentIndex(2);
+
     RefPosTypeP->setCurrentIndex(0);
-    if      (prcopt.refpos==POSOPT_RTCM  ) RefPosTypeP->setCurrentIndex(3);
-    else if (prcopt.refpos==POSOPT_SINGLE) RefPosTypeP->setCurrentIndex(4);
+    if (prcopt.refpos == POSOPT_POS_LLH)
+      RefPosTypeP->setCurrentIndex(0);
+    else if (prcopt.refpos == POSOPT_POS_XYZ)
+      RefPosTypeP->setCurrentIndex(2);
+    else if (prcopt.refpos == POSOPT_RTCM)
+      RefPosTypeP->setCurrentIndex(3);
+    else if (prcopt.refpos==POSOPT_SINGLE)
+      RefPosTypeP->setCurrentIndex(4);
 
     RovPosTypeF = RovPosTypeP->currentIndex();
     RefPosTypeF = RefPosTypeP->currentIndex();
@@ -1049,13 +1060,26 @@ void OptDialog::SaveOpt(const QString &file)
     prcopt.maxaveep = MaxAveEp->value();
     prcopt.initrst = ChkInitRestart->isChecked();
 
-    prcopt.rovpos = 4;
-    prcopt.refpos = 4;
-    if      (RefPosTypeP->currentIndex()==3) prcopt.refpos=POSOPT_RTCM;
-    else if (RefPosTypeP->currentIndex()==4) prcopt.refpos=POSOPT_SINGLE;
+    prcopt.rovpos = POSOPT_POS_LLH;
+    if (RovPosTypeP->currentIndex() < 2)
+      prcopt.rovpos = POSOPT_POS_LLH;
+    else if (RovPosTypeP->currentIndex() == 2)
+      prcopt.rovpos = POSOPT_POS_XYZ;
 
-    if (prcopt.rovpos == POSOPT_POS) GetPos(RovPosTypeP->currentIndex(), editu, prcopt.ru);
-    if (prcopt.refpos == POSOPT_POS) GetPos(RefPosTypeP->currentIndex(), editr, prcopt.rb);
+    prcopt.refpos = POSOPT_POS_LLH;
+    if (RefPosTypeP->currentIndex() < 2)
+      prcopt.refpos = POSOPT_POS_LLH;
+    else if (RefPosTypeP->currentIndex() == 2)
+      prcopt.refpos = POSOPT_POS_XYZ;
+    else if (RefPosTypeP->currentIndex() == 3)
+      prcopt.refpos = POSOPT_RTCM;
+    else if (RefPosTypeP->currentIndex() == 4)
+      prcopt.refpos = POSOPT_SINGLE;
+
+    if (prcopt.rovpos == POSOPT_POS_LLH || prcopt.rovpos == POSOPT_POS_XYZ)
+      GetPos(RovPosTypeP->currentIndex(), editu, prcopt.ru);
+    if (prcopt.refpos == POSOPT_POS_LLH || prcopt.refpos == POSOPT_POS_XYZ)
+      GetPos(RefPosTypeP->currentIndex(), editr, prcopt.rb);
 
     strcpy(filopt.satantp, qPrintable(SatPcvFile_Text));
     strcpy(filopt.rcvantp, qPrintable(AntPcvFile_Text));

--- a/app/qtapp/rtkpost_qt/postmain.cpp
+++ b/app/qtapp/rtkpost_qt/postmain.cpp
@@ -958,21 +958,18 @@ int MainForm::GetOption(prcopt_t &prcopt, solopt_t &solopt,
         prcopt.baseline[0]=0.0;
         prcopt.baseline[1]=0.0;
     }
-    if (PosMode!=PMODE_FIXED&&PosMode!=PMODE_PPP_FIXED) {
-        for (int i=0;i<3;i++) prcopt.ru[i]=0.0;
-    }
-    else if (RovPosType<=2) {
-        for (int i=0;i<3;i++) prcopt.ru[i]=RovPos[i];
-    }
-    else prcopt.rovpos=RovPosType-2; /* 1:single,2:posfile,3:rinex */
 
-    if (PosMode==PMODE_SINGLE||PosMode==PMODE_MOVEB) {
-        for (int i=0;i<3;i++) prcopt.rb[i]=0.0;
+    for (int i=0;i<3;i++) prcopt.ru[i]=RovPos[i];
+    if (RovPosType<=2) {
+        prcopt.rovpos = RovPosType < 2 ? POSOPT_POS_LLH : POSOPT_POS_XYZ;
     }
-    else if (RefPosType<=2) {
-        for (int i=0;i<3;i++) prcopt.rb[i]=RefPos[i];
+    else prcopt.rovpos=RovPosType-1; /* 1:single,2:posfile,3:rinex */
+
+    for (int i=0;i<3;i++) prcopt.rb[i]=RefPos[i];
+    if (RefPosType<=2) {
+        prcopt.refpos = RefPosType < 2 ? POSOPT_POS_LLH : POSOPT_POS_XYZ;
     }
-    else prcopt.refpos=RefPosType-2;
+    else prcopt.refpos=RefPosType-1;
 
     if (RovAntPcv) {
         strcpy(prcopt.anttype[0],qPrintable(RovAnt));

--- a/app/qtapp/rtkpost_qt/postopt.cpp
+++ b/app/qtapp/rtkpost_qt/postopt.cpp
@@ -772,8 +772,8 @@ void OptDialog::LoadOpt(const QString &file)
 
     IntpRefObs->setCurrentIndex(prcopt.intpref);
     SbasSat->setText(QString::number(prcopt.sbassatsel));
-    RovPosType->setCurrentIndex(prcopt.rovpos == 0 ? 0 : prcopt.rovpos + 2);
-    RefPosType->setCurrentIndex(prcopt.refpos == 0 ? 0 : prcopt.refpos + 2);
+    RovPosType->setCurrentIndex(prcopt.rovpos == POSOPT_POS_LLH ? 0 : prcopt.rovpos == POSOPT_POS_XYZ ? 2 : prcopt.rovpos + 1);
+    RefPosType->setCurrentIndex(prcopt.refpos == POSOPT_POS_LLH ? 0 : prcopt.refpos == POSOPT_POS_XYZ ? 2 : prcopt.refpos + 1);
     RovPosTypeP = RovPosType->currentIndex();
     RefPosTypeP = RefPosType->currentIndex();
     SetPos(RovPosType->currentIndex(), editu, prcopt.ru);
@@ -917,10 +917,12 @@ void OptDialog::SaveOpt(const QString &file)
 
     prcopt.intpref = IntpRefObs->currentIndex();
     prcopt.sbassatsel = SbasSat->text().toInt();
-    prcopt.rovpos = RovPosType->currentIndex() < 3 ? 0 : RovPosType->currentIndex() - 2;
-    prcopt.refpos = RefPosType->currentIndex() < 3 ? 0 : RefPosType->currentIndex() - 2;
-    if (prcopt.rovpos == 0) GetPos(RovPosType->currentIndex(), editu, prcopt.ru);
-    if (prcopt.refpos == 0) GetPos(RefPosType->currentIndex(), editr, prcopt.rb);
+    prcopt.rovpos = RovPosType->currentIndex() < 2 ? POSOPT_POS_LLH : RovPosType->currentIndex() == 2 ? POSOPT_POS_XYZ : (RovPosType->currentIndex() - 1);
+    prcopt.refpos = RefPosType->currentIndex() < 2 ? POSOPT_POS_LLH : RefPosType->currentIndex() == 2 ? POSOPT_POS_XYZ : (RefPosType->currentIndex() - 1);
+    if (prcopt.rovpos == POSOPT_POS_LLH || prcopt.rovpos == POSOPT_POS_XYZ)
+      GetPos(RovPosType->currentIndex(), editu, prcopt.ru);
+    if (prcopt.refpos == POSOPT_POS_LLH || prcopt.refpos == POSOPT_POS_XYZ)
+      GetPos(RefPosType->currentIndex(), editr, prcopt.rb);
 
     strcpy(prcopt.rnxopt[0], qPrintable(RnxOpts1_Text));
     strcpy(prcopt.rnxopt[1], qPrintable(RnxOpts2_Text));

--- a/app/winapp/rtknavi/navimain.cpp
+++ b/app/winapp/rtknavi/navimain.cpp
@@ -1139,7 +1139,7 @@ void __fastcall TMainForm::SvrStart(void)
         tracelevel(DebugTraceF);
     }
     if (RovPosTypeF<=2) { // LLH,XYZ
-        PrcOpt.rovpos=POSOPT_POS;
+        PrcOpt.rovpos = RovPosTypeF < 2 ? POSOPT_POS_LLH : POSOPT_POS_XYZ;
         PrcOpt.ru[0]=RovPos[0];
         PrcOpt.ru[1]=RovPos[1];
         PrcOpt.ru[2]=RovPos[2];
@@ -1149,7 +1149,7 @@ void __fastcall TMainForm::SvrStart(void)
         for (i=0;i<3;i++) PrcOpt.ru[i]=0.0;
     }
     if (RefPosTypeF<=2) { // LLH,XYZ
-        PrcOpt.refpos=POSOPT_POS;
+        PrcOpt.refpos = RefPosTypeF < 2 ? POSOPT_POS_LLH : POSOPT_POS_XYZ;
         PrcOpt.rb[0]=RefPos[0];
         PrcOpt.rb[1]=RefPos[1];
         PrcOpt.rb[2]=RefPos[2];

--- a/app/winapp/rtknavi/naviopt.cpp
+++ b/app/winapp/rtknavi/naviopt.cpp
@@ -830,8 +830,13 @@ void __fastcall TOptDialog::LoadOpt(AnsiString file)
 	ChkInitRestart->Checked		=prcopt.initrst;
 	
 	RovPosTypeP	 ->ItemIndex	=0;
+        if (prcopt.rovpos == POSOPT_POS_LLH) RovPosTypeP->ItemIndex = 0;
+        else if (prcopt.rovpos == POSOPT_POS_XYZ) RovPosTypeP->ItemIndex = 2;
+
 	RefPosTypeP	 ->ItemIndex	=0;
-	if      (prcopt.refpos==POSOPT_RTCM  ) RefPosTypeP->ItemIndex=3;
+        if (prcopt.refpos == POSOPT_POS_LLH) RefPosTypeP->ItemIndex = 0;
+        else if (prcopt.refpos == POSOPT_POS_XYZ) RefPosTypeP->ItemIndex = 2;
+	else if (prcopt.refpos==POSOPT_RTCM  ) RefPosTypeP->ItemIndex=3;
 	else if (prcopt.refpos==POSOPT_SINGLE) RefPosTypeP->ItemIndex=4;
 	
 	RovPosTypeF					=RovPosTypeP->ItemIndex;
@@ -1059,13 +1064,20 @@ void __fastcall TOptDialog::SaveOpt(AnsiString file)
 	prcopt.maxaveep=MaxAveEp->Text.ToInt();
 	prcopt.initrst=ChkInitRestart->Checked;
 	
-	prcopt.rovpos=POSOPT_POS;
-	prcopt.refpos=POSOPT_POS;
-	if      (RefPosTypeP->ItemIndex==3) prcopt.refpos=POSOPT_RTCM;
+        prcopt.rovpos = POSOPT_POS_LLH;
+        if (RovPosTypeP->ItemIndex < 2) prcopt.rovpos = POSOPT_POS_LLH;
+        else if (RovPosTypeP->ItemIndex == 2) prcopt.rovpos = POSOPT_POS_XYZ;
+
+        prcopt.refpos = POSOPT_POS_LLH;
+        if (RefPosTypeP->ItemIndex < 2) prcopt.refpos = POSOPT_POS_LLH;
+        else if (RefPosTypeP->ItemIndex == 2) prcopt.refpos = POSOPT_POS_XYZ;
+        else if (RefPosTypeP->ItemIndex == 3) prcopt.refpos=POSOPT_RTCM;
 	else if (RefPosTypeP->ItemIndex==4) prcopt.refpos=POSOPT_SINGLE;
 	
-	if (prcopt.rovpos==POSOPT_POS) GetPos(RovPosTypeP->ItemIndex,editu,prcopt.ru);
-	if (prcopt.refpos==POSOPT_POS) GetPos(RefPosTypeP->ItemIndex,editr,prcopt.rb);
+        if (prcopt.rovpos == POSOPT_POS_LLH || prcopt.rovpos == POSOPT_POS_XYZ)
+          GetPos(RovPosTypeP->ItemIndex, editu, prcopt.ru);
+        if (prcopt.refpos == POSOPT_POS_LLH || prcopt.refpos == POSOPT_POS_XYZ)
+          GetPos(RefPosTypeP->ItemIndex, editr, prcopt.rb);
 	
 	strcpy(filopt.satantp,SatPcvFile_Text.c_str());
 	strcpy(filopt.rcvantp,AntPcvFile_Text.c_str());

--- a/app/winapp/rtkpost/postmain.cpp
+++ b/app/winapp/rtkpost/postmain.cpp
@@ -918,21 +918,17 @@ int __fastcall TMainForm::GetOption(prcopt_t &prcopt, solopt_t &solopt,
         prcopt.baseline[0]=0.0;
         prcopt.baseline[1]=0.0;
     }
-    if (PosMode!=PMODE_FIXED&&PosMode!=PMODE_PPP_FIXED) {
-        for (int i=0;i<3;i++) prcopt.ru[i]=0.0;
+    for (int i=0;i<3;i++) prcopt.ru[i]=RovPos[i];
+    if (RovPosType<=2) {
+        prcopt.rovpos = RovPosType < 2 ? POSOPT_POS_LLH : POSOPT_POS_XYZ;
     }
-    else if (RovPosType<=2) {
-        for (int i=0;i<3;i++) prcopt.ru[i]=RovPos[i];
-    }
-    else prcopt.rovpos=RovPosType-2; /* 1:single,2:posfile,3:rinex */
+    else prcopt.rovpos=RovPosType-1; /* 1:single,2:posfile,3:rinex */
     
-    if (PosMode==PMODE_SINGLE||PosMode==PMODE_MOVEB) {
-        for (int i=0;i<3;i++) prcopt.rb[i]=0.0;
+    for (int i=0;i<3;i++) prcopt.rb[i]=RefPos[i];
+    if (RefPosType<=2) {
+        prcopt.refpos = RefPosType < 2 ? POSOPT_POS_LLH : POSOPT_POS_XYZ;
     }
-    else if (RefPosType<=2) {
-        for (int i=0;i<3;i++) prcopt.rb[i]=RefPos[i];
-    }
-    else prcopt.refpos=RefPosType-2;
+    else prcopt.refpos=RefPosType-1;
     
     if (RovAntPcv) {
         strcpy(prcopt.anttype[0],RovAnt.c_str());

--- a/app/winapp/rtkpost/postopt.cpp
+++ b/app/winapp/rtkpost/postopt.cpp
@@ -743,8 +743,8 @@ int ppp=PosMode->ItemIndex>=PMODE_PPP_KINEMA;
 	
 	IntpRefObs	 ->ItemIndex	=prcopt.intpref;
 	SbasSat		 ->Text			=s.sprintf("%d",prcopt.sbassatsel);
-	RovPosType	 ->ItemIndex	=prcopt.rovpos==0?0:prcopt.rovpos+2;
-	RefPosType	 ->ItemIndex	=prcopt.refpos==0?0:prcopt.refpos+2;
+        RovPosType->ItemIndex = prcopt.rovpos == POSOPT_POS_LLH ? 0 : prcopt.rovpos == POSOPT_POS_XYZ ? 2 : prcopt.rovpos + 1;
+        RefPosType->ItemIndex = prcopt.refpos == POSOPT_POS_LLH ? 0 : prcopt.refpos == POSOPT_POS_XYZ ? 2 : prcopt.refpos + 1;
 	RovPosTypeP					=RovPosType->ItemIndex;
 	RefPosTypeP					=RefPosType->ItemIndex;
 	SetPos(RovPosType->ItemIndex,editu,prcopt.ru);
@@ -899,10 +899,12 @@ int ppp=PosMode->ItemIndex>=PMODE_PPP_KINEMA;
 	
 	prcopt.intpref	=IntpRefObs->ItemIndex;
 	prcopt.sbassatsel=SbasSat->Text.ToInt();
-	prcopt.rovpos=RovPosType->ItemIndex<3?0:RovPosType->ItemIndex-2;
-	prcopt.refpos=RefPosType->ItemIndex<3?0:RefPosType->ItemIndex-2;
-	if (prcopt.rovpos==0) GetPos(RovPosType->ItemIndex,editu,prcopt.ru);
-	if (prcopt.refpos==0) GetPos(RefPosType->ItemIndex,editr,prcopt.rb);
+        prcopt.rovpos = RovPosType->ItemIndex < 2 ? POSOPT_POS_LLH : RovPosType->ItemIndex == 2 ? POSOPT_POS_XYZ : (RovPosType->ItemIndex - 1);
+        prcopt.refpos = RefPosType->ItemIndex < 2 ? POSOPT_POS_LLH : RefPosType->ItemIndex == 2 ? POSOPT_POS_XYZ : (RefPosType->ItemIndex - 1);
+        if (prcopt.rovpos == POSOPT_POS_LLH || prcopt.rovpos == POSOPT_POS_XYZ)
+          GetPos(RovPosType->ItemIndex, editu, prcopt.ru);
+        if (prcopt.refpos == POSOPT_POS_LLH || prcopt.refpos == POSOPT_POS_XYZ)
+          GetPos(RefPosType->ItemIndex, editr, prcopt.rb);
 	
 	strcpy(prcopt.rnxopt[0],RnxOpts1_Text.c_str());
 	strcpy(prcopt.rnxopt[1],RnxOpts2_Text.c_str());

--- a/src/options.c
+++ b/src/options.c
@@ -34,7 +34,6 @@
 static prcopt_t prcopt_;
 static solopt_t solopt_;
 static filopt_t filopt_;
-static int antpostype_[2];
 static double elmask_,elmaskar_,elmaskhold_;
 static double antpos_[2][3];
 static char exsats_[1024];
@@ -158,7 +157,7 @@ EXPORT opt_t sysopts[]={
     {"stats-prnpos",    1,  (void *)&prcopt_.prn[5],     "m"    },
     {"stats-clkstab",   1,  (void *)&prcopt_.sclkstab,   "s/s"  },
     
-    {"ant1-postype",    3,  (void *)&antpostype_[0],     POSOPT },
+    {"ant1-postype",    3,  (void *)&prcopt_.rovpos,     POSOPT },
     {"ant1-pos1",       1,  (void *)&antpos_[0][0],      "deg|m"},
     {"ant1-pos2",       1,  (void *)&antpos_[0][1],      "deg|m"},
     {"ant1-pos3",       1,  (void *)&antpos_[0][2],      "m|m"  },
@@ -167,7 +166,7 @@ EXPORT opt_t sysopts[]={
     {"ant1-antdeln",    1,  (void *)&prcopt_.antdel[0][1],"m"   },
     {"ant1-antdelu",    1,  (void *)&prcopt_.antdel[0][2],"m"   },
     
-    {"ant2-postype",    3,  (void *)&antpostype_[1],     POSOPT },
+    {"ant2-postype",    3,  (void *)&prcopt_.refpos,     POSOPT },
     {"ant2-pos1",       1,  (void *)&antpos_[1][0],      "deg|m"},
     {"ant2-pos2",       1,  (void *)&antpos_[1][1],      "deg|m"},
     {"ant2-pos3",       1,  (void *)&antpos_[1][2],      "m|m"  },
@@ -406,30 +405,27 @@ static void buff2sysopts(void)
 {
     double pos[3],*rr;
     char buff[1024],*p,*id;
-    int i,j,sat,*ps;
+    int i,j,sat,ps;
     
     prcopt_.elmin     =elmask_    *D2R;
     prcopt_.elmaskar  =elmaskar_  *D2R;
     prcopt_.elmaskhold=elmaskhold_*D2R;
     
     for (i=0;i<2;i++) {
-        ps=i==0?&prcopt_.rovpos:&prcopt_.refpos;
+        ps=i==0?prcopt_.rovpos:prcopt_.refpos;
         rr=i==0?prcopt_.ru:prcopt_.rb;
         
-        if (antpostype_[i]==0) { /* lat/lon/hgt */
-            *ps=0;
+        if (ps==POSOPT_POS_LLH) { /* lat/lon/hgt */
             pos[0]=antpos_[i][0]*D2R;
             pos[1]=antpos_[i][1]*D2R;
             pos[2]=antpos_[i][2];
             pos2ecef(pos,rr);
         }
-        else if (antpostype_[i]==1) { /* xyz-ecef */
-            *ps=0;
+        else if (ps==POSOPT_POS_XYZ) { /* xyz-ecef */
             rr[0]=antpos_[i][0];
             rr[1]=antpos_[i][1];
             rr[2]=antpos_[i][2];
         }
-        else *ps=antpostype_[i]-1;
     }
     /* excluded satellites */
     for (i=0;i<MAXSAT;i++) prcopt_.exsats[i]=0;
@@ -464,25 +460,27 @@ static void buff2sysopts(void)
 static void sysopts2buff(void)
 {
     double pos[3],*rr;
-    char id[32],*p;
-    int i,j,sat,*ps;
+    char id[8],*p;
+    int i,j,sat,ps;
     
     elmask_    =prcopt_.elmin     *R2D;
     elmaskar_  =prcopt_.elmaskar  *R2D;
     elmaskhold_=prcopt_.elmaskhold*R2D;
     
     for (i=0;i<2;i++) {
-        ps=i==0?&prcopt_.rovpos:&prcopt_.refpos;
+        ps=i==0?prcopt_.rovpos:prcopt_.refpos;
         rr=i==0?prcopt_.ru:prcopt_.rb;
         
-        if (*ps==0) {
-            antpostype_[i]=0;
+        if (ps==POSOPT_POS_LLH) {
             ecef2pos(rr,pos);
             antpos_[i][0]=pos[0]*R2D;
             antpos_[i][1]=pos[1]*R2D;
             antpos_[i][2]=pos[2];
+        } else if (ps==POSOPT_POS_XYZ) {
+            antpos_[i][0] = rr[0];
+            antpos_[i][1] = rr[1];
+            antpos_[i][2] = rr[2];
         }
-        else antpostype_[i]=*ps+1;
     }
     /* excluded satellites */
     exsats_[0]='\0';
@@ -528,7 +526,6 @@ extern void resetsysopts(void)
     filopt_.blq    [0]='\0';
     filopt_.solstat[0]='\0';
     filopt_.trace  [0]='\0';
-    for (i=0;i<2;i++) antpostype_[i]=0;
     elmask_=15.0;
     elmaskar_=0.0;
     elmaskhold_=0.0;

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -432,11 +432,12 @@ extern "C" {
 #define SBSOPT_ICORR 4                  /* SBAS option: ionosphere correction */
 #define SBSOPT_RANGE 8                  /* SBAS option: ranging */
 
-#define POSOPT_POS   0                  /* pos option: LLH/XYZ */
-#define POSOPT_SINGLE 1                 /* pos option: average of single pos */
-#define POSOPT_FILE  2                  /* pos option: read from pos file */
-#define POSOPT_RINEX 3                  /* pos option: rinex header pos */
-#define POSOPT_RTCM  4                  /* pos option: rtcm/raw station pos */
+#define POSOPT_POS_LLH 0                /* pos option: LLH */
+#define POSOPT_POS_XYZ 1                /* pos option: XYZ */
+#define POSOPT_SINGLE  2                /* pos option: average of single pos */
+#define POSOPT_FILE    3                /* pos option: read from pos file */
+#define POSOPT_RINEX   4                /* pos option: rinex header pos */
+#define POSOPT_RTCM    5                /* pos option: rtcm/raw station pos */
 
 #define STR_NONE     0                  /* stream type: none */
 #define STR_SERIAL   1                  /* stream type: serial */


### PR DESCRIPTION
Add separate position option implementation states for llh and xyz position types. The implementation of the antenna types was already consistent with the configuration options for the antenna types, but the implementation state in refpos and rovpos dropped the distinction between llh and xyz position formats and so lost the distinction when converting back to the configuation option.

Now the rovpos and refpos use the same set of states as the antenna types, including llh and xyz position types, although the positions stored in ru and bu are still always in xyz format.

This simplifies the option handling and little as there is now no translation between the position types, but the positions are still translated between xyz and llh as needed.

It is now possible to save antenna positions to configuration files in ecef xyx format, whereas previously these would be saved in llh format even if loaded in xyx format.

The fronts ends have been updated to handle the two position states and to take advantage of the new xyz state. So that an antenna position set in the GUI in xyz format now saves to a configuration file in xyz format, rather than in llh format.

Also tried to address some issues with the propagation of this state, both in the core options and front ends.