### PR TITLE
Qt gui: correct opening of the monitor port

### DIFF
--- a/app/qtapp/rtknavi_qt/navimain.cpp
+++ b/app/qtapp/rtknavi_qt/navimain.cpp
@@ -602,7 +602,7 @@ void MainWindow::showOptionsDialog()
             strclose(&monistr);
         }
         // reopen monitor stream
-        openMonitorPort(monitorPort_old);
+        openMonitorPort(optDialog->monitorPort);
     }
 }
 // callback on button-input-streams -----------------------------------------


### PR DESCRIPTION
The code checks for a change in the monitor port and closes the old port and should be opening then new port.