### PR TITLE
convrnx: relax the test for duplicate data

### DIFF
--- a/src/convrnx.c
+++ b/src/convrnx.c
@@ -1016,8 +1016,8 @@ static void convobs(FILE **ofp, rnxopt_t *opt, strfile_t *str, int *n,
     
     time=str->obs->data[0].time;
     
-    /* avoid duplicated data by multiple files handover */
-    if (tend->time&&timediff(time,*tend)<opt->ttol) return;
+    /* Avoid duplicated data by multiple files handover */
+    if (tend->time&&timediff(time,*tend)<-opt->ttol) return;
     *tend=time;
 
     /* save cycle slips */
@@ -1166,8 +1166,8 @@ static void convsbs(FILE **ofp, rnxopt_t *opt, strfile_t *str, int *n,
 
     if (!screent(time,opt->ts,opt->te,0.0)) return;
     
-    /* avoid duplicated data by multiple files handover */
-    if (tend->time&&timediff(time,*tend)<opt->ttol) return;
+    /* Avoid duplicated data by multiple files handover */
+    if (tend->time&&timediff(time,*tend)<-opt->ttol) return;
     *tend=time;
 
     prn=str->raw.sbsmsg.prn;


### PR DESCRIPTION
Both convobs and convsbs were omitting data that was within the time tolerance or later than the previous latest data time. This was intended to omit some duplicate data. At least for the SBAS data this heuristic was too strict as multiple messages typically occur with the same time and messages and ephemeris were being omitted.

Relax the test to now keep data within the time tolerance.