### PR TITLE
rcvraw decode_frame_alm: use uint32_t as appropriate

### DIFF
--- a/src/rcvraw.c
+++ b/src/rcvraw.c
@@ -1188,7 +1188,8 @@ static int decode_alm_qzs(const uint8_t *buff, alm_t *alm)
 /* decode GPS/QZSS almanac/health --------------------------------------------*/
 static int decode_frame_alm(const uint8_t *buff, alm_t *alm)
 {
-    int frm,dataid,ret=0;
+    uint32_t frm,dataid;
+    int ret=0;
     
     trace(4,"decode_frame_alm:\n");
     


### PR DESCRIPTION
The results from getbitu() were being assigned or compared to signed integers. This quietens some warnings.