### PR TITLE
rinex, rtcm, rtksvr: keep the nav eph max consistent with the allocation

### DIFF
--- a/src/rcvraw.c
+++ b/src/rcvraw.c
@@ -1347,10 +1347,10 @@ extern int init_raw(raw_t *raw, int format)
     }
     raw->obs.n =0;
     raw->obuf.n=0;
-    raw->nav.n =MAXSAT*2;
-    raw->nav.na=MAXSAT;
-    raw->nav.ng=NSATGLO;
-    raw->nav.ns=NSATSBS*2;
+    raw->nav.n =raw->nav.nmax =MAXSAT*2;
+    raw->nav.na=raw->nav.namax=MAXSAT;
+    raw->nav.ng=raw->nav.ngmax=NSATGLO;
+    raw->nav.ns=raw->nav.nsmax=NSATSBS*2;
     for (i=0;i<MAXOBS   ;i++) raw->obs.data [i]=data0;
     for (i=0;i<MAXOBS   ;i++) raw->obuf.data[i]=data0;
     for (i=0;i<MAXSAT*2 ;i++) raw->nav.eph  [i]=eph0;
@@ -1388,10 +1388,10 @@ extern void free_raw(raw_t *raw)
     
     free(raw->obs.data ); raw->obs.data =NULL; raw->obs.n =0;
     free(raw->obuf.data); raw->obuf.data=NULL; raw->obuf.n=0;
