### PR TITLE
str2str, rtkrcv: add support to detach from the console

### DIFF
--- a/app/consapp/rtkrcv/rtkrcv.c
+++ b/app/consapp/rtkrcv/rtkrcv.c
@@ -63,6 +63,7 @@
 #define NAVIFILE    "rtkrcv.nav"        /* navigation save file */
 #define STATFILE    "rtkrcv_%Y%m%d%h%M.stat"  /* solution status file */
 #define TRACEFILE   "rtkrcv_%Y%m%d%h%M.trace" /* debug trace file */
+#define LOGFILE     "rtkrcv_%Y%m%d%h%M.log"   /* Deamon log file */
 #define INTKEEPALIVE 1000               /* keep alive interval (ms) */
 
 #define ESC_CLEAR   "\033[H\033[2J"     /* ansi/vt100 escape: erase screen */
@@ -137,7 +138,9 @@ static const char *usage[]={
     "  -w pwd     login password for remote console (\"\": no password)",
     "  -r level   output solution status file (0:off,1:states,2:residuals)",
     "  -t level   debug trace level (0:off,1-5:on)",
-    "  -sta sta   station name for receiver dcb"
+    "  -sta sta   station name for receiver dcb",
+    "  --deamon   detach from the console",
+    "  --version  print the version and exit"
 };
 static const char *helptxt[]={
     "start                 : start rtk server",
@@ -1373,7 +1376,10 @@ static void *con_thread(void *arg)
     while (con->state) {
         
         /* output prompt */
-        if (!vt_puts(con->vt,CMDPROMPT)) break;
+        if (!vt_puts(con->vt,CMDPROMPT)) {
+            con->state = 0;
+            break;
+        }
         
         /* input command */
         if (!vt_gets(con->vt,buff,sizeof(buff))) break;
@@ -1428,6 +1434,7 @@ static void *con_thread(void *arg)
         }
     }
     vt_close(con->vt);
+    con->vt = NULL;
     return NULL;
 }
 /* open console --------------------------------------------------------------*/
@@ -1525,9 +1532,42 @@ static void accept_sock(int ssock, con_t **con)
     trace(2,"remote console connection refused. addr=%s\n",
          inet_ntoa(addr.sin_addr));
 }
+
+static void deamonise(void)
+{
+#ifndef WIN32
+    /* In case we were not started in the background, fork and let the parent
+     * exit.  Guarantees that the child is not a process group leader. */
+    int childpid = fork();
+    if (childpid < 0) {
+        perror("fork\n");
+        _exit(1);
+    } else if (childpid > 0) {
+        /* parent */
+      _exit(0);
+    }
+
+    /* Make ourselves the leader of a new process group with no controlling
+     * terminal. */
+    if (setsid() < 0) {
+        perror("setsid\n");
+        _exit(1);
+    }
+
+    for (int fd = 0; fd < 10; fd++) close(fd);
+
+    open("/dev/null", O_RDWR);
+    gtime_t time = utc2gpst(timeget());
+    char path[1024];
+    reppath(LOGFILE, path, time, "", "");
+    open(path, O_WRONLY|O_CREAT|O_TRUNC, 0666);
+    dup(1);
+#endif
+}
+
 /* rtkrcv main -----------------------------------------------------------------
 * synopsis
-*     rtkrcv [-s][-p port][-d dev][-o file][-r level][-t level][-sta sta]
+*     rtkrcv [-s][-nc][-p port][-d dev][-o file][-r level][-t level][-sta sta]
 *
 * description
 *     A command line version of the real-time positioning AP by rtklib. To start
@@ -1541,8 +1581,13 @@ static void accept_sock(int ssock, con_t **con)
 *     set, load or save command on the console. To shutdown the program, use
 *     shutdown command on the console or send USR2 signal to the process.
 *
+*     The --deamon option implies no console. When used with -s or -nc the RTK
+*     server is started on program startup. A telnet console can be used with
+*     this option to start and control the RTK server.
+*
 * option
 *     -s         start RTK server on program startup
+*     -nc        start RTK server on program startup with no console
 *     -p port    port number for telnet console
 *     -m port    port number for monitor stream
 *     -d dev     terminal device for console
@@ -1551,6 +1596,8 @@ static void accept_sock(int ssock, con_t **con)
 *     -r level   output solution status file (0:off,1:states,2:residuals)
 *     -t level   debug trace level (0:off,1-5:on)
 *     -sta sta   station name for receiver dcb
+*     --deamon   detach from the console
+*     --version  prints the version and exits
 *
 * command
 *     start
@@ -1634,6 +1681,7 @@ int main(int argc, char **argv)
     con_t *con[MAXCON]={0};
     int i,port=0,outstat=0,trace=0,sock=0;
     char *dev="",file[MAXSTR]="";
+    int deamon=0;
     
     for (i=1;i<argc;i++) {
         if      (!strcmp(argv[i],"-s")) start|=1; /* console */
@@ -1646,12 +1694,14 @@ int main(int argc, char **argv)
         else if (!strcmp(argv[i],"-r")&&i+1<argc) outstat=atoi(argv[++i]);
         else if (!strcmp(argv[i],"-t")&&i+1<argc) trace=atoi(argv[++i]);
         else if (!strcmp(argv[i],"-sta")&&i+1<argc) strcpy(sta_name,argv[++i]);
+        else if (!strcmp(argv[i], "--deamon")) deamon=1;
         else if (!strcmp(argv[i], "--version")) {
             fprintf(stderr, "rtkrcv RTKLIB %s %s\n", VER_RTKLIB, PATCH_LEVEL);
             exit(0);
         }
         else printusage();
     }
