### PR TITLE
Qt gui rtknavi_qt: showOptionsDialog stream guard

### DIFF
--- a/app/qtapp/rtknavi_qt/navimain.cpp
+++ b/app/qtapp/rtknavi_qt/navimain.cpp
@@ -481,7 +481,6 @@ void MainWindow::showOptionsDialog()
                 strtype[i] = STR_NONE;
         }
 
-        strtype[i] = i < 3 ? itype[streamType[i]] : otype[streamType[i]];
         strfmt[i] = inputFormat[i];
 
         if (!streamEnabled[i]) {


### PR DESCRIPTION
Remove redundant computation of the stream type. It is computed just above with guards.

Correcting a prior patch to this same code, perhaps my merge error sorry.