### PR TITLE
detslp_dop: hoist use of rtk->opt.nf

### DIFF
--- a/src/rtkpos.c
+++ b/src/rtkpos.c
@@ -731,7 +731,7 @@ static void detslp_gf(rtk_t *rtk, const obsd_t *obs, int i, int j,
 static void detslp_dop(rtk_t *rtk, const obsd_t *obs, const int *ix, int ns,
                        int rcv, const nav_t *nav)
 {
-    int i,ii,f,sat,ndop=0;
+    int i,ii,f,sat,ndop=0,nf=rtk->opt.nf;
     double dph,dpt,mean_dop=0;
     double dopdif[MAXSAT][NFREQ], tt[MAXSAT][NFREQ];
 
@@ -743,7 +743,7 @@ static void detslp_dop(rtk_t *rtk, const obsd_t *obs, const int *ix, int ns,
         ii = ix[i];
         sat=obs[ii].sat;
 
-        for (f=0;f<rtk->opt.nf;f++) {
+        for (f=0;f<nf;f++) {
             dopdif[i][f]=0;tt[i][f]=0.00;
             if (obs[ii].L[f]==0.0||obs[ii].D[f]==0.0||rtk->ssat[sat-1].ph[rcv-1][f]==0.0) continue;
             if (fabs(tt[i][f]=timediff(obs[ii].time,rtk->ssat[sat-1].pt[rcv-1][f]))<DTTOL) continue;
@@ -768,7 +768,7 @@ static void detslp_dop(rtk_t *rtk, const obsd_t *obs, const int *ix, int ns,
     for (i=0;i<ns;i++) {
         sat=obs[ix[i]].sat;
 
-        for (f=0;f<rtk->opt.nf;f++) {
+        for (f=0;f<nf;f++) {
             if (dopdif[i][f]==0.00) continue;
             if (fabs(dopdif[i][f]-mean_dop)>rtk->opt.thresdop) {
                 rtk->ssat[sat-1].slip[f]|=1;


### PR DESCRIPTION
Looks trivial and pointless, but it actually helps the compiler, helps code analysis reason about the code, and some warnings go away.