-    free(raw->nav.eph  ); raw->nav.eph  =NULL; raw->nav.n =0;
-    free(raw->nav.alm  ); raw->nav.alm  =NULL; raw->nav.na=0;
-    free(raw->nav.geph ); raw->nav.geph =NULL; raw->nav.ng=0;
-    free(raw->nav.seph ); raw->nav.seph =NULL; raw->nav.ns=0;
+    free(raw->nav.eph  ); raw->nav.eph  =NULL; raw->nav.n =raw->nav.nmax =0;
+    free(raw->nav.alm  ); raw->nav.alm  =NULL; raw->nav.na=raw->nav.namax=0;
+    free(raw->nav.geph ); raw->nav.geph =NULL; raw->nav.ng=raw->nav.ngmax=0;
+    free(raw->nav.seph ); raw->nav.seph =NULL; raw->nav.ns=raw->nav.nsmax=0;
     
     /* free receiver dependent data */
     switch (raw->format) {

--- a/src/rinex.c
+++ b/src/rinex.c
@@ -1832,9 +1832,10 @@ extern int init_rnxctr(rnxctr_t *rnx)
     rnx->sys=rnx->tsys=0;
     for (i=0;i<RNX_NUMSYS;i++) for (j=0;j<MAXOBSTYPE;j++) rnx->tobs[i][j][0]='\0';
     rnx->obs.n=0;
-    rnx->nav.n=MAXSAT*2;
-    rnx->nav.ng=NSATGLO;
-    rnx->nav.ns=NSATSBS*2;
+    rnx->obs.nmax=MAXOBS;
+    rnx->nav.n=rnx->nav.nmax=MAXSAT*2;
+    rnx->nav.ng=rnx->nav.ngmax=NSATGLO;
+    rnx->nav.ns=rnx->nav.nsmax=NSATSBS*2;
     for (i=0;i<MAXOBS   ;i++) rnx->obs.data[i]=data0;
     for (i=0;i<MAXSAT*2 ;i++) rnx->nav.eph [i]=eph0;
     for (i=0;i<NSATGLO  ;i++) rnx->nav.geph[i]=geph0;
@@ -1853,10 +1854,10 @@ extern void free_rnxctr(rnxctr_t *rnx)
 {
     trace(3,"free_rnxctr:\n");
 
-    free(rnx->obs.data); rnx->obs.data=NULL; rnx->obs.n =0;
-    free(rnx->nav.eph ); rnx->nav.eph =NULL; rnx->nav.n =0;
-    free(rnx->nav.geph); rnx->nav.geph=NULL; rnx->nav.ng=0;
-    free(rnx->nav.seph); rnx->nav.seph=NULL; rnx->nav.ns=0;
+    free(rnx->obs.data); rnx->obs.data=NULL; rnx->obs.n =rnx->obs.nmax =0;
+    free(rnx->nav.eph ); rnx->nav.eph =NULL; rnx->nav.n =rnx->nav.nmax =0;
+    free(rnx->nav.geph); rnx->nav.geph=NULL; rnx->nav.ng=rnx->nav.ngmax=0;
+    free(rnx->nav.seph); rnx->nav.seph=NULL; rnx->nav.ns=rnx->nav.nsmax=0;
 }
 /* open RINEX data -------------------------------------------------------------
 * fetch next RINEX message and input a message from file

--- a/src/rtcm.c
+++ b/src/rtcm.c
@@ -104,6 +104,7 @@ extern int init_rtcm(rtcm_t *rtcm)
     rtcm->obs.data=NULL;
     rtcm->nav.eph =NULL;
     rtcm->nav.geph=NULL;
+    rtcm->nav.seph=NULL;
     
     /* reallocate memory for observation and ephemeris buffer */
     if (!(rtcm->obs.data=(obsd_t *)malloc(sizeof(obsd_t)*MAXOBS))||
@@ -113,8 +114,9 @@ extern int init_rtcm(rtcm_t *rtcm)
         return 0;
     }
     rtcm->obs.n=0;
-    rtcm->nav.n=MAXSAT*2;
-    rtcm->nav.ng=MAXPRNGLO;
+    rtcm->nav.n=rtcm->nav.nmax=MAXSAT*2;
+    rtcm->nav.ng=rtcm->nav.ngmax=MAXPRNGLO;
+    rtcm->nav.ns=rtcm->nav.nsmax=0;
     for (i=0;i<MAXOBS   ;i++) rtcm->obs.data[i]=data0;
     for (i=0;i<MAXSAT*2 ;i++) rtcm->nav.eph [i]=eph0;
     for (i=0;i<MAXPRNGLO;i++) rtcm->nav.geph[i]=geph0;
@@ -131,8 +133,8 @@ extern void free_rtcm(rtcm_t *rtcm)
     
     /* free memory for observation and ephemeris buffer */
     free(rtcm->obs.data); rtcm->obs.data=NULL; rtcm->obs.n=0;
-    free(rtcm->nav.eph ); rtcm->nav.eph =NULL; rtcm->nav.n=0;
-    free(rtcm->nav.geph); rtcm->nav.geph=NULL; rtcm->nav.ng=0;
+    free(rtcm->nav.eph ); rtcm->nav.eph =NULL; rtcm->nav.n=rtcm->nav.nmax=0;
+    free(rtcm->nav.geph); rtcm->nav.geph=NULL; rtcm->nav.ng=rtcm->nav.ngmax=0;
 }
 /* input RTCM 2 message from stream --------------------------------------------
 * fetch next RTCM 2 message and input a message from byte stream

--- a/src/rtksvr.c
+++ b/src/rtksvr.c
@@ -730,22 +730,25 @@ extern int rtksvrinit(rtksvr_t *svr)
     for (i=0;i<3;i++) svr->rb_ave[i]=0.0;
     
     memset(&svr->nav,0,sizeof(nav_t));
+    memset(&svr->obs,0,sizeof(svr->obs));
     if (!(svr->nav.eph =(eph_t  *)malloc(sizeof(eph_t )*MAXSAT*4 ))||
         !(svr->nav.geph=(geph_t *)malloc(sizeof(geph_t)*NSATGLO*2))||
         !(svr->nav.seph=(seph_t *)malloc(sizeof(seph_t)*NSATSBS*2))) {
         tracet(1,"rtksvrinit: malloc error\n");
+        rtksvrfree(svr);
         return 0;
     }
     for (i=0;i<MAXSAT*4 ;i++) svr->nav.eph [i]=eph0;
     for (i=0;i<NSATGLO*2;i++) svr->nav.geph[i]=geph0;
     for (i=0;i<NSATSBS*2;i++) svr->nav.seph[i]=seph0;
-    svr->nav.n =MAXSAT *2;
-    svr->nav.ng=NSATGLO*2;
-    svr->nav.ns=NSATSBS*2;
+    svr->nav.n =svr->nav.nmax =MAXSAT *2;
+    svr->nav.ng=svr->nav.ngmax=NSATGLO*2;
+    svr->nav.ns=svr->nav.nsmax=NSATSBS*2;
     
     for (i=0;i<3;i++) for (j=0;j<MAXOBSBUF;j++) {
         if (!(svr->obs[i][j].data=(obsd_t *)malloc(sizeof(obsd_t)*MAXOBS))) {
             tracet(1,"rtksvrinit: malloc error\n");
+            rtksvrfree(svr);
             return 0;
         }
     }


### PR DESCRIPTION
Some of these paths make a single static allocation, so had ignored maintaining the maximum size of the allocations, and that was adequate, but lets maintain the maximum.

rtksrv: free these allocations on an allocation failure.

Trying to keep the state initialised, if only for monitors etc inspecting the state.
