### PR TITLE
console apps: add a --version command line option

### DIFF
--- a/app/consapp/convbin/convbin.c
+++ b/app/consapp/convbin/convbin.c
@@ -535,6 +535,10 @@ static int cmdopts(int argc, char **argv, rnxopt_t *opt, char **ifile,
         else if (!strcmp(argv[i],"-trace" )&&i+1<argc) {
             *trace=atoi(argv[++i]);
         }
+        else if (!strcmp(argv[i], "--version")) {
+            fprintf(stderr, "convbin RTKLIB %s %s\n", VER_RTKLIB, PATCH_LEVEL);
+            exit(0);
+        }
         else if (!strncmp(argv[i],"-",1)) printhelp();
         
         else *ifile=argv[i];

--- a/app/consapp/pos2kml/pos2kml.c
+++ b/app/consapp/pos2kml/pos2kml.c
@@ -80,6 +80,10 @@ int main(int argc, char **argv)
         else if (!strcmp(argv[i],"-i")&&i+i<argc) tint=atof(argv[++i]);
         else if (!strcmp(argv[i],"-q")&&i+i<argc) qflg=atoi(argv[++i]);
         else if (!strcmp(argv[i],"-gpx")) gpx=1;
+        else if (!strcmp(argv[i], "--version")) {
+            fprintf(stderr, "pos2kml RTKLIB %s %s\n", VER_RTKLIB, PATCH_LEVEL);
+            exit(0);
+        }
         else if (*argv[i]=='-') printhelp();
         else if (n<32) infile[n++]=argv[i];
     }

--- a/app/consapp/rnx2rtkp/rnx2rtkp.c
+++ b/app/consapp/rnx2rtkp/rnx2rtkp.c
@@ -180,6 +180,10 @@ int main(int argc, char **argv)
         }
         else if (!strcmp(argv[i],"-y")&&i+1<argc) solopt.sstat=atoi(argv[++i]);
         else if (!strcmp(argv[i],"-x")&&i+1<argc) solopt.trace=atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--version")) {
+            fprintf(stderr, "rnx2rtkp RTKLIB %s %s\n", VER_RTKLIB, PATCH_LEVEL);
+            exit(0);
+        }
         else if (*argv[i]=='-') printhelp();
         else if (n<MAXFILE) infile[n++]=argv[i];
     }

--- a/app/consapp/rtkrcv/rtkrcv.c
+++ b/app/consapp/rtkrcv/rtkrcv.c
@@ -1646,6 +1646,10 @@ int main(int argc, char **argv)
         else if (!strcmp(argv[i],"-r")&&i+1<argc) outstat=atoi(argv[++i]);
         else if (!strcmp(argv[i],"-t")&&i+1<argc) trace=atoi(argv[++i]);
         else if (!strcmp(argv[i],"-sta")&&i+1<argc) strcpy(sta_name,argv[++i]);
+        else if (!strcmp(argv[i], "--version")) {
+            fprintf(stderr, "rtkrcv RTKLIB %s %s\n", VER_RTKLIB, PATCH_LEVEL);
+            exit(0);
+        }
         else printusage();
     }
     if (trace>0) {

--- a/app/consapp/str2str/str2str.c
+++ b/app/consapp/str2str/str2str.c
@@ -278,6 +278,10 @@ int main(int argc, char **argv)
         else if (!strcmp(argv[i],"-b"  )&&i+1<argc) opts[7]=atoi(argv[++i]);
         else if (!strcmp(argv[i],"-fl" )&&i+1<argc) logfile=argv[++i];
         else if (!strcmp(argv[i],"-t"  )&&i+1<argc) trlevel=atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--version")) {
+            fprintf(stderr, "str2str RTKLIB %s %s\n", VER_RTKLIB, PATCH_LEVEL);
+            exit(0);
+        }
         else if (*argv[i]=='-') printhelp();
     }
     if (n<=0) n=1; /* stdout */


### PR DESCRIPTION
Requested here https://github.com/rtklibexplorer/RTKLIB/issues/332

The -v argument is already taken in some apps, so use --version.

Quick suggestion for the output, could do it differently.