+    if (deamon) deamonise();
     if (trace>0) {
         traceopen(TRACEFILE);
         tracelevel(trace);
@@ -1689,9 +1739,10 @@ int main(int argc, char **argv)
             traceclose();
             return EXIT_FAILURE;
         }
-    } else if (start&2) { /* start without console */
+    }
+    if (start&2) { /* Start without console */
         startsvr(NULL); 
-    } else  {  
+    } else if (!deamon) {
         /* open device for local console */
         if (!(con[0]=con_open(0,dev))) {
             fprintf(stderr,"console open error dev=%s\n",dev);

--- a/app/consapp/str2str/str2str.c
+++ b/app/consapp/str2str/str2str.c
@@ -29,13 +29,16 @@
 *           2017/05/26  1.17 add input format tersus
 *           2020/11/30  1.18 support api change strsvrstart(),strsvrstat()
 *-----------------------------------------------------------------------------*/
+#define _POSIX_C_SOURCE 199506
+#include <fcntl.h>
 #include <signal.h>
 #include <unistd.h>
 #include "rtklib.h"
 
 #define PRGNAME     "str2str"          /* program name */
 #define MAXSTR      5                  /* max number of streams */
-#define TRFILE      "str2str.trace"    /* trace file */
+#define TRACEFILE   "str2str_%Y%m%d%h%M.trace" /* Debug trace file */
+#define LOGFILE     "str2str_%Y%m%d%h%M.log"   /* Deamon log file */
 
 /* global variables ----------------------------------------------------------*/
 static strsvr_t strsvr;                /* stream server */
@@ -109,6 +112,8 @@ static const char *help[]={
 " -b  str_no        relay back messages from output str to input str [no]",
 " -t  level         trace level [0]",
 " -fl file          log file [str2str.trace]",
+" --deamon          detach from the console",
+" --version         print version",
 " -h                print help",
 "",
 "  command file cheat sheet:",
@@ -210,6 +215,39 @@ static void readcmd(const char *file, char *cmd, int type)
     }
     fclose(fp);
 }
+
+static void deamonise(void)
+{
+#ifndef WIN32
+    /* In case we were not started in the background, fork and let the parent
+     * exit.  Guarantees that the child is not a process group leader. */
+    int childpid = fork();
+    if (childpid < 0) {
+        perror("fork\n");
+        _exit(1);
+    } else if (childpid > 0) {
+        /* parent */
+        _exit(0);
+    }
+
+    /* Make ourselves the leader of a new process group with no controlling
+     * terminal. */
+    if (setsid() < 0) {
+        perror("setsid\n");
+        _exit(1);
+    }
+
+    for (int fd = 0; fd < 10; fd++) close(fd);
+
+    open("/dev/null", O_RDWR);
+    gtime_t time = utc2gpst(timeget());
+    char path[1024];
+    reppath(LOGFILE, path, time, "", "");
+    open(path, O_WRONLY|O_CREAT|O_TRUNC, 0666);
+    dup(1);
+#endif
+}
+
 /* str2str -------------------------------------------------------------------*/
 int main(int argc, char **argv)
 {
@@ -227,6 +265,7 @@ int main(int argc, char **argv)
     int i,j,n=0,dispint=5000,trlevel=0,opts[]={10000,10000,2000,32768,10,0,30,0};
     int types[MAXSTR]={STR_FILE,STR_FILE},stat[MAXSTR]={0},log_stat[MAXSTR]={0};
     int byte[MAXSTR]={0},bps[MAXSTR]={0},fmts[MAXSTR]={0},sta=0;
+    int deamon=0;
     
     for (i=0;i<MAXSTR;i++) {
         paths[i]=s1[i];
@@ -278,6 +317,7 @@ int main(int argc, char **argv)
         else if (!strcmp(argv[i],"-b"  )&&i+1<argc) opts[7]=atoi(argv[++i]);
         else if (!strcmp(argv[i],"-fl" )&&i+1<argc) logfile=argv[++i];
         else if (!strcmp(argv[i],"-t"  )&&i+1<argc) trlevel=atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--deamon")) deamon=1;
         else if (!strcmp(argv[i], "--version")) {
             fprintf(stderr, "str2str RTKLIB %s %s\n", VER_RTKLIB, PATCH_LEVEL);
             exit(0);
@@ -313,6 +353,7 @@ int main(int argc, char **argv)
         matcpy(conv[i]->out.sta.pos,stapos,3,1);
         matcpy(conv[i]->out.sta.del,stadel,3,1);
     }
+    if (deamon) deamonise();
     signal(SIGTERM,sigfunc);
     signal(SIGINT ,sigfunc);
     signal(SIGHUP ,SIG_IGN);
@@ -321,7 +362,7 @@ int main(int argc, char **argv)
     strsvrinit(&strsvr,n+1);
     
     if (trlevel>0) {
-        traceopen(*logfile?logfile:TRFILE);
+        traceopen(*logfile?logfile:TRACEFILE);
         tracelevel(trlevel);
     }
     fprintf(stderr,"stream server start\n");


### PR DESCRIPTION
Adds the --deamon option. The standard output and error are written to a new log file with this option. For rtkrcv also allow telnet consoles in general.

Not implemented for Windows, it will just use no console but not detach from the console.

This is a feature addition, with running in the background in mind, for example from a OS startup script, or when wish it to not exit when logging out.

For rtkrcv it could usefully be used with the -s option to startup RTK, but can also be started from a telnet console.
