### PR TITLE
Rinex mask defs

### DIFF
--- a/app/consapp/convbin/convbin.c
+++ b/app/consapp/convbin/convbin.c
@@ -321,15 +321,16 @@ static void setmask(const char *argv, rnxopt_t *opt, int mask)
     strcpy(buff,argv);
     for (p=strtok(buff,",");p;p=strtok(NULL,",")) {
         if (strlen(p)<4||p[1]!='L') continue;
-        if      (p[0]=='G') i=0;
-        else if (p[0]=='R') i=1;
-        else if (p[0]=='E') i=2;
-        else if (p[0]=='J') i=3;
-        else if (p[0]=='S') i=4;
-        else if (p[0]=='C') i=5;
-        else if (p[0]=='I') i=6;
+        if      (p[0]=='G') i=RNX_SYS_GPS;
+        else if (p[0]=='R') i=RNX_SYS_GLO;
+        else if (p[0]=='E') i=RNX_SYS_GAL;
+        else if (p[0]=='J') i=RNX_SYS_QZS;
+        else if (p[0]=='S') i=RNX_SYS_SBS;
+        else if (p[0]=='C') i=RNX_SYS_CMP;
+        else if (p[0]=='I') i=RNX_SYS_IRN;
         else continue;
-        if ((code=obs2code(p+2))) {
+        int code=obs2code(p+2);
+        if (code != CODE_NONE) {
             opt->mask[i][code-1]=mask?'1':'0';
         }
     }
@@ -388,7 +389,10 @@ static int cmdopts(int argc, char **argv, rnxopt_t *opt, char **ifile,
     opt->navsys=SYS_GPS|SYS_GLO|SYS_GAL|SYS_QZS|SYS_SBS|SYS_CMP|SYS_IRN;
     opt->ttol = 0.005;
     
-    for (i=0;i<6;i++) for (j=0;j<64;j++) opt->mask[i][j]='1';
+    for (i=0;i<RNX_NUMSYS;i++) {
+        for (j=0;j<MAXCODE;j++) opt->mask[i][j]='1';
+        opt->mask[i][MAXCODE]='\0';
+    }
     
     for (i=1;i<argc;i++) {
         if (!strcmp(argv[i],"-ts")&&i+2<argc) {
@@ -491,7 +495,10 @@ static int cmdopts(int argc, char **argv, rnxopt_t *opt, char **ifile,
             opt->halfcyc=1;
         }
         else if (!strcmp(argv[i],"-mask")&&i+1<argc) {
-            for (j=0;j<6;j++) for (k=0;k<64;k++) opt->mask[j][k]='0';
+            for (j=0;j<RNX_NUMSYS;j++) {
+              for (k=0;k<MAXCODE;k++) opt->mask[j][k]='0';
+              opt->mask[j][MAXCODE]='\0';
+            }
             setmask(argv[++i],opt,1);
         }
         else if (!strcmp(argv[i],"-nomask")&&i+1<argc) {

--- a/app/qtapp/rtkconv_qt/convmain.cpp
+++ b/app/qtapp/rtkconv_qt/convmain.cpp
@@ -908,7 +908,11 @@ void MainWindow::ConvertFile(void)
     conversionThread->rnxopt.obstype = ObsType;
     conversionThread->rnxopt.freqtype = FreqType;
     for (i=0;i<2;i++) sprintf(conversionThread->rnxopt.comment[i],"%.63s",qPrintable(Comment[i]));
-    for (i = 0; i < 7; i++) strcpy(conversionThread->rnxopt.mask[i], qPrintable(CodeMask[i]));
+    for (i = 0; i < 7; i++) {
+        /* strncpy is appropriate here, the elements are accessed randomly */
+        strncpy(conversionThread->rnxopt.mask[i], qPrintable(convOptDialog->codeMask[i]), sizeof(conversionThread->rnxopt.mask[i]));
+        conversionThread->rnxopt.mask[i][MAXCODE] = '\0';
+    }
     conversionThread->rnxopt.autopos = AutoPos;
     conversionThread->rnxopt.phshift = PhaseShift;
     conversionThread->rnxopt.halfcyc = HalfCyc;

--- a/app/winapp/rtkconv/convmain.cpp
+++ b/app/winapp/rtkconv/convmain.cpp
@@ -954,6 +954,11 @@ void __fastcall TMainWindow::ConvertFile(void)
 	rnxopt.freqtype=FreqType;
 	for (i=0;i<2;i++) sprintf(rnxopt.comment[i],"%.63s",Comment[i].c_str());
 	for (i=0;i<7;i++) strcpy(rnxopt.mask[i],CodeMask[i].c_str());
+        for (i=0;i<7;i++) {
+            /* strncpy is appropriate here, the elements are accessed randomly */
+            strncpy(rnxopt.mask[i],CodeMask[i].c_str(),sizeof(rnxopt.mask[i]);
+            rnxopt.mask[i][MAXCODE]='\0';
+        }
 	rnxopt.autopos=AutoPos;
 	rnxopt.phshift=PhaseShift;
 	rnxopt.halfcyc=HalfCyc;

--- a/src/rinex.c
+++ b/src/rinex.c
@@ -124,17 +124,17 @@
 #define SQR(x)      ((x)*(x))
 
 #define NAVEXP      "D"                 /* exponent letter in RINEX NAV */
-#define NUMSYS      7                   /* number of systems */
 #define MAXRNXLEN   (16*MAXOBSTYPE+4)   /* max RINEX record length */
 #define MAXPOSHEAD  1024                /* max head line position */
 #define MINFREQ_GLO -7                  /* min frequency number GLONASS */
 #define MAXFREQ_GLO 13                  /* max frequency number GLONASS */
 #define NINCOBS     262144              /* incremental number of obs data */
 
-static const int navsys[]={             /* satellite systems */
-    SYS_GPS,SYS_GLO,SYS_GAL,SYS_QZS,SYS_SBS,SYS_CMP,SYS_IRN,0
+static const int navsys[RNX_NUMSYS]={ /* satellite systems */
+    SYS_GPS,SYS_GLO,SYS_GAL,SYS_QZS,SYS_SBS,SYS_CMP,SYS_IRN
 };
-static const char syscodes[]="GREJSCI"; /* satellite system codes */
+/* Satellite system codes, nul terminated. RNX_SYS_ */
+static const char syscodes[RNX_NUMSYS+1]="GREJSCI";
 
 static const char obscodes[]="CLDS";    /* observation type codes */
 
@@ -433,7 +433,7 @@ static void decode_obsh(FILE *fp, char *buff, double ver, int *tsys,
         *tobs[i][nt]='\0';
         
         /* change BDS B1 code: 3.02 */
-        if (i==5&&fabs(ver-3.02)<1e-3) {
+        if (i==RNX_SYS_CMP&&fabs(ver-3.02)<1e-3) {
             for (j=0;j<nt;j++) if (tobs[i][j][1]=='1') tobs[i][j][1]='2';
         }
         /* uncomment this code to convert unknown codes to defaults */
@@ -456,12 +456,13 @@ static void decode_obsh(FILE *fp, char *buff, double ver, int *tsys,
             if (nt>=MAXOBSTYPE-1) continue;
             if (ver<=2.99) {
                 setstr(str,buff+j,2);
-                convcode(ver,SYS_GPS,str,tobs[0][nt]);
-                convcode(ver,SYS_GLO,str,tobs[1][nt]);
-                convcode(ver,SYS_GAL,str,tobs[2][nt]);
-                convcode(ver,SYS_QZS,str,tobs[3][nt]);
-                convcode(ver,SYS_SBS,str,tobs[4][nt]);
-                convcode(ver,SYS_CMP,str,tobs[5][nt]);
+                convcode(ver,SYS_GPS,str,tobs[RNX_SYS_GPS][nt]);
+                convcode(ver,SYS_GLO,str,tobs[RNX_SYS_GLO][nt]);
+                convcode(ver,SYS_GAL,str,tobs[RNX_SYS_GAL][nt]);
+                convcode(ver,SYS_QZS,str,tobs[RNX_SYS_QZS][nt]);
+                convcode(ver,SYS_SBS,str,tobs[RNX_SYS_SBS][nt]);
+                convcode(ver,SYS_CMP,str,tobs[RNX_SYS_CMP][nt]);
+                /* IRN missing, assumed to be not applicable? */
             }
             nt++;
         }
@@ -1036,21 +1037,35 @@ static int readrnxobsb(FILE *fp, const char *opt, double ver, int *tsys,
                        sta_t *sta)
 {
     gtime_t time={0};
-    sigind_t index[NUMSYS]={{0}};
+    sigind_t index[RNX_NUMSYS]={{0}};
     char buff[MAXRNXLEN];
-    int i=0,n=0,nsat=0,nsys=NUMSYS,sats[MAXOBS]={0},mask;
+    int i=0,n=0,nsat=0,sats[MAXOBS]={0},mask;
     
     /* set system mask */
     mask=set_sysmask(opt);
     
     /* set signal index */
-    if (nsys>=1) set_index(ver,SYS_GPS,opt,tobs[0],index  );
-    if (nsys>=2) set_index(ver,SYS_GLO,opt,tobs[1],index+1);
-    if (nsys>=3) set_index(ver,SYS_GAL,opt,tobs[2],index+2);
-    if (nsys>=4) set_index(ver,SYS_QZS,opt,tobs[3],index+3);
-    if (nsys>=5) set_index(ver,SYS_SBS,opt,tobs[4],index+4);
-    if (nsys>=6) set_index(ver,SYS_CMP,opt,tobs[5],index+5);
-    if (nsys>=7) set_index(ver,SYS_IRN,opt,tobs[6],index+6);
+#if RNX_NUMSYS>=1
+    set_index(ver,SYS_GPS,opt,tobs[RNX_SYS_GPS],index  );
+#endif
+#if RNX_NUMSYS>=2
+    set_index(ver,SYS_GLO,opt,tobs[RNX_SYS_GLO],index+1);
+#endif
+#if RNX_NUMSYS>=3
+    set_index(ver,SYS_GAL,opt,tobs[RNX_SYS_GAL],index+2);
+#endif
+#if RNX_NUMSYS>=4
+    set_index(ver,SYS_QZS,opt,tobs[RNX_SYS_QZS],index+3);
+#endif
+#if RNX_NUMSYS>=5
+    set_index(ver,SYS_SBS,opt,tobs[RNX_SYS_SBS],index+4);
+#endif
+#if RNX_NUMSYS>=6
+    set_index(ver,SYS_CMP,opt,tobs[RNX_SYS_CMP],index+5);
+#endif
+#if RNX_NUMSYS>=7
+    set_index(ver,SYS_IRN,opt,tobs[RNX_SYS_IRN],index+6);
+#endif
     
     /* read record */
     while (fgets(buff,MAXRNXLEN,fp)) {
@@ -1566,7 +1581,7 @@ static int readrnxfp(FILE *fp, gtime_t ts, gtime_t te, double tint,
 {
     double ver;
     int sys,tsys=TSYS_GPS;
-    char tobs[NUMSYS][MAXOBSTYPE][4]={{""}};
+    char tobs[RNX_NUMSYS][MAXOBSTYPE][4]={{""}};
     
     trace(3,"readrnxfp: flag=%d index=%d\n",flag,index);
     
@@ -1815,7 +1830,7 @@ extern int init_rnxctr(rnxctr_t *rnx)
     rnx->time=time0;
     rnx->ver=0.0;
     rnx->sys=rnx->tsys=0;
-    for (i=0;i<6;i++) for (j=0;j<MAXOBSTYPE;j++) rnx->tobs[i][j][0]='\0';
+    for (i=0;i<RNX_NUMSYS;i++) for (j=0;j<MAXOBSTYPE;j++) rnx->tobs[i][j][0]='\0';
     rnx->obs.n=0;
     rnx->nav.n=MAXSAT*2;
     rnx->nav.ng=NSATGLO;
@@ -1854,7 +1869,7 @@ extern int open_rnxctr(rnxctr_t *rnx, FILE *fp)
 {
     const char *rnxtypes="ONGLJHC";
     double ver;
-    char type,tobs[NUMSYS][MAXOBSTYPE][4]={{""}};
+    char type,tobs[RNX_NUMSYS][MAXOBSTYPE][4]={{""}};
     int i,j,sys,tsys;
     
     trace(3,"open_rnxctr:\n");
@@ -1872,7 +1887,7 @@ extern int open_rnxctr(rnxctr_t *rnx, FILE *fp)
     rnx->type=type;
     rnx->sys=sys;
     rnx->tsys=tsys;
-    for (i=0;i<NUMSYS;i++) for (j=0;j<MAXOBSTYPE&&*tobs[i][j];j++) {
+    for (i=0;i<RNX_NUMSYS;i++) for (j=0;j<MAXOBSTYPE&&*tobs[i][j];j++) {
         strcpy(rnx->tobs[i][j],tobs[i][j]);
     }
     rnx->ephset=rnx->ephsat=0;
@@ -1965,16 +1980,16 @@ static void outobstype_ver2(FILE *fp, const rnxopt_t *opt)
     
     trace(3,"outobstype_ver2:\n");
     
-    fprintf(fp,"%6d",opt->nobs[0]);
+    fprintf(fp,"%6d",opt->nobs[RNX_SYS_GPS]);
     
-    for (i=0;i<opt->nobs[0];i++) {
+    for (i=0;i<opt->nobs[RNX_SYS_GPS];i++) {
         if (i>0&&i%9==0) fprintf(fp,"      ");
-        
-        fprintf(fp,"%6s",opt->tobs[0][i]);
+
+        fprintf(fp,"%6s",opt->tobs[RNX_SYS_GPS][i]);
         
         if (i%9==8) fprintf(fp,"%-20s\n",label);
     }
-    if (opt->nobs[0]==0||i%9>0) {
+    if (opt->nobs[RNX_SYS_GPS]==0||i%9>0) {
         fprintf(fp,"%*s%-20s\n",(9-i%9)*6,"",label);
     }
 }
@@ -1982,23 +1997,23 @@ static void outobstype_ver2(FILE *fp, const rnxopt_t *opt)
 static void outobstype_ver3(FILE *fp, const rnxopt_t *opt)
 {
     const char label[]="SYS / # / OBS TYPES";
-    char tobs[8];
+    char tobs[4];
     int i,j;
     
     trace(3,"outobstype_ver3:\n");
     
-    for (i=0;navsys[i];i++) {
+    for (i=0;i<RNX_NUMSYS;i++) {
         if (!(navsys[i]&opt->navsys)||!opt->nobs[i]) continue;
         
         fprintf(fp,"%c  %3d",syscodes[i],opt->nobs[i]);
         
         for (j=0;j<opt->nobs[i];j++) {
             if (j>0&&j%13==0) fprintf(fp,"      ");
-            
+
             strcpy(tobs,opt->tobs[i][j]);
             
             /* BDS B2x -> 1x (3.02), 2x (other) */
-            if (navsys[i]==SYS_CMP) {
+            if (i==RNX_SYS_CMP) {
                 if (opt->rnxver==302&&tobs[1]=='2') tobs[1]='1';
             }
             fprintf(fp," %3s", tobs);
@@ -2013,7 +2028,7 @@ static void outobstype_ver3(FILE *fp, const rnxopt_t *opt)
 /* output RINEX phase shift --------------------------------------------------*/
 static void outrnx_phase_shift(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 {
-    static const uint8_t ref_code[][10]={ /* reference signal [9] table A23 */
+    static const uint8_t ref_code[RNX_NUMSYS][10]={ /* reference signal [9] table A23 */
         {CODE_L1C,CODE_L2P,CODE_L5I,0},                   /* GPS */
         {CODE_L1C,CODE_L4A,CODE_L2C,CODE_L6A,CODE_L3I,0}, /* GLO */
         {CODE_L1B,CODE_L5I,CODE_L7I,CODE_L8I,CODE_L6B,0}, /* GAL */
@@ -2026,7 +2041,7 @@ static void outrnx_phase_shift(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
     char obs[8];
     int i,j,k;
     
-    for (i=0;navsys[i];i++) {
+    for (i=0;i<RNX_NUMSYS;i++) {
         if (!(navsys[i]&opt->navsys)||!opt->nobs[i]) continue;
         for (j=0;j<opt->nobs[i];j++) {
             if (opt->tobs[i][j][0]!='L') continue;
@@ -2034,7 +2049,7 @@ static void outrnx_phase_shift(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
             for (k=0;ref_code[i][k];k++) {
                 if (obs2code(obs+1)==ref_code[i][k]) break;
             }
-            if (navsys[i]==SYS_CMP) { /* BDS B2x -> 1x (3.02), 2x (other) */
+            if (i==RNX_SYS_CMP) { /* BDS B2x -> 1x (3.02), 2x (other) */
                 if (opt->rnxver==302&&obs[1]=='2') obs[1]='1';
             }
             if (ref_code[i][k]) {
@@ -2106,7 +2121,7 @@ extern int outrnxobsh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
     trace(3,"outrnxobsh:\n");
     
     timestr_rnx(date);
-    
+
     if      (opt->navsys==SYS_GPS) sys="G: GPS";
     else if (opt->navsys==SYS_GLO) sys="R: GLONASS";
     else if (opt->navsys==SYS_GAL) sys="E: Galileo";
@@ -2305,15 +2320,16 @@ extern int outrnxobsb(FILE *fp, const rnxopt_t *opt, const obsd_t *obs, int n,
         if (!(sys&opt->navsys)||opt->exsats[obs[i].sat-1]) continue;
         if (!sat2code(obs[i].sat,sats[ns])) continue;
         switch (sys) {
-            case SYS_GPS: s[ns]=0; break;
-            case SYS_GLO: s[ns]=1; break;
-            case SYS_GAL: s[ns]=2; break;
-            case SYS_QZS: s[ns]=3; break;
-            case SYS_SBS: s[ns]=4; break;
-            case SYS_CMP: s[ns]=5; break;
-            case SYS_IRN: s[ns]=6; break;
+            case SYS_GPS: s[ns]=RNX_SYS_GPS; break;
+            case SYS_GLO: s[ns]=RNX_SYS_GLO; break;
+            case SYS_GAL: s[ns]=RNX_SYS_GAL; break;
+            case SYS_QZS: s[ns]=RNX_SYS_QZS; break;
+            case SYS_SBS: s[ns]=RNX_SYS_SBS; break;
+            case SYS_CMP: s[ns]=RNX_SYS_CMP; break;
+            case SYS_IRN: s[ns]=RNX_SYS_IRN; break;
+            default: continue;
         }
-        if (!opt->nobs[(opt->rnxver<=299)?0:s[ns]]) continue;
+        if (!opt->nobs[(opt->rnxver<=299)?RNX_SYS_GPS:s[ns]]) continue;
         ind[ns++]=i;
     }
     if (ns<=0) return 1;
@@ -2339,13 +2355,13 @@ extern int outrnxobsb(FILE *fp, const rnxopt_t *opt, const obsd_t *obs, int n,
         sys=satsys(obs[ind[i]].sat,NULL);
         
         if (opt->rnxver<=299) { /* ver.2 */
-            m=0;
+            m=RNX_SYS_GPS;
             mask=opt->mask[s[i]];
         }
         else { /* ver.3 */
             fprintf(fp,"%-3s",sats[i]);
             m=s[i];
-            mask=opt->mask[s[i]];
+            mask=opt->mask[m];
         }
         for (j=0;j<opt->nobs[m];j++) {
             

--- a/src/rinex.c
+++ b/src/rinex.c
@@ -2214,55 +2214,57 @@ static int obsindex(int rnxver, int sys, const uint8_t *code, const char *tobs,
     int i;
     
     for (i=0;i<NFREQ+NEXOBS;i++) {
-        
+        int c=code[i];
+        if (c==CODE_NONE) continue;
+
         /* signal mask */
-        if (mask[code[i]-1]=='0') continue;
+        if (mask[c-1]=='0') continue;
         
         if (rnxver<=299) { /* ver.2 */
             if (!strcmp(tobs,"C1")&&(sys==SYS_GPS||sys==SYS_GLO||sys==SYS_QZS||
                 sys==SYS_SBS||sys==SYS_CMP)) {
-                if (code[i]==CODE_L1C) return i;
+                if (c==CODE_L1C) return i;
             }
             else if (!strcmp(tobs,"P1")) {
-                if (code[i]==CODE_L1P||code[i]==CODE_L1W||code[i]==CODE_L1Y||
-                    code[i]==CODE_L1N) return i;
+                if (c==CODE_L1P||c==CODE_L1W||c==CODE_L1Y||
+                    c==CODE_L1N) return i;
             }
             else if (!strcmp(tobs,"C2")&&(sys==SYS_GPS||sys==SYS_QZS)) {
-                if (code[i]==CODE_L2S||code[i]==CODE_L2L||code[i]==CODE_L2X)
+                if (c==CODE_L2S||c==CODE_L2L||c==CODE_L2X)
                     return i;
             }
             else if (!strcmp(tobs,"C2")&&sys==SYS_GLO) {
-                if (code[i]==CODE_L2C) return i;
+                if (c==CODE_L2C) return i;
             }
             else if (!strcmp(tobs,"P2")) {
-                if (code[i]==CODE_L2P||code[i]==CODE_L2W||code[i]==CODE_L2Y||
-                    code[i]==CODE_L2N||code[i]==CODE_L2D) return i;
+                if (c==CODE_L2P||c==CODE_L2W||c==CODE_L2Y||
+                    c==CODE_L2N||c==CODE_L2D) return i;
             }
             else if (rnxver>=212&&tobs[1]=='A') { /* L1C/A */
-                if (code[i]==CODE_L1C) return i;
+                if (c==CODE_L1C) return i;
             }
             else if (rnxver>=212&&tobs[1]=='B') { /* L1C */
-                if (code[i]==CODE_L1S||code[i]==CODE_L1L||code[i]==CODE_L1X)
+                if (c==CODE_L1S||c==CODE_L1L||c==CODE_L1X)
                     return i;
             }
             else if (rnxver>=212&&tobs[1]=='C') { /* L2C */
-                if (code[i]==CODE_L2S||code[i]==CODE_L2L||code[i]==CODE_L2X)
+                if (c==CODE_L2S||c==CODE_L2L||c==CODE_L2X)
                     return i;
             }
             else if (rnxver>=212&&tobs[1]=='D'&&sys==SYS_GLO) { /* GLO L2C/A */
-                if (code[i]==CODE_L2C) return i;
+                if (c==CODE_L2C) return i;
             }
             else if (tobs[1]=='2'&&sys==SYS_CMP) { /* BDS B1 */
-                if (code[i]==CODE_L2I||code[i]==CODE_L2Q||code[i]==CODE_L2X)
+                if (c==CODE_L2I||c==CODE_L2Q||c==CODE_L2X)
                     return i;
             }
             else {
-                id=code2obs(code[i]);
+                id=code2obs(c);
                 if (id[0]==tobs[1]) return i;
             }
         }
         else { /* ver.3 */
-            id=code2obs(code[i]);
+            id=code2obs(c);
             if (!strcmp(id,tobs+1)) return i;
         }
     }

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -118,6 +118,16 @@ extern "C" {
 #define SYS_LEO     0x80                /* navigation system: LEO */
 #define SYS_ALL     0xFF                /* navigation system: all */
 
+/* System codes used in rnxopt_t mask, tobs, shift, and nobs. */
+#define RNX_SYS_GPS 0                   /* Navigation system: GPS */
+#define RNX_SYS_GLO 1                   /* Navigation system: GLONASS */
+#define RNX_SYS_GAL 2                   /* Navigation system: Galileo */
+#define RNX_SYS_QZS 3                   /* Navigation system: QZSS */
+#define RNX_SYS_SBS 4                   /* Navigation system: SBAS */
+#define RNX_SYS_CMP 5                   /* Navigation system: BeiDou */
+#define RNX_SYS_IRN 6                   /* Navigation system: IRNS */
+#define RNX_NUMSYS  7
+
 #define TSYS_GPS    0                   /* time system: GPS time */
 #define TSYS_UTC    1                   /* time system: UTC */
 #define TSYS_GLO    2                   /* time system: GLONASS time */
@@ -954,7 +964,7 @@ typedef struct {        /* RINEX control struct type */
     char   type;        /* RINEX file type ('O','N',...) */
     int    sys;         /* navigation system */
     int    tsys;        /* time system */
-    char   tobs[8][MAXOBSTYPE][4]; /* rinex obs types */
+    char   tobs[RNX_NUMSYS][MAXOBSTYPE][4]; /* rinex obs types */
     obs_t  obs;         /* observation data */
     nav_t  nav;         /* navigation data */
     sta_t  sta;         /* station info */
@@ -1091,10 +1101,13 @@ typedef struct {        /* RINEX options type */
     double ttol;        /* time tolerance (s) */
     double tunit;       /* time unit for multiple-session (s) */
     int rnxver;         /* RINEX version (x100) */
-    int navsys;         /* navigation system */
+    int navsys;         /* navigation system, SYS_ mask */
     int obstype;        /* observation type */
     int freqtype;       /* frequency type */
-    char mask[7][MAXCODE]; /* code mask {GPS,GLO,GAL,QZS,SBS,CMP,IRN} */
+    /* The mask allocates room for a nul terminator in the last element to
+     * support access as a string, but it is accessed randomly and must be full
+     * length. */
+    char mask[RNX_NUMSYS][MAXCODE+1]; /* code mask {GPS,GLO,GAL,QZS,SBS,CMP,IRN} */
     char staid [32];    /* station id for rinex file name */
     char prog  [32];    /* program */
     char runby [32];    /* run-by */
@@ -1121,9 +1134,9 @@ typedef struct {        /* RINEX options type */
     gtime_t tstart;     /* first obs time */
     gtime_t tend;       /* last obs time */
     gtime_t trtcm;      /* approx log start time for rtcm */
-    char tobs[7][MAXOBSTYPE][4]; /* obs types {GPS,GLO,GAL,QZS,SBS,CMP,IRN} */
-    double shift[7][MAXOBSTYPE]; /* phase shift (cyc) {GPS,GLO,GAL,QZS,SBS,CMP,IRN} */
-    int nobs[7];        /* number of obs types {GPS,GLO,GAL,QZS,SBS,CMP,IRN} */
+    char tobs[RNX_NUMSYS][MAXOBSTYPE][4]; /* obs types {GPS,GLO,GAL,QZS,SBS,CMP,IRN} */
+    double shift[RNX_NUMSYS][MAXOBSTYPE]; /* phase shift (cyc) {GPS,GLO,GAL,QZS,SBS,CMP,IRN} */
+    int nobs[RNX_NUMSYS]; /* number of obs types {GPS,GLO,GAL,QZS,SBS,CMP,IRN} */
 } rnxopt_t;
 
 typedef struct {        /* satellite status type */

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1094,7 +1094,7 @@ typedef struct {        /* RINEX options type */
     int navsys;         /* navigation system */
     int obstype;        /* observation type */
     int freqtype;       /* frequency type */
-    char mask[7][64];   /* code mask {GPS,GLO,GAL,QZS,SBS,CMP,IRN} */
+    char mask[7][MAXCODE]; /* code mask {GPS,GLO,GAL,QZS,SBS,CMP,IRN} */
     char staid [32];    /* station id for rinex file name */
     char prog  [32];    /* program */
     char runby [32];    /* run-by */


### PR DESCRIPTION
Noted an OOB access in the rnxopt mask, the constant 64 length is less than MAXCODE. This will also be needed for the qt_gui branch where this was first noted.

While checking further, added defines for the particular system index used in the rinex code. The convbin app had not been updated to iterate over all 7 systems. Have not checked the other front ends or made uses of these defines there, but they appear to bake in 7 systems.

Seems odd having a separate index sequence just for the rinex code, but this is a least a step towards cleaning that up. But it some baked in constants have been missed then it will break something to change the order. So suggest revisiting such a change as a later step.