### PR TITLE
rtknavi_qt mondlg: show nav offset is already guarded

### DIFF
--- a/app/qtapp/rtknavi_qt/mondlg.cpp
+++ b/app/qtapp/rtknavi_qt/mondlg.cpp
@@ -1127,7 +1127,7 @@ void MonitorDialog::showNavigationsGPS()
 	gtime_t time;
     QString s;
     char tstr[64], id[32];
-    int i, k, n, nsat, prn, off = ui->cBSelectEphemeris->currentIndex() ? MAXSAT : 0;
+    int i, k, n, nsat, prn, off = ui->cBSelectEphemeris->currentIndex();
     bool valid;
     int sys = sys_tbl[ui->cBSelectSingleNavigationSystem->currentIndex() + 1];
 
@@ -1241,7 +1241,7 @@ void MonitorDialog::showGlonassNavigations()
 	gtime_t time;
     QString s;
     char tstr[64], id[32];
-    int i, n, nsat, valid, prn, off = ui->cBSelectEphemeris->currentIndex() ? NSATGLO : 0;
+    int i, n, nsat, valid, prn, off = ui->cBSelectEphemeris->currentIndex();
 
     geph_t geph0;
     memset(&geph0, 0, sizeof(geph_t));
@@ -1334,7 +1334,7 @@ void MonitorDialog::showSbsNavigations()
 {
     seph_t seph[MAXPRNSBS - MINPRNSBS + 1];
 	gtime_t time;
-    int i, n, nsat, valid, prn, off = ui->cBSelectEphemeris->currentIndex() ? NSATSBS : 0;
+    int i, n, nsat, valid, prn, off = ui->cBSelectEphemeris->currentIndex();
     char tstr[64], id[32];
 
     seph_t seph0;


### PR DESCRIPTION
The eph off need only be multiplied by the number of sats in each set once, and there can be more that two sets, the UI supports 4 sets and at most 4 sets are currently used in the library, and the code already guards against the offset begin OOB unless there was an issue with negative indexes.

See for example the current guard and use:
```
if (i + off * MAXSAT < rtksvr->nav.n)
   eph[i] = rtksvr->nav.eph[i + off * MAXSAT];

```