### PR TITLE
rtklib interface const char

### DIFF
--- a/app/consapp/rnx2rtkp/rnx2rtkp.c
+++ b/app/consapp/rnx2rtkp/rnx2rtkp.c
@@ -101,7 +101,7 @@ int main(int argc, char **argv)
     gtime_t ts={0},te={0};
     double tint=0.0,es[]={2000,1,1,0,0,0},ee[]={2000,12,31,23,59,59},pos[3];
     int i,j,n,ret;
-    char *infile[MAXFILE],*outfile="",*p;
+    const char *infile[MAXFILE],*outfile="",*p;
 
     prcopt.mode  =PMODE_KINEMA;
     prcopt.navsys=0;

--- a/app/consapp/rtkrcv/rtkrcv.c
+++ b/app/consapp/rtkrcv/rtkrcv.c
@@ -477,8 +477,8 @@ static int startsvr(vt_t *vt)
     solopt[1].posf=strfmt[4];
     
     /* start rtk server */
-    if (!rtksvrstart(&svr,svrcycle,buffsize,strtype,paths,strfmt,navmsgsel,
-                     cmds,cmds_periodic,ropts,nmeacycle,nmeareq,npos,&prcopt,
+    if (!rtksvrstart(&svr,svrcycle,buffsize,strtype,(const char **)paths,strfmt,navmsgsel,
+                     (const char **)cmds,(const char **)cmds_periodic,(const char **)ropts,nmeacycle,nmeareq,npos,&prcopt,
                      solopt,&moni,errmsg)) {
         trace(2,"rtk server start error (%s)\n",errmsg);
         vt_printf(vt,"rtk server start error (%s)\n",errmsg);
@@ -505,7 +505,7 @@ static void stopsvr(vt_t *vt)
         else cmds[i]=s[i];
     }
     /* stop rtk server */
-    rtksvrstop(&svr,cmds);
+    rtksvrstop(&svr,(const char **)cmds);
     
     /* execute stop command */
     if (*stopcmd&&(ret=system(stopcmd))) {

--- a/app/consapp/str2str/str2str.c
+++ b/app/consapp/str2str/str2str.c
@@ -379,7 +379,7 @@ int main(int argc, char **argv)
         if (*cmdfile[i]) readcmd(cmdfile[i],cmds_periodic[i],2);
     }
     /* start stream server */
-    if (!strsvrstart(&strsvr,opts,types,paths,logs,conv,cmds,cmds_periodic,
+    if (!strsvrstart(&strsvr,opts,types,(const char **)paths,(const char **)logs,conv,(const char **)cmds,(const char **)cmds_periodic,
                      stapos)) {
         fprintf(stderr,"stream server start error\n");
         return EXIT_FAILURE;
@@ -401,7 +401,7 @@ int main(int argc, char **argv)
         if (*cmdfile[i]) readcmd(cmdfile[i],cmds[i],1);
     }
     /* stop stream server */
-    strsvrstop(&strsvr,cmds);
+    strsvrstop(&strsvr,(const char **)cmds);
     
     for (i=0;i<n;i++) {
         strconvfree(conv[i]);

--- a/app/qtapp/rtkget_qt/getmain.cpp
+++ b/app/qtapp/rtkget_qt/getmain.cpp
@@ -150,9 +150,9 @@ class DownloadThread : public QThread
                 fp = fopen(path, append ? "a" : "w");
             }
             if (test)
-                dl_test(ts, te, ti, urls, nurl, stas, nsta, qPrintable(dir), columnCnt, dateFormat, fp);
+                dl_test(ts, te, ti, urls, nurl, (const char **)stas, nsta, qPrintable(dir), columnCnt, dateFormat, fp);
             else
-                dl_exec(ts, te, ti, seqnos, seqnoe, urls, nurl, stas, nsta, qPrintable(dir), qPrintable(usr),
+                dl_exec(ts, te, ti, seqnos, seqnoe, urls, nurl, (const char **)stas, nsta, qPrintable(dir), qPrintable(usr),
                     qPrintable(pwd), qPrintable(proxy), opts, msg, fp);
             if (fp)
                 fclose(fp);
@@ -673,7 +673,7 @@ void MainForm::loadUrlList(const QString &file)
     ui->cBDataType->addItem(tr("ALL"));
     ui->cBSubType->addItem("");
 
-    n = dl_readurls(file.isEmpty() ? URL_FILE : qPrintable(file), (char **)sel, 1, urls_list, MAX_URL);
+    n = dl_readurls(file.isEmpty() ? URL_FILE : qPrintable(file), (const char **)sel, 1, urls_list, MAX_URL);
 
     for (i = 0; i < n; i++) {
         int p;
@@ -775,7 +775,7 @@ int MainForm::selectUrl(url_t *urls)
     }
     if (downOptDialog->urlFile.isEmpty()) file = URL_FILE;
 
-    nurl_out = dl_readurls(qPrintable(file), types, nurl_in, urls, MAX_URL_SEL);
+    nurl_out = dl_readurls(qPrintable(file), (const char **)types, nurl_in, urls, MAX_URL_SEL);
 
     for (i = 0; i < nurl_in; i++) delete []types[i];
 

--- a/app/qtapp/rtknavi_qt/navimain.cpp
+++ b/app/qtapp/rtknavi_qt/navimain.cpp
@@ -1197,8 +1197,8 @@ void MainWindow::serverStart()
     rtksvr.bl_reset = maxBaseLine;
 
     // start rtk server
-    if (!rtksvrstart(&rtksvr, optDialog->serverCycle, optDialog->serverBufferSize, streamTypes, serverPaths, inputFormat, optDialog->navSelect,
-                     cmds, cmds_periodic, rcvopts, optDialog->nmeaCycle, nmeaRequestType, nmeapos,
+    if (!rtksvrstart(&rtksvr, optDialog->serverCycle, optDialog->serverBufferSize, streamTypes, (const char **)serverPaths, inputFormat, optDialog->navSelect,
+                      (const char **)cmds, (const char **)cmds_periodic, (const char **)rcvopts, optDialog->nmeaCycle, nmeaRequestType, nmeapos,
                      &optDialog->processingOptions, solopt, &monistr, errmsg)) {
 
         trace(2, "rtksvrstart error %s\n", errmsg);
@@ -1267,7 +1267,7 @@ void MainWindow::serverStop()
             if (commandEnableTcp[i][1]) strncpy(cmds[i], qPrintable(commandsTcp[i][1]), 1023);
         }
     }
-    rtksvrstop(&rtksvr, cmds);
+    rtksvrstop(&rtksvr, (const char **)cmds);
 
     for (i = 0; i < 3; i++) delete[] cmds[i];
 

--- a/app/qtapp/rtkplot_qt/plotdata.cpp
+++ b/app/qtapp/rtkplot_qt/plotdata.cpp
@@ -69,7 +69,7 @@ void Plot::readSolution(const QStringList &files, int sel)
     showMessage(tr("Reading %1...").arg(files.first()));
     showLegend(QStringList());
 
-    if (!readsolt(paths, n, ts, te, tint, SOLQ_NONE, &sol)) {
+    if (!readsolt((const char **)paths, n, ts, te, tint, SOLQ_NONE, &sol)) {
         showMessage(tr("No solution data: %1...").arg(files.first()));
         showLegend(QStringList());
         readWaitEnd();
@@ -145,7 +145,7 @@ void Plot::readSolutionStat(const QStringList &files, int sel)
     showMessage(tr("Reading %1...").arg(files.first()));
     showLegend(QStringList());
 
-    readsolstatt(paths, n, ts, te, tint, solutionStat + sel);
+    readsolstatt((const char **)paths, n, ts, te, tint, solutionStat + sel);
 
     updateSatelliteList();
 }

--- a/app/qtapp/rtkpost_qt/postmain.cpp
+++ b/app/qtapp/rtkpost_qt/postmain.cpp
@@ -141,7 +141,7 @@ void ProcessingThread::addInput(const QString & file) {
 }
 void ProcessingThread::run()
 {
-    if ((stat = postpos(ts, te, ti, tu, &prcopt, &solopt, &filopt, infile, n, outfile,
+    if ((stat = postpos(ts, te, ti, tu, &prcopt, &solopt, &filopt, (const char **)infile, n, outfile,
                         qPrintable(rov), qPrintable(base))) == 1) {
         showmsg("Aborted");
     };

--- a/app/qtapp/strsvr_qt/svrmain.cpp
+++ b/app/qtapp/strsvr_qt/svrmain.cpp
@@ -561,7 +561,7 @@ void MainForm::startServer()
     }
 
     // stream server start (if no error in preparation occured)
-    if (!error && strsvrstart(&strsvr, opt, streamTypes, pths, logs, conv, cmds, cmds_periodic, svrOptDialog->antennaPosition)) {
+    if (!error && strsvrstart(&strsvr, opt, streamTypes, (const char **)pths, (const char **)logs, conv, (const char **)cmds, (const char **)cmds_periodic, svrOptDialog->antennaPosition)) {
         startTime = utc2gpst(timeget());
         ui->panelStreams->setEnabled(false);
         ui->btnStart->setVisible(false);
@@ -611,7 +611,7 @@ void MainForm::stopServer()
             if (commandsEnabledTcp[i][1]) strncpy(cmds[i], qPrintable(commandsTcp[i][1]), 1023);
         }
     }
-    strsvrstop(&strsvr, cmds);
+    strsvrstop(&strsvr, (const char **)cmds);
 
     endTime = utc2gpst(timeget());
     ui->panelStreams->setEnabled(true);

--- a/app/winapp/rtkget/getmain.cpp
+++ b/app/winapp/rtkget/getmain.cpp
@@ -241,7 +241,7 @@ void __fastcall TMainForm::BtnTestClick(TObject *Sender)
     abortf=0;
     Application->ProcessMessages();
     
-    dl_test(ts,te,ti,urls,nurl,stas,nsta,dir,NCol,DateFormat,fp);
+    dl_test(ts,te,ti,urls,nurl,(const char **)stas,nsta,dir,NCol,DateFormat,fp);
     
     BtnTest->Caption="&Test...";
     MsgLabel1->Font->Color=clBlack;
@@ -332,7 +332,7 @@ void __fastcall TMainForm::BtnDownloadClick(TObject *Sender)
     Timer->Enabled=true;
     Application->ProcessMessages();
     
-    dl_exec(ts,te,ti,seqnos,seqnoe,urls,nurl,stas,nsta,dir,usr.c_str(),
+    dl_exec(ts,te,ti,seqnos,seqnoe,urls,nurl,(const char **)stas,nsta,dir,usr.c_str(),
             pwd.c_str(),proxy.c_str(),opts,msg,fp);
     
     PanelEnable(1);
@@ -686,7 +686,7 @@ void __fastcall TMainForm::LoadUrl(AnsiString file)
     
     if (file=="") file=URL_FILE; // default url
     
-    n=dl_readurls(file.c_str(),sels,1,urls,MAX_URL);
+    n=dl_readurls(file.c_str(),(const char **)sels,1,urls,MAX_URL);
     
     for (i=0;i<n;i++) {
         Types ->Add(urls[i].type);
@@ -777,7 +777,7 @@ int __fastcall TMainForm::SelectUrl(url_t *urls)
     }
     if (UrlFile=="") file=URL_FILE;
     
-    nurl=dl_readurls(file.c_str(),types,nurl,urls,MAX_URL_SEL);
+    nurl=dl_readurls(file.c_str(),(const char **)types,nurl,urls,MAX_URL_SEL);
     
     for (i=0;i<MAX_URL_SEL;i++) delete [] types[i];
     

--- a/app/winapp/rtknavi/navimain.cpp
+++ b/app/winapp/rtknavi/navimain.cpp
@@ -1282,8 +1282,8 @@ void __fastcall TMainForm::SvrStart(void)
     rtksvr.bl_reset=MaxBL;
     
     // start rtk server
-    if (!rtksvrstart(&rtksvr,SvrCycle,SvrBuffSize,strs,paths,Format,NavSelect,
-                     cmds,cmds_periodic,rcvopts,NmeaCycle,NmeaReq,nmeapos,
+    if (!rtksvrstart(&rtksvr,SvrCycle,SvrBuffSize,strs,(const char **paths),Format,NavSelect,
+                     (const char **paths)cmds,(const char **paths)cmds_periodic,(const char **paths)rcvopts,NmeaCycle,NmeaReq,nmeapos,
                      &PrcOpt,solopt,&monistr,errmsg)) {
         trace(2,"rtksvrstart error %s\n",errmsg);
         traceclose();
@@ -1327,7 +1327,7 @@ void __fastcall TMainForm::SvrStop(void)
             if (CmdEnaTcp[i][1]) cmds[i]=CmdsTcp[i][1].c_str();
         }
     }
-    rtksvrstop(&rtksvr,cmds);
+    rtksvrstop(&rtksvr,(const char **paths)cmds);
     
     BtnStart    ->Visible=true;
     BtnOpt      ->Enabled=true;

--- a/app/winapp/rtkplot/plotdata.cpp
+++ b/app/winapp/rtkplot/plotdata.cpp
@@ -62,7 +62,7 @@ void __fastcall TPlot::ReadSol(TStrings *files, int sel)
     ShowMsg(s.sprintf("reading %s...",paths[0]));
     ShowLegend(NULL);
     
-    if (!readsolt(paths,n,ts,te,tint,SOLQ_NONE,&sol)) {
+    if (!readsolt((const char **)paths,n,ts,te,tint,SOLQ_NONE,&sol)) {
         ShowMsg(s.sprintf("no solution data : %s...",paths[0]));
         ShowLegend(NULL);
         ReadWaitEnd();
@@ -137,7 +137,7 @@ void __fastcall TPlot::ReadSolStat(TStrings *files, int sel)
     ShowMsg(s.sprintf("reading %s...",paths[0]));
     ShowLegend(NULL);
     
-    readsolstatt(paths,n,ts,te,tint,SolStat+sel);
+    readsolstatt((const char **)paths,n,ts,te,tint,SolStat+sel);
     
     UpdateSatList();
 }

--- a/app/winapp/rtkpost/postmain.cpp
+++ b/app/winapp/rtkpost/postmain.cpp
@@ -828,8 +828,8 @@ int __fastcall TMainForm::ExecProc(void)
     showmsg((char *)"reading...");
     
     // post processing positioning
-    if ((stat=postpos(ts,te,ti,tu,&prcopt,&solopt,&filopt,infile,n,outfile,
-                      rov,base))==1) {
+    if ((stat=postpos(ts,te,ti,tu,&prcopt,&solopt,&filopt,(const char **)infile,n,(const char **)outfile,
+                      (const char *)rov,base))==1) {
         showmsg((char *)"aborted");
     }
     delete [] rov ;

--- a/app/winapp/strsvr/svrmain.cpp
+++ b/app/winapp/strsvr/svrmain.cpp
@@ -495,7 +495,7 @@ void __fastcall TMainForm::SvrStart(void)
 		matcpy(conv[i]->out.sta.del,AntOff,3,1);
 	}
 	// stream server start
-	if (!strsvrstart(&strsvr,opt,strs,paths,logs,conv,cmds,cmds_periodic,AntPos)) {
+	if (!strsvrstart(&strsvr,opt,strs,(const char **)paths,(const char **)logs,conv,(const char **)cmds,(const char **)cmds_periodic,AntPos)) {
 		return;
 	}
 	StartTime=utc2gpst(timeget());
@@ -536,7 +536,7 @@ void __fastcall TMainForm::SvrStop(void)
 			if (CmdEnaTcp[i][1]) cmds[i]=MainForm->CmdsTcp[i][1].c_str();
 		}
 	}
-	strsvrstop(&strsvr,cmds);
+	strsvrstop(&strsvr,(const char **)cmds);
 	
 	EndTime=utc2gpst(timeget());
 	Panel1	  ->Enabled=true;

--- a/src/convgpx.c
+++ b/src/convgpx.c
@@ -153,7 +153,7 @@ extern int convgpx(const char *infile, const char *outfile, gtime_t ts,
     else strcpy(file,outfile);
     
     /* read solution file */
-    if (!readsolt((char **)&infile,1,ts,te,tint,qflg,&solbuf)) return -1;
+    if (!readsolt(&infile,1,ts,te,tint,qflg,&solbuf)) return -1;
     
     /* mean position */
     for (i=0;i<3;i++) {

--- a/src/convkml.c
+++ b/src/convkml.c
@@ -187,7 +187,7 @@ extern int convkml(const char *infile, const char *outfile, gtime_t ts,
     else strcpy(file,outfile);
     
     /* read solution file */
-    stat=readsolt(files,nfile,ts,te,tint,qflg,&solbuf);
+    stat=readsolt((const char **)files,nfile,ts,te,tint,qflg,&solbuf);
     
     for (i=0;i<MAXEXFILE;i++) free(files[i]);
     

--- a/src/download.c
+++ b/src/download.c
@@ -248,7 +248,7 @@ static int gen_path(gtime_t time, gtime_t time_p, int seqnos, int seqnoe,
 }
 /* generate download paths ---------------------------------------------------*/
 static int gen_paths(gtime_t time, gtime_t time_p, int seqnos, int seqnoe,
-                     const url_t *url, char **stas, int nsta, const char *dir,
+                     const url_t *url, const char **stas, int nsta, const char *dir,
                      paths_t *paths)
 {
     int i;
@@ -591,7 +591,7 @@ static int test_local(gtime_t ts, gtime_t te, double ti, const char *path,
 }
 /* test local files ----------------------------------------------------------*/
 static int test_locals(gtime_t ts, gtime_t te, double ti, const url_t *url,
-                       char **stas, int nsta, const char *dir, int *nc, int *nt,
+                       const char **stas, int nsta, const char *dir, int *nc, int *nt,
                        FILE *fp)
 {
     int i;
@@ -615,7 +615,7 @@ static int test_locals(gtime_t ts, gtime_t te, double ti, const url_t *url,
     return 0;
 }
 /* print total count of local files ------------------------------------------*/
-static int print_total(const url_t *url, char **stas, int nsta, int *nc,
+static int print_total(const url_t *url, const char **stas, int nsta, int *nc,
                        int *nt, FILE *fp)
 {
     int i;
@@ -672,7 +672,7 @@ static int print_total(const url_t *url, char **stas, int nsta, int *nc,
 *        %r -> rrrr    : station name
 *        %{env} -> env : environment variable
 *-----------------------------------------------------------------------------*/
-extern int dl_readurls(const char *file, char **types, int ntype, url_t *urls,
+extern int dl_readurls(const char *file, const char **types, int ntype, url_t *urls,
                        int nmax)
 {
     FILE *fp;
@@ -773,7 +773,7 @@ extern int dl_readstas(const char *file, char **stas, int nmax)
 *          not downloaded.
 *-----------------------------------------------------------------------------*/
 extern int dl_exec(gtime_t ts, gtime_t te, double ti, int seqnos, int seqnoe,
-                   const url_t *urls, int nurl, char **stas, int nsta,
+                   const url_t *urls, int nurl, const char **stas, int nsta,
                    const char *dir, const char *usr, const char *pwd,
                    const char *proxy, int opts, char *msg, FILE *fp)
 {
@@ -840,7 +840,7 @@ extern int dl_exec(gtime_t ts, gtime_t te, double ti, int seqnos, int seqnoe,
 * return : status (1:ok,0:error,-1:aborted)
 *-----------------------------------------------------------------------------*/
 extern void dl_test(gtime_t ts, gtime_t te, double ti, const url_t *urls,
-                    int nurl, char **stas, int nsta, const char *dir,
+                    int nurl, const char **stas, int nsta, const char *dir,
                     int ncol, int datefmt, FILE *fp)
 {
     gtime_t time;

--- a/src/postpos.c
+++ b/src/postpos.c
@@ -124,7 +124,7 @@ static void outrpos(FILE *fp, const double *r, const solopt_t *opt)
     }
 }
 /* output header -------------------------------------------------------------*/
-static void outheader(FILE *fp, char **file, int n, const prcopt_t *popt,
+static void outheader(FILE *fp, const char **file, int n, const prcopt_t *popt,
                       const solopt_t *sopt)
 {
     const char *s1[]={"GPST","UTC","JST"};
@@ -636,12 +636,12 @@ static void combres(FILE *fp, FILE *fptm, const prcopt_t *popt, const solopt_t *
     }
 }
 /* read prec ephemeris, sbas data, tec grid and open rtcm --------------------*/
-static void readpreceph(char **infile, int n, const prcopt_t *prcopt,
+static void readpreceph(const char **infile, int n, const prcopt_t *prcopt,
                         nav_t *nav, sbs_t *sbs)
 {
     seph_t seph0={0};
     int i;
-    char *ext;
+    const char *ext;
 
     trace(2,"readpreceph: n=%d\n",n);
 
@@ -706,7 +706,7 @@ static void freepreceph(nav_t *nav, sbs_t *sbs)
     free_rtcm(&rtcm);
 }
 /* read obs and nav data -----------------------------------------------------*/
-static int readobsnav(gtime_t ts, gtime_t te, double ti, char **infile,
+static int readobsnav(gtime_t ts, gtime_t te, double ti, const char **infile,
                       const int *index, int n, const prcopt_t *prcopt,
                       obs_t *obs, nav_t *nav, sta_t *sta)
 {
@@ -810,10 +810,11 @@ static int avepos(double *ra, int rcv, const obs_t *obs, const nav_t *nav,
     return 1;
 }
 /* station position from file ------------------------------------------------*/
-static int getstapos(const char *file, char *name, double *r)
+static int getstapos(const char *file, const char *name, double *r)
 {
     FILE *fp;
-    char buff[256],sname[256],*p,*q;
+    char buff[256],sname[256],*p;
+    const char *q;
     double pos[3];
 
     trace(3,"getstapos: file=%s name=%s\n",file,name);
@@ -986,7 +987,7 @@ static void readotl(prcopt_t *popt, const char *file, const sta_t *sta)
     }
 }
 /* write header to output file -----------------------------------------------*/
-static int outhead(const char *outfile, char **infile, int n,
+static int outhead(const char *outfile, const char **infile, int n,
                    const prcopt_t *popt, const solopt_t *sopt)
 {
     FILE *fp=stdout;
@@ -1035,11 +1036,12 @@ static void namefiletm(char *outfiletm, const char *outfile)
 /* execute processing session ------------------------------------------------*/
 static int execses(gtime_t ts, gtime_t te, double ti, const prcopt_t *popt,
                    const solopt_t *sopt, const filopt_t *fopt, int flag,
-                   char **infile, const int *index, int n, char *outfile)
+                   const char **infile, const int *index, int n, const char *outfile)
 {
     rtk_t *rtk_ptr = (rtk_t *)malloc(sizeof(rtk_t)); /* moved from stack to heap to avoid stack overflow warning */
     prcopt_t popt_=*popt;
-    char tracefile[1024],statfile[1024],path[1024],*ext,outfiletm[1024]={0};
+    char tracefile[1024],statfile[1024],path[1024],outfiletm[1024]={0};
+    const char *ext;
     int i,j,k,dcb_ok;
 
     trace(3,"execses : n=%d outfile=%s\n",n,outfile);
@@ -1222,12 +1224,13 @@ static int execses(gtime_t ts, gtime_t te, double ti, const prcopt_t *popt,
 /* execute processing session for each rover ---------------------------------*/
 static int execses_r(gtime_t ts, gtime_t te, double ti, const prcopt_t *popt,
                      const solopt_t *sopt, const filopt_t *fopt, int flag,
-                     char **infile, const int *index, int n, char *outfile,
+                     const char **infile, const int *index, int n, const char *outfile,
                      const char *rov)
 {
     gtime_t t0={0};
     int i,stat=0;
-    char *ifile[MAXINFILE],ofile[1024],*rov_,*p,*q,s[64]="";
+    char *ifile[MAXINFILE],ofile[1024],*rov_,*q,s[40]="";
+    const char *p;
 
     trace(3,"execses_r: n=%d outfile=%s\n",n,outfile);
 
@@ -1257,7 +1260,7 @@ static int execses_r(gtime_t ts, gtime_t te, double ti, const prcopt_t *popt,
                 reppath(outfile,ofile,t0,p,"");
 
                 /* execute processing session */
-                stat=execses(ts,te,ti,popt,sopt,fopt,flag,ifile,index,n,ofile);
+                stat=execses(ts,te,ti,popt,sopt,fopt,flag,(const char **)ifile,index,n,ofile);
             }
             if (stat==1||!q) break;
         }
@@ -1272,12 +1275,13 @@ static int execses_r(gtime_t ts, gtime_t te, double ti, const prcopt_t *popt,
 /* execute processing session for each base station --------------------------*/
 static int execses_b(gtime_t ts, gtime_t te, double ti, const prcopt_t *popt,
                      const solopt_t *sopt, const filopt_t *fopt, int flag,
-                     char **infile, const int *index, int n, char *outfile,
+                     const char **infile, const int *index, int n, const char *outfile,
                      const char *rov, const char *base)
 {
     gtime_t t0={0};
     int i,stat=0;
-    char *ifile[MAXINFILE],ofile[1024],*base_,*p,*q,s[64];
+    char *ifile[MAXINFILE],ofile[1024],*base_,*q,s[40];
+    const char *p;
 
     trace(3,"execses_b: n=%d outfile=%s\n",n,outfile);
 
@@ -1313,7 +1317,7 @@ static int execses_b(gtime_t ts, gtime_t te, double ti, const prcopt_t *popt,
                 for (i=0;i<n;i++) reppath(infile[i],ifile[i],t0,"",p);
                 reppath(outfile,ofile,t0,"",p);
 
-                stat=execses_r(ts,te,ti,popt,sopt,fopt,flag,ifile,index,n,ofile,rov);
+                stat=execses_r(ts,te,ti,popt,sopt,fopt,flag,(const char **)ifile,index,n,(const char *)ofile,rov);
             }
             if (stat==1||!q) break;
         }
@@ -1372,13 +1376,14 @@ static int execses_b(gtime_t ts, gtime_t te, double ti, const prcopt_t *popt,
 *-----------------------------------------------------------------------------*/
 extern int postpos(gtime_t ts, gtime_t te, double ti, double tu,
                    const prcopt_t *popt, const solopt_t *sopt,
-                   const filopt_t *fopt, char **infile, int n, char *outfile,
+                   const filopt_t *fopt, const char **infile, int n, const char *outfile,
                    const char *rov, const char *base)
 {
     gtime_t tts,tte,ttte;
     double tunit,tss;
     int i,j,k,nf,stat=0,week,flag=1,index[MAXINFILE]={0};
-    char *ifile[MAXINFILE],ofile[1024],*ext;
+    char *ifile[MAXINFILE],ofile[1024];
+    const char *ext;
 
     trace(3,"postpos : ti=%.0f tu=%.0f n=%d outfile=%s\n",ti,tu,n,outfile);
 
@@ -1445,7 +1450,7 @@ extern int postpos(gtime_t ts, gtime_t te, double ti, double tu,
             if (!reppath(outfile,ofile,tts,"","")&&i>0) flag=0;
 
             /* execute processing session */
-            stat=execses_b(tts,tte,ti,popt,sopt,fopt,flag,ifile,index,nf,ofile,
+            stat=execses_b(tts,tte,ti,popt,sopt,fopt,flag,(const char **)ifile,index,nf,(const char *)ofile,
                            rov,base);
 
             if (stat==1) break;
@@ -1464,7 +1469,7 @@ extern int postpos(gtime_t ts, gtime_t te, double ti, double tu,
         reppath(outfile,ofile,ts,"","");
 
         /* execute processing session */
-        stat=execses_b(ts,te,ti,popt,sopt,fopt,1,ifile,index,n,ofile,rov,
+        stat=execses_b(ts,te,ti,popt,sopt,fopt,1,(const char **)ifile,index,n,ofile,rov,
                        base);
 
         for (i=0;i<n&&i<MAXINFILE;i++) free(ifile[i]);

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1709,11 +1709,11 @@ EXPORT void freesolbuf(solbuf_t *solbuf);
 EXPORT void freesolstatbuf(solstatbuf_t *solstatbuf);
 EXPORT sol_t *getsol(solbuf_t *solbuf, int index);
 EXPORT int addsol(solbuf_t *solbuf, const sol_t *sol);
-EXPORT int readsol (char *files[], int nfile, solbuf_t *sol);
-EXPORT int readsolt(char *files[], int nfile, gtime_t ts, gtime_t te,
+EXPORT int readsol (const char *files[], int nfile, solbuf_t *sol);
+EXPORT int readsolt(const char *files[], int nfile, gtime_t ts, gtime_t te,
                     double tint, int qflag, solbuf_t *sol);
-EXPORT int readsolstat(char *files[], int nfile, solstatbuf_t *statbuf);
-EXPORT int readsolstatt(char *files[], int nfile, gtime_t ts, gtime_t te,
+EXPORT int readsolstat(const char *files[], int nfile, solstatbuf_t *statbuf);
+EXPORT int readsolstatt(const char *files[], int nfile, gtime_t ts, gtime_t te,
                         double tint, solstatbuf_t *statbuf);
 EXPORT int inputsol(uint8_t data, gtime_t ts, gtime_t te, double tint,
                     int qflag, const solopt_t *opt, solbuf_t *solbuf);
@@ -1827,15 +1827,15 @@ EXPORT int ppp_ar(rtk_t *rtk, const obsd_t *obs, int n, int *exc,
 /* post-processing positioning -----------------------------------------------*/
 EXPORT int postpos(gtime_t ts, gtime_t te, double ti, double tu,
                    const prcopt_t *popt, const solopt_t *sopt,
-                   const filopt_t *fopt, char **infile, int n, char *outfile,
+                   const filopt_t *fopt, const char **infile, int n, const char *outfile,
                    const char *rov, const char *base);
 
 /* stream server functions ---------------------------------------------------*/
 EXPORT void strsvrinit (strsvr_t *svr, int nout);
-EXPORT int  strsvrstart(strsvr_t *svr, int *opts, int *strs, char **paths,
-                        char **logs, strconv_t **conv, char **cmds,
-                        char **cmds_priodic, const double *nmeapos);
-EXPORT void strsvrstop (strsvr_t *svr, char **cmds);
+EXPORT int  strsvrstart(strsvr_t *svr, int *opts, int *strs, const char **paths,
+                        const char **logs, strconv_t **conv, const char **cmds,
+                        const char **cmds_priodic, const double *nmeapos);
+EXPORT void strsvrstop (strsvr_t *svr, const char **cmds);
 EXPORT void strsvrstat (strsvr_t *svr, int *stat, int *log_stat, int *byte,
                         int *bps, char *msg);
 EXPORT strconv_t *strconvnew(int itype, int otype, const char *msgs, int staid,
@@ -1846,11 +1846,11 @@ EXPORT void strconvfree(strconv_t *conv);
 EXPORT int  rtksvrinit  (rtksvr_t *svr);
 EXPORT void rtksvrfree  (rtksvr_t *svr);
 EXPORT int  rtksvrstart (rtksvr_t *svr, int cycle, int buffsize, int *strs,
-                         char **paths, int *formats, int navsel, char **cmds,
-                         char **cmds_periodic, char **rcvopts, int nmeacycle,
+                         const char **paths, int *formats, int navsel, const char **cmds,
+                         const char **cmds_periodic, const char **rcvopts, int nmeacycle,
                          int nmeareq, const double *nmeapos, prcopt_t *prcopt,
                          solopt_t *solopt, stream_t *moni, char *errmsg);
-EXPORT void rtksvrstop  (rtksvr_t *svr, char **cmds);
+EXPORT void rtksvrstop  (rtksvr_t *svr, const char **cmds);
 EXPORT int  rtksvropenstr(rtksvr_t *svr, int index, int str, const char *path,
                           const solopt_t *solopt);
 EXPORT void rtksvrclosestr(rtksvr_t *svr, int index);
@@ -1862,15 +1862,15 @@ EXPORT void rtksvrsstat (rtksvr_t *svr, int *sstat, char *msg);
 EXPORT int  rtksvrmark(rtksvr_t *svr, const char *name, const char *comment);
 
 /* downloader functions ------------------------------------------------------*/
-EXPORT int dl_readurls(const char *file, char **types, int ntype, url_t *urls,
+EXPORT int dl_readurls(const char *file, const char **types, int ntype, url_t *urls,
                        int nmax);
 EXPORT int dl_readstas(const char *file, char **stas, int nmax);
 EXPORT int dl_exec(gtime_t ts, gtime_t te, double ti, int seqnos, int seqnoe,
-                   const url_t *urls, int nurl, char **stas, int nsta,
+                   const url_t *urls, int nurl, const char **stas, int nsta,
                    const char *dir, const char *usr, const char *pwd,
                    const char *proxy, int opts, char *msg, FILE *fp);
 EXPORT void dl_test(gtime_t ts, gtime_t te, double ti, const url_t *urls,
-                    int nurl, char **stas, int nsta, const char *dir,
+                    int nurl, const char **stas, int nsta, const char *dir,
                     int ncol, int datefmt, FILE *fp);
 
 /* GIS data functions --------------------------------------------------------*/

--- a/src/rtksvr.c
+++ b/src/rtksvr.c
@@ -836,8 +836,8 @@ extern void rtksvrunlock(rtksvr_t *svr) {rtklib_unlock(&svr->lock);}
 * return : status (1:ok 0:error)
 *-----------------------------------------------------------------------------*/
 extern int rtksvrstart(rtksvr_t *svr, int cycle, int buffsize, int *strs,
-                       char **paths, int *formats, int navsel, char **cmds,
-                       char **cmds_periodic, char **rcvopts, int nmeacycle,
+                       const char **paths, int *formats, int navsel, const char **cmds,
+                       const char **cmds_periodic, const char **rcvopts, int nmeacycle,
                        int nmeareq, const double *nmeapos, prcopt_t *prcopt,
                        solopt_t *solopt, stream_t *moni, char *errmsg)
 {
@@ -969,7 +969,7 @@ extern int rtksvrstart(rtksvr_t *svr, int cycle, int buffsize, int *strs,
 *                              cmds[2]=input stream ephem (NULL: no command)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void rtksvrstop(rtksvr_t *svr, char **cmds)
+extern void rtksvrstop(rtksvr_t *svr, const char **cmds)
 {
     int i;
     

--- a/src/solution.c
+++ b/src/solution.c
@@ -872,7 +872,7 @@ static int sort_solbuf(solbuf_t *solbuf)
 *          solbuf_t *solbuf O  solution buffer
 * return : status (1:ok,0:no data or error)
 *-----------------------------------------------------------------------------*/
-extern int readsolt(char *files[], int nfile, gtime_t ts, gtime_t te,
+extern int readsolt(const char *files[], int nfile, gtime_t ts, gtime_t te,
                     double tint, int qflag, solbuf_t *solbuf)
 {
     FILE *fp;
@@ -900,7 +900,7 @@ extern int readsolt(char *files[], int nfile, gtime_t ts, gtime_t te,
     }
     return sort_solbuf(solbuf);
 }
-extern int readsol(char *files[], int nfile, solbuf_t *sol)
+extern int readsol(const char *files[], int nfile, solbuf_t *sol)
 {
     gtime_t time={0};
     
@@ -1137,7 +1137,7 @@ static int readsolstatdata(FILE *fp, gtime_t ts, gtime_t te, double tint,
 *          solstatbuf_t *statbuf O  solution status buffer
 * return : status (1:ok,0:no data or error)
 *-----------------------------------------------------------------------------*/
-extern int readsolstatt(char *files[], int nfile, gtime_t ts, gtime_t te,
+extern int readsolstatt(const char *files[], int nfile, gtime_t ts, gtime_t te,
                         double tint, solstatbuf_t *statbuf)
 {
     FILE *fp;
@@ -1168,7 +1168,7 @@ extern int readsolstatt(char *files[], int nfile, gtime_t ts, gtime_t te,
     }
     return sort_solstat(statbuf);
 }
-extern int readsolstat(char *files[], int nfile, solstatbuf_t *statbuf)
+extern int readsolstat(const char *files[], int nfile, solstatbuf_t *statbuf)
 {
     gtime_t time={0};
     

--- a/src/streamsvr.c
+++ b/src/streamsvr.c
@@ -638,9 +638,9 @@ extern void strsvrinit(strsvr_t *svr, int nout)
 *          double *nmeapos  I   nmea request position (ecef) (m) (NULL: no)
 * return : status (0:error,1:ok)
 *-----------------------------------------------------------------------------*/
-extern int strsvrstart(strsvr_t *svr, int *opts, int *strs, char **paths,
-                       char **logs, strconv_t **conv, char **cmds,
-                       char **cmds_periodic, const double *nmeapos)
+extern int strsvrstart(strsvr_t *svr, int *opts, int *strs, const char **paths,
+                       const char **logs, strconv_t **conv, const char **cmds,
+                       const char **cmds_periodic, const double *nmeapos)
 {
     int i,rw,stropt[8]={0};
     char file1[MAXSTRPATH],file2[MAXSTRPATH],*p;
@@ -732,7 +732,7 @@ extern int strsvrstart(strsvr_t *svr, int *opts, int *strs, char **paths,
 *              ...
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strsvrstop(strsvr_t *svr, char **cmds)
+extern void strsvrstop(strsvr_t *svr, const char **cmds)
 {
     int i;
     


### PR DESCRIPTION
For the rtklib interface functions, declare char pointer arguments as 'const char ...' when the function does not modify the data. Many were already declared.

Some follow on patches are also included for some of the callees for consistency, and some of the caller arguments needed type casts.