### PR TITLE
stream ntrip agent: specialize for windows

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -104,7 +104,11 @@
 #define MAXSTATMSG          32          /* max length of status message */
 #define DEFAULT_MEMBUF_SIZE 4096        /* default memory buffer size (bytes) */
 
+#ifdef WIN32
+#define NTRIP_AGENT         "RTKLIB/" VER_RTKLIB "_" PATCH_LEVEL "_Win32"
+#else
 #define NTRIP_AGENT         "RTKLIB/" VER_RTKLIB "_" PATCH_LEVEL
+#endif
 #define NTRIP_CLI_PORT      2101        /* default ntrip-client connection port */
 #define NTRIP_SVR_PORT      80          /* default ntrip-server connection port */
 #define NTRIP_MAXRSP        32768       /* max size of ntrip response */


### PR DESCRIPTION
To help narrow down issues report by servers.

See https://github.com/rtklibexplorer/RTKLIB/issues/302 where we don't know if the clients are using the windows vs the Linux/MacOS stream code paths and there a good few differences in this code.

Perhaps people have a better suggestion.