### PR TITLE
strsvr: zero the rtcm and raw structs

### DIFF
--- a/app/qtapp/strsvr_qt/mondlg.cpp
+++ b/app/qtapp/strsvr_qt/mondlg.cpp
@@ -30,6 +30,8 @@ StrMonDialog::StrMonDialog(QWidget *parent)
     for (int i = 0; i <= MAXRCVFMT; i++) {
         ui->cBSelectFormat->addItem(formatstrs[i]);
     }
+    memset(&rtcm, 0, sizeof(rtcm));
+    memset(&raw, 0, sizeof(raw));
     rtcm.outtype = raw.outtype = 1;
 }
 //---------------------------------------------------------------------------

--- a/app/winapp/strsvr/mondlg.cpp
+++ b/app/winapp/strsvr/mondlg.cpp
@@ -29,6 +29,8 @@ __fastcall TStrMonDialog::TStrMonDialog(TComponent* Owner)
 	for (int i=0;i<=MAXRCVFMT;i++) {
 		SelFmt->Items->Add(formatstrs[i]);
 	}
+	memset(&rtcm,0,sizeof(rtcm));
+	memset(&raw,0,sizeof(raw));
 	rtcm.outtype=raw.outtype=1;
 }
 //---------------------------------------------------------------------------


### PR DESCRIPTION
If not zero filled then on a format change either free_rtcm or free_raw will be called with a garbage struct and in turn free() will be called with garbage.