### PR TITLE
rtksrv: have stats out streams respect the stats level

### DIFF
--- a/app/consapp/rtkrcv/rtkrcv.c
+++ b/app/consapp/rtkrcv/rtkrcv.c
@@ -1229,6 +1229,7 @@ static void cmd_set(char **args, int narg, vt_t *vt)
         return;
     }
     getsysopts(&prcopt,solopt,&filopt);
+    solopt[1]=solopt[0];
     
     vt_printf(vt,"option %s changed.",opt->name);
     if (strncmp(opt->name,"console",7)) {
@@ -1256,6 +1257,7 @@ static void cmd_load(char **args, int narg, vt_t *vt)
         return;
     }
     getsysopts(&prcopt,solopt,&filopt);
+    solopt[1]=solopt[0];
     
     if (!loadopts(file,rcvopts)) {
         vt_printf(vt,"no options file: %s\n",file);
@@ -1677,6 +1679,9 @@ static void deamonise(void)
 *     Short form of a command is allowed. In case of the short form, the
 *     command is distinguished according to header characters.
 *     
+*     The -r argument only affects the status file. The status output streams
+*     take their level from the out-outstat option.
+*
 *-----------------------------------------------------------------------------*/
 int main(int argc, char **argv)
 {
@@ -1720,6 +1725,8 @@ int main(int argc, char **argv)
         fprintf(stderr,"no options file: %s. defaults used\n",file);
     }
     getsysopts(&prcopt,solopt,&filopt);
+    /* Copy the system options for the second output solution stream */
+    solopt[1]=solopt[0];
     
     /* read navigation data */
     if (!readnav(NAVIFILE,&svr.nav)) {

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1814,7 +1814,7 @@ EXPORT void rtkfree(rtk_t *rtk);
 EXPORT int  rtkpos (rtk_t *rtk, const obsd_t *obs, int nobs, const nav_t *nav);
 EXPORT int  rtkopenstat(const char *file, int level);
 EXPORT void rtkclosestat(void);
-EXPORT int  rtkoutstat(rtk_t *rtk, char *buff);
+EXPORT int  rtkoutstat(rtk_t *rtk, int level, char *buff);
 
 /* precise point positioning -------------------------------------------------*/
 EXPORT void pppos(rtk_t *rtk, const obsd_t *obs, int n, const nav_t *nav);

--- a/src/rtkpos.c
+++ b/src/rtkpos.c
@@ -213,92 +213,113 @@ extern void rtkclosestat(void)
     file_stat[0]='\0';
     statlevel=0;
 }
-/* write solution status to buffer -------------------------------------------*/
-extern int rtkoutstat(rtk_t *rtk, char *buff)
+/* Write solution status to buffer -------------------------------------------*/
+extern int rtkoutstat(rtk_t *rtk, int level, char *buff)
 {
-    ssat_t *ssat;
-    double tow,pos[3],vel[3],acc[3],vela[3]={0},acca[3]={0},xa[3];
-    int i,j,week,est,nfreq,nf=NF(&rtk->opt);
-    char id[32],*p=buff;
-    
-    if (rtk->sol.stat==SOLQ_NONE) {
+    if (level<=0||rtk->sol.stat==SOLQ_NONE) {
         return 0;
     }
-    /* write ppp solution status to buffer */
+
+    ssat_t *ssat;
+    double pos[3],vel[3],acc[3],vela[3]={0},acca[3]={0},xa[3];
+    int week,nf=NF(&rtk->opt);
+    char id[8],*p=buff;
+
+    int est=rtk->opt.mode>=PMODE_DGPS;
+    int nfreq=est?nf:1;
+    double tow=time2gpst(rtk->sol.time,&week);
+
     if (rtk->opt.mode>=PMODE_PPP_KINEMA) {
-        return pppoutstat(rtk,buff);
-    }
-    est=rtk->opt.mode>=PMODE_DGPS;
-    nfreq=est?nf:1;
-    tow=time2gpst(rtk->sol.time,&week);
+        /* Write ppp solution status to buffer */
+        p+=pppoutstat(rtk,buff);
+    } else {
+        /* Receiver position */
+        if (est) {
+            for (int i=0;i<3;i++) xa[i]=i<rtk->na?rtk->xa[i]:0.0;
+            p+=sprintf(p,"$POS,%d,%.3f,%d,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f\n",week,tow,
+                       rtk->sol.stat,rtk->x[0],rtk->x[1],rtk->x[2],xa[0],xa[1],
+                       xa[2]);
+        }
+        else {
+            p+=sprintf(p,"$POS,%d,%.3f,%d,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f\n",week,tow,
+                       rtk->sol.stat,rtk->sol.rr[0],rtk->sol.rr[1],rtk->sol.rr[2],
+                       0.0,0.0,0.0);
+        }
+        /* Receiver velocity and acceleration */
+        if (est&&rtk->opt.dynamics) {
+            ecef2pos(rtk->sol.rr,pos);
+            ecef2enu(pos,rtk->x+3,vel);
+            ecef2enu(pos,rtk->x+6,acc);
+            if (rtk->na>=6) ecef2enu(pos,rtk->xa+3,vela);
+            if (rtk->na>=9) ecef2enu(pos,rtk->xa+6,acca);
+            p+=sprintf(p,"$VELACC,%d,%.3f,%d,%.4f,%.4f,%.4f,%.5f,%.5f,%.5f,%.4f,%.4f,%.4f,%.5f,%.5f,%.5f\n",
+                       week,tow,rtk->sol.stat,vel[0],vel[1],vel[2],acc[0],acc[1],
+                       acc[2],vela[0],vela[1],vela[2],acca[0],acca[1],acca[2]);
+        }
+        else {
+            ecef2pos(rtk->sol.rr,pos);
+            ecef2enu(pos,rtk->sol.rr+3,vel);
+            p+=sprintf(p,"$VELACC,%d,%.3f,%d,%.4f,%.4f,%.4f,%.5f,%.5f,%.5f,%.4f,%.4f,%.4f,%.5f,%.5f,%.5f\n",
+                       week,tow,rtk->sol.stat,vel[0],vel[1],vel[2],
+                       0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0);
+        }
+        /* Receiver clocks */
+        p+=sprintf(p,"$CLK,%d,%.3f,%d,%d,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f\n",
+                   week,tow,rtk->sol.stat,1,rtk->sol.dtr[0]*1E9,rtk->sol.dtr[1]*1E9,
+                   rtk->sol.dtr[2]*1E9,rtk->sol.dtr[3]*1E9,
+                   rtk->sol.dtr[4]*1E9,rtk->sol.dtr[5]*1E9);
 
-    /* receiver position */
-    if (est) {
-        for (i=0;i<3;i++) xa[i]=i<rtk->na?rtk->xa[i]:0.0;
-        p+=sprintf(p,"$POS,%d,%.3f,%d,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f\n",week,tow,
-                   rtk->sol.stat,rtk->x[0],rtk->x[1],rtk->x[2],xa[0],xa[1],
-                   xa[2]);
+        /* Ionospheric parameters */
+        if (est&&rtk->opt.ionoopt==IONOOPT_EST) {
+            for (int i=0;i<MAXSAT;i++) {
+                ssat=rtk->ssat+i;
+                if (!ssat->vs) continue;
+                satno2id(i+1,id);
+                int j=II(i+1,&rtk->opt);
+                xa[0]=j<rtk->na?rtk->xa[j]:0.0;
+                p+=sprintf(p,"$ION,%d,%.3f,%d,%s,%.1f,%.1f,%.4f,%.4f\n",week,tow,
+                           rtk->sol.stat,id,ssat->azel[0]*R2D,ssat->azel[1]*R2D,
+                           rtk->x[j],xa[0]);
+            }
+        }
+        /* Tropospheric parameters */
+        if (est&&(rtk->opt.tropopt>=TROPOPT_EST)) {
+            for (int i=0;i<2;i++) {
+                int j=IT(i,&rtk->opt);
+                xa[0]=j<rtk->na?rtk->xa[j]:0.0;
+                p+=sprintf(p,"$TROP,%d,%.3f,%d,%d,%.4f,%.4f\n",week,tow,
+                           rtk->sol.stat,i+1,rtk->x[j],xa[0]);
+            }
+        }
+        /* Receiver h/w bias */
+        if (est&&rtk->opt.glomodear==GLO_ARMODE_AUTOCAL) {
+            for (int i=0;i<nfreq;i++) {
+                int j=IL(i,&rtk->opt);
+                xa[0]=j<rtk->na?rtk->xa[j]:0.0;
+                p+=sprintf(p,"$HWBIAS,%d,%.3f,%d,%d,%.4f,%.4f\n",week,tow,
+                           rtk->sol.stat,i+1,rtk->x[j],xa[0]);
+            }
+        }
     }
-    else {
-        p+=sprintf(p,"$POS,%d,%.3f,%d,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f\n",week,tow,
-                   rtk->sol.stat,rtk->sol.rr[0],rtk->sol.rr[1],rtk->sol.rr[2],
-                   0.0,0.0,0.0);
-    }
-    /* receiver velocity and acceleration */
-    if (est&&rtk->opt.dynamics) {
-        ecef2pos(rtk->sol.rr,pos);
-        ecef2enu(pos,rtk->x+3,vel);
-        ecef2enu(pos,rtk->x+6,acc);
-        if (rtk->na>=6) ecef2enu(pos,rtk->xa+3,vela);
-        if (rtk->na>=9) ecef2enu(pos,rtk->xa+6,acca);
-        p+=sprintf(p,"$VELACC,%d,%.3f,%d,%.4f,%.4f,%.4f,%.5f,%.5f,%.5f,%.4f,%.4f,%.4f,%.5f,%.5f,%.5f\n",
-                   week,tow,rtk->sol.stat,vel[0],vel[1],vel[2],acc[0],acc[1],
-                   acc[2],vela[0],vela[1],vela[2],acca[0],acca[1],acca[2]);
-    }
-    else {
-        ecef2pos(rtk->sol.rr,pos);
-        ecef2enu(pos,rtk->sol.rr+3,vel);
-        p+=sprintf(p,"$VELACC,%d,%.3f,%d,%.4f,%.4f,%.4f,%.5f,%.5f,%.5f,%.4f,%.4f,%.4f,%.5f,%.5f,%.5f\n",
-                   week,tow,rtk->sol.stat,vel[0],vel[1],vel[2],
-                   0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0);
-    }
-    /* receiver clocks */
-    p+=sprintf(p,"$CLK,%d,%.3f,%d,%d,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f\n",
-               week,tow,rtk->sol.stat,1,rtk->sol.dtr[0]*1E9,rtk->sol.dtr[1]*1E9,
-               rtk->sol.dtr[2]*1E9,rtk->sol.dtr[3]*1E9,
-               rtk->sol.dtr[4]*1E9,rtk->sol.dtr[5]*1E9);
 
-    /* ionospheric parameters */
-    if (est&&rtk->opt.ionoopt==IONOOPT_EST) {
-        for (i=0;i<MAXSAT;i++) {
-            ssat=rtk->ssat+i;
-            if (!ssat->vs) continue;
-            satno2id(i+1,id);
-            j=II(i+1,&rtk->opt);
-            xa[0]=j<rtk->na?rtk->xa[j]:0.0;
-            p+=sprintf(p,"$ION,%d,%.3f,%d,%s,%.1f,%.1f,%.4f,%.4f\n",week,tow,
-                       rtk->sol.stat,id,ssat->azel[0]*R2D,ssat->azel[1]*R2D,
-                       rtk->x[j],xa[0]);
+    if (level <= 1) return (int)(p-buff);
+
+    /* Write residuals and status */
+    for (int i=0;i<MAXSAT;i++) {
+        ssat=rtk->ssat+i;
+        if (!ssat->vs) continue;
+        satno2id(i+1,id);
+        for (int j=0;j<nfreq;j++) {
+            int k=IB(i+1,j,&rtk->opt);
+            p+=sprintf(p,"$SAT,%d,%.3f,%s,%d,%.1f,%.1f,%.4f,%.4f,%d,%.0f,%d,%d,%d,%u,%u,%u,%.2f,%.6f,%.5f\n",
+                       week,tow,id,j+1,ssat->azel[0]*R2D,ssat->azel[1]*R2D,
+                       ssat->resp[j],ssat->resc[j],ssat->vsat[j],ssat->snr_rover[j]*SNR_UNIT,
+                       ssat->fix[j],ssat->slip[j]&3,ssat->lock[j],ssat->outc[j],
+                       ssat->slipc[j],ssat->rejc[j],k<rtk->nx?rtk->x[k]:0,
+                       k<rtk->nx?rtk->P[k+k*rtk->nx]:0,ssat->icbias[j]);
         }
     }
-    /* tropospheric parameters */
-    if (est&&(rtk->opt.tropopt>=TROPOPT_EST)) {
-        for (i=0;i<2;i++) {
-            j=IT(i,&rtk->opt);
-            xa[0]=j<rtk->na?rtk->xa[j]:0.0;
-            p+=sprintf(p,"$TROP,%d,%.3f,%d,%d,%.4f,%.4f\n",week,tow,
-                       rtk->sol.stat,i+1,rtk->x[j],xa[0]);
-        }
-    }
-    /* receiver h/w bias */
-    if (est&&rtk->opt.glomodear==GLO_ARMODE_AUTOCAL) {
-        for (i=0;i<nfreq;i++) {
-            j=IL(i,&rtk->opt);
-            xa[0]=j<rtk->na?rtk->xa[j]:0.0;
-            p+=sprintf(p,"$HWBIAS,%d,%.3f,%d,%d,%.4f,%.4f\n",week,tow,
-                       rtk->sol.stat,i+1,rtk->x[j],xa[0]);
-        }
-    }
+
     return (int)(p-buff);
 }
 /* swap solution status file -------------------------------------------------*/
@@ -327,11 +348,6 @@ static void swapsolstat(void)
 /* output solution status ----------------------------------------------------*/
 static void outsolstat(rtk_t *rtk,const nav_t *nav)
 {
-    ssat_t *ssat;
-    double tow;
-    char buff[MAXSOLMSG+1],id[32];
-    int i,j,k,n,week,nfreq,nf=NF(&rtk->opt);
-
     if (statlevel<=0||!fp_stat||!rtk->sol.stat) return;
 
     trace(3,"outsolstat:\n");
@@ -340,30 +356,11 @@ static void outsolstat(rtk_t *rtk,const nav_t *nav)
     swapsolstat();
 
     /* write solution status */
-    n=rtkoutstat(rtk,buff); buff[n]='\0';
-
+    char buff[2*MAXSOLMSG+1];
+    int n=rtkoutstat(rtk,statlevel,buff);
+    buff[n]='\0';
+    
     fputs(buff,fp_stat);
-
-    if (rtk->sol.stat==SOLQ_NONE||statlevel<=1) return;
-
-    tow=time2gpst(rtk->sol.time,&week);
-    nfreq=rtk->opt.mode>=PMODE_DGPS?nf:1;
-
-    /* write residuals and status */
-    for (i=0;i<MAXSAT;i++) {
-        ssat=rtk->ssat+i;
-        if (!ssat->vs) continue;
-        satno2id(i+1,id);
-        for (j=0;j<nfreq;j++) {
-            k=IB(i+1,j,&rtk->opt);
-            fprintf(fp_stat,"$SAT,%d,%.3f,%s,%d,%.1f,%.1f,%.4f,%.4f,%d,%.0f,%d,%d,%d,%u,%u,%u,%.2f,%.6f,%.5f\n",
-                    week,tow,id,j+1,ssat->azel[0]*R2D,ssat->azel[1]*R2D,
-                    ssat->resp[j],ssat->resc[j],ssat->vsat[j],ssat->snr_rover[j]*SNR_UNIT,
-                    ssat->fix[j],ssat->slip[j]&3,ssat->lock[j],ssat->outc[j],
-                    ssat->slipc[j],ssat->rejc[j],k<rtk->nx?rtk->x[k]:0,
-                    k<rtk->nx?rtk->P[k+k*rtk->nx]:0,ssat->icbias[j]);
-        }
-    }
 }
 /* save error message --------------------------------------------------------*/
 static void errmsg(rtk_t *rtk, const char *format, ...)

--- a/src/rtksvr.c
+++ b/src/rtksvr.c
@@ -71,7 +71,7 @@ static void saveoutbuf(rtksvr_t *svr, uint8_t *buff, int n, int index)
 static void writesol(rtksvr_t *svr, int index)
 {
     solopt_t solopt=solopt_default;
-    uint8_t buff[MAXSOLMSG+1];
+    uint8_t buff[2*MAXSOLMSG+1];
     int i,n;
     
     tracet(4,"writesol: index=%d\n",index);
@@ -82,7 +82,7 @@ static void writesol(rtksvr_t *svr, int index)
             
             /* output solution status */
             rtksvrlock(svr);
-            n=rtkoutstat(&svr->rtk,(char *)buff);
+            n=rtkoutstat(&svr->rtk,svr->solopt[i].sstat,(char *)buff);
             rtksvrunlock(svr);
         }
         else {


### PR DESCRIPTION
The rtkrcv command was not copying the system output options to both of the output stream options, so the second streams always used the initialization options.

Move the output of the stats residuals from outsolstat() to rtkoutstat(), which allows the residuals to be output for the rtksvr output streams when the out-outstat is set to 'residuals'. A new argument is added to rtkoutstat() for the output level.