### PR TITLE
convsbs: disable broken duplicate data test

### DIFF
--- a/src/convrnx.c
+++ b/src/convrnx.c
@@ -1166,9 +1166,13 @@ static void convsbs(FILE **ofp, rnxopt_t *opt, strfile_t *str, int *n,
 
     if (!screent(time,opt->ts,opt->te,0.0)) return;
     
-    /* avoid duplicated data by multiple files handover */
+#if 0
+    /* Avoid duplicated data by multiple files handover */
+    /* TODO There can be multiple messages at each time step that are not duplicates.
+     * Might be able to use a per-prn time. */
     if (tend->time&&timediff(time,*tend)<opt->ttol) return;
     *tend=time;
+#endif
 
     prn=str->raw.sbsmsg.prn;
     if (MINPRNSBS<=prn&&prn<=MAXPRNSBS) {


### PR DESCRIPTION
There can be multiple SMS messages at each time step that are not duplicates. Just disable this test for now so that SBS messages and ephemeris are not lost.

This can change the results, add more SBS messages and ephemeris to the output. This issue was masked when the time tolerance was zero.

Perhaps a fix would be to note the last time for each PRN. Or perhaps a real duplicate test is best?