### PR TITLE
misc udp stream fixes

### DIFF
--- a/app/consapp/rtkrcv/rtkrcv.c
+++ b/app/consapp/rtkrcv/rtkrcv.c
@@ -180,7 +180,7 @@ static const char *pathopts[]={         /* path options help */
 #define CONOPT  "0:dms,1:deg,2:xyz,3:enu,4:pyl"
 #define FLGOPT  "0:off,1:std+2:age/ratio/ns"
 #define ISTOPT  "0:off,1:serial,2:file,3:tcpsvr,4:tcpcli,6:ntripcli,7:ftp,8:http"
-#define OSTOPT  "0:off,1:serial,2:file,3:tcpsvr,4:tcpcli,5:ntripsvr,9:ntripcas"
+#define OSTOPT  "0:off,1:serial,2:file,3:tcpsvr,4:tcpcli,5:ntripsvr,9:ntripcas,11:udpcli"
 #define FMTOPT  "0:rtcm2,1:rtcm3,2:oem4,4:ubx,5:swift,6:hemis,7:skytraq,8:javad,9:nvs,10:binex,11:rt17,12:sbf,14,15:sp3"
 #define NMEOPT  "0:off,1:latlon,2:single"
 #define SOLOPT  "0:llh,1:xyz,2:enu,3:nmea,4:stat"
@@ -935,8 +935,8 @@ static void prstream(vt_t *vt)
         "log rover","log base","log corr","monitor"
     };
     const char *type[]={
-        "-","serial","file","tcpsvr","tcpcli","udp","ntrips","ntripc","ftp",
-        "http","ntripcas"
+        "-","serial","file","tcpsvr","tcpcli","ntrips","ntripc","ftp",
+        "http","ntripcas","udpsvr","udpcli","membuf"
     };
     const char *fmt[]={"rtcm2","rtcm3","oem4","","ubx","swift","hemis","skytreq",
                        "javad","nvs","binex","rt17","sbf","","","sp3",""};

--- a/app/consapp/str2str/str2str.c
+++ b/app/consapp/str2str/str2str.c
@@ -69,6 +69,8 @@ static const char *help[]={
 "    ntrip client : ntrip://[user[:passwd]@]addr[:port][/mntpnt]",
 "    ntrip server : ntrips://[:passwd@]addr[:port]/mntpnt[:str] (only out)",
 "    ntrip caster : ntripc://[user:passwd@][:port]/mntpnt[:srctbl] (only out)",
+"    udp server   : udpsvr://:port (only in)",
+"    udp client   : udpcli://addr:port (only out)",
 "    file         : [file://]path[::T][::+start][::xseppd][::S=swap]",
 "",
 "  format",
@@ -184,6 +186,7 @@ static int decodepath(const char *path, int *type, char *strpath, int *fmt)
     else if (!strncmp(path,"ntrip", 5)) *type=STR_NTRIPCLI;
     else if (!strncmp(path,"file",  4)) *type=STR_FILE;
     else if (!strncmp(path,"udpsvr",  6)) *type=STR_UDPSVR;
+    else if (!strncmp(path,"udpcli",  6)) *type=STR_UDPCLI;
     else {
         fprintf(stderr,"stream path error: %s\n",buff);
         return 0;

--- a/app/qtapp/strsvr_qt/svrmain.cpp
+++ b/app/qtapp/strsvr_qt/svrmain.cpp
@@ -240,7 +240,7 @@ void MainForm::showInputOptions()
         case 1: tcpClientOptions(0, 1); break; // TCP Client
         case 2: tcpServerOptions(0, 2); break; // TCP Server
         case 3: ntripClientOptions(0, 3); break; // Ntrip Client
-        case 4: udpServerOptions(0, 6); break;  // UDP Server
+        case 4: udpServerOptions(0, 4); break;  // UDP Server
         case 5: fileOptions(0, 0); break;
     }
 }
@@ -591,7 +591,7 @@ void MainForm::stopServer()
                          STR_FTP, STR_HTTP};
     const int outputTypes[] = {
         STR_NONE, STR_SERIAL, STR_TCPCLI, STR_TCPSVR, STR_NTRIPSVR, STR_NTRIPCAS,
-        STR_FILE
+        STR_UDPCLI, STR_FILE
     };
     int streamTypes[MAXSTR];
 
@@ -635,9 +635,9 @@ void MainForm::stopServer()
 void MainForm::updateStreamMonitor()
 {
     static const QString types[] = {
-        tr("None"), tr("Serial"), tr("File"), tr("TCP Server"), tr("TCP Client"), tr("UDP"), tr("Ntrip Sever"),
+        tr("None"), tr("Serial"), tr("File"), tr("TCP Server"), tr("TCP Client"), tr("Ntrip Sever"),
         tr("Ntrip Client"), tr("FTP"), tr("HTTP"), tr("Ntrip Caster"), tr("UDP Server"),
-        tr("UDP Client")
+        tr("UDP Client"), tr("Mem Buffer")
     };
     unsigned char *msg = 0;
     char *p;
@@ -863,7 +863,7 @@ void MainForm::loadOptions()
 
     // paths
     for (int i = 0; i < MAXSTR; i++)
-        for (int j = 0; j < 4; j++)
+        for (int j = 0; j < 7; j++)
             paths[i][j] = settings.value(QString("path/path_%1_%2").arg(i).arg(j), "").toString();
 
     for (int i=0;i<MAXSTR;i++) {
@@ -953,7 +953,7 @@ void MainForm::saveOptions()
             settings.setValue(QString("tcpip/cmdena_%1_%2").arg(i).arg(j), commandsEnabledTcp[i][j]);
         }
     for (int i = 0; i < MAXSTR; i++)
-        for (int j = 0; j < 4; j++)
+        for (int j = 0; j < 7; j++)
             settings.setValue(QString("path/path_%1_%2").arg(i).arg(j), paths[i][j]);
 
     for (int i = 0; i < MAXSTR; i++)

--- a/app/qtapp/strsvr_qt/svrmain.h
+++ b/app/qtapp/strsvr_qt/svrmain.h
@@ -51,7 +51,7 @@ protected:
 
 private:
     QString iniFile;
-    QString paths[MAXSTR][4], commands[MAXSTR][3], commandsTcp[MAXSTR][3];
+    QString paths[MAXSTR][7], commands[MAXSTR][3], commandsTcp[MAXSTR][3];
     QString tcpHistory[MAXHIST], tcpMountpointHistory[MAXHIST];
     QString conversionMessage[MAXSTR - 1], conversionOptions[MAXSTR - 1];
     QString pathLog[MAXSTR];

--- a/src/stream.c
+++ b/src/stream.c
@@ -2132,7 +2132,7 @@ static udp_t *openudpsvr(const char *path, char *msg)
     
     if (sscanf(sport,"%d",&port)<1) {
         sprintf(msg,"port error: %s",sport);
-        tracet(2,"openudpsvr: port error port=%s\n",port);
+        tracet(2,"openudpsvr: port error port=%s\n",sport);
         return NULL;
     }
     return genudp(0,port,"",msg);


### PR DESCRIPTION
stream.c: fix UDP trace format, was passing an int for a string pointer.

rtkrcv: correct the stream types array of strings; can add 'UDP client' as an output option.

str2str: add 'UDP client' as a stream output option.

QT str2str: correct the size of the paths[] array, there are 7 paths not 4, correcting an OOB access. Save and load all 7 path options to the ini file. Correct an outputTypes[] array which was missing an entry for UDP client causing an OOB for STR_FILE. Correct an index into the paths for the input options, the UDP input option is index 4.