### PR TITLE
postpos outrpos: use the same interpretation of the opt sep as elsewhere

### DIFF
--- a/src/postpos.c
+++ b/src/postpos.c
@@ -97,14 +97,22 @@ static int checkbrk(const char *format, ...)
     else if (*proc_base) sprintf(p," (%s)",proc_base);
     return showmsg(buff);
 }
+/* Solution option to field separator ----------------------------------------*/
+/* Repeated from solution.c */
+static const char *opt2sep(const solopt_t *opt)
+{
+    if (!*opt->sep) return " ";
+    else if (!strcmp(opt->sep,"\\t")) return "\t";
+    return opt->sep;
+}
 /* output reference position -------------------------------------------------*/
 static void outrpos(FILE *fp, const double *r, const solopt_t *opt)
 {
     double pos[3],dms1[3],dms2[3];
-    const char *sep=opt->sep;
 
     trace(3,"outrpos :\n");
 
+    const char *sep = opt2sep(opt);
     if (opt->posf==SOLF_LLH||opt->posf==SOLF_ENU) {
         ecef2pos(r,pos);
         if (opt->degf) {

--- a/src/solution.c
+++ b/src/solution.c
@@ -373,8 +373,8 @@ static int decode_nmea(char *buff, sol_t *sol)
 static char *decode_soltime(char *buff, const solopt_t *opt, gtime_t *time)
 {
     double v[MAXFIELD];
-    char *p,*q,sep[64]=" ";
-    int n,sep_len;
+    char *p,*q;
+    int n;
 
     trace(4,"decode_soltime:\n");
 
@@ -382,9 +382,8 @@ static char *decode_soltime(char *buff, const solopt_t *opt, gtime_t *time)
         return buff;
     }
 
-    if (!strcmp(opt->sep,"\\t")) strcpy(sep,"\t");
-    else if (*opt->sep) strcpy(sep,opt->sep);
-    sep_len=(int)strlen(sep);
+    const char *sep = opt2sep(opt);
+    size_t sep_len = strlen(sep);
 
     if (opt->posf==SOLF_GSIF) {
         if (sscanf(buff,"%lf %lf %lf %lf:%lf:%lf",v,v+1,v+2,v+3,v+4,v+5)<6) {


### PR DESCRIPTION
outrpos() was using the option separator string raw, without interpreting as elsewhere through opt2sep(), and this made it incompatible with decode_refpos()

decode_soltime() can also use opt2sep() rather than repeating the same logic.