### PR TITLE
Qt gui saveNavigation: modify the guard, use the number of elements

### DIFF
--- a/app/qtapp/rtknavi_qt/navimain.cpp
+++ b/app/qtapp/rtknavi_qt/navimain.cpp
@@ -2380,9 +2380,8 @@ void MainWindow::saveNavigation(nav_t *nav)
     trace(3, "saveNavigation\n");
 
     if (nav == NULL) return;
-    if (nav->eph == NULL) return;
 
-    for (i = 0; i < MAXSAT*2; i++) {
+    for (i = 0; i < nav->n; i++) {
         if (nav->eph[i].ttr.time == 0) continue;
         str = "";
         satno2id(nav->eph[i].sat, id);


### PR DESCRIPTION
Rather than just testing for any nav->eph, iterate over the actual number of nav->eph elements. This also add the ability to save all sets where there are more than the 2 sets currently saved.