### PR TITLE
rinex comments: refactor into a new function rnxcomment() and wrap ov…

### DIFF
--- a/app/consapp/convbin/convbin.c
+++ b/app/consapp/convbin/convbin.c
@@ -383,7 +383,7 @@ static int cmdopts(int argc, char **argv, rnxopt_t *opt, char **ifile,
 {
     double eps[]={1980,1,1,0,0,0},epe[]={2037,12,31,0,0,0};
     double epr[]={2010,1,1,0,0,0},span=0.0;
-    int i,j,k,sat,nf=5,nc=2,format=-1;
+    int i,j,k,sat,nf=5,format=-1;
     char *p,*sys,*fmt="",*paths[1],path[1024],buff[256];
     
     opt->rnxver=304;
@@ -431,7 +431,7 @@ static int cmdopts(int argc, char **argv, rnxopt_t *opt, char **ifile,
             nf=atoi(argv[++i]);
         }
         else if (!strcmp(argv[i],"-hc")&&i+1<argc) {
-            if (nc<MAXCOMMENT) strcpy(opt->comment[nc++],argv[++i]);
+            rnxcomment(opt, argv[++i]);
         }
         else if (!strcmp(argv[i],"-hm")&&i+1<argc) {
             strcpy(opt->marker,argv[++i]);
@@ -627,12 +627,6 @@ int main(int argc, char **argv)
         return EXIT_FAILURE;
     }
     sprintf(opt.prog,"%s %s %s",PRGNAME,VER_RTKLIB,PATCH_LEVEL);
-    sprintf(opt.comment[0],"log: %-55.55s",ifile);
-    sprintf(opt.comment[1],"format: %s",formatstrs[format]);
-    if (*opt.rcvopt) {
-        strcat(opt.comment[1],", option: ");
-        strcat(opt.comment[1],opt.rcvopt);
-    }
     if (trace>0) {
         traceopen(TRACEFILE);
         tracelevel(trace);

--- a/app/qtapp/rtkconv_qt/convmain.cpp
+++ b/app/qtapp/rtkconv_qt/convmain.cpp
@@ -899,7 +899,8 @@ void MainWindow::convertFile()
     conversionThread->rnxopt.navsys = convOptDialog->navSys;
     conversionThread->rnxopt.obstype = convOptDialog->observationType;
     conversionThread->rnxopt.freqtype = convOptDialog->frequencyType;
-    for (i = 0; i < 2; i++) sprintf(conversionThread->rnxopt.comment[i], "%.63s", qPrintable(convOptDialog->comment[i]));
+    for (i = 0; i < 2; i++)
+        rnxcomment(&conversionThread->rnxopt, "%s", qPrintable(convOptDialog->comment[i]));
     for (i = 0; i < 7; i++) strncpy(conversionThread->rnxopt.mask[i], qPrintable(convOptDialog->codeMask[i]), 63);
     conversionThread->rnxopt.autopos = convOptDialog->autoPosition;
     conversionThread->rnxopt.phshift = convOptDialog->phaseShift;

--- a/app/winapp/rtkconv/convmain.cpp
+++ b/app/winapp/rtkconv/convmain.cpp
@@ -953,7 +953,7 @@ void __fastcall TMainWindow::ConvertFile(void)
 	rnxopt.navsys=NavSys;
 	rnxopt.obstype=ObsType;
 	rnxopt.freqtype=FreqType;
-	for (i=0;i<2;i++) sprintf(rnxopt.comment[i],"%.63s",Comment[i].c_str());
+	for (i=0;i<2;i++) rnxcomment(&rnxopt, "%s", Comment[i].c_str());
 	for (i=0;i<7;i++) strcpy(rnxopt.mask[i],CodeMask[i].c_str());
         for (i=0;i<7;i++) {
             /* strncpy is appropriate here, the elements are accessed randomly */

--- a/src/convrnx.c
+++ b/src/convrnx.c
@@ -335,28 +335,20 @@ static void close_strfile(strfile_t *str)
 static void setopt_file(int format, char **paths, int n, const int *mask,
                         rnxopt_t *opt)
 {
-    int i,j;
-
-    for (i=0;i<MAXCOMMENT;i++) {
-        if (!*opt->comment[i]) break;
-    }
-    if (i<MAXCOMMENT) {
-        sprintf(opt->comment[i++],"format: %.55s",formatstrs[format]);
-    }
-    for (j=0;j<n&&i<MAXCOMMENT;j++) {
+    rnxcomment(opt,"format: %s",formatstrs[format]);
+    if (*opt->rcvopt)
+        rnxcomment(opt, "options: %s", opt->rcvopt);
+    for (int j=0; j<n; j++) {
         if (!mask[j]) continue;
-        sprintf(opt->comment[i++],"log: %.58s",paths[j]);
-    }
-    if (*opt->rcvopt) {
-        sprintf(opt->comment[i++], "options: %.54s", opt->rcvopt);
+        rnxcomment(opt,"log: %s",paths[j]);
     }
 }
 /* unset RINEX options comments ----------------------------------------------*/
 static void unsetopt_file(rnxopt_t *opt)
 {
-    int i,brk=0;
+    int brk=0;
 
-    for (i=MAXCOMMENT-1;i>=0&&!brk;i--) {
+    for (int i=MAXCOMMENT-1;i>=0&&!brk;i--) {
         if (!*opt->comment[i]) continue;
         if (!strncmp(opt->comment[i],"format: ",8)) brk=1;
         *opt->comment[i]='\0';
@@ -493,25 +485,19 @@ static void setopt_sta_list(const strfile_t *str, rnxopt_t *opt)
 {
     const stas_t *p;
     char s1[32],s2[32];
-    int i,n=0;
+    int n=0;
 
     for (p=str->stas;p;p=p->next) {
         n++;
     }
     if (n<=1) return;
 
-    for (i=0;i<MAXCOMMENT;i++) {
-        if (!*opt->comment[i]) break;
-    }
-    if (i>=MAXCOMMENT) return;
-    sprintf(opt->comment[i++],"%5s  %22s  %22s","STAID","TIME OF FIRST OBS",
-            "TIME OF LAST OBS");
+    rnxcomment(opt,"%5s  %22s  %22s", "STAID", "TIME OF FIRST OBS", "TIME OF LAST OBS");
     
     for (p=str->stas,n--;p&&n>=0;p=p->next,n--) {
-        if (i+n>=MAXCOMMENT) continue;
         time2str(p->ts,s1,2);
         time2str(p->te,s2,2);
-        sprintf(opt->comment[i+n]," %04d  %s  %s",p->staid,s1,s2);
+        rnxcomment(opt," %04d  %s  %s",p->staid,s1,s2);
     }
 }
 /* set station info in RINEX options -----------------------------------------*/

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1593,6 +1593,7 @@ EXPORT int outrnxinavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav);
 EXPORT int outrnxnavb (FILE *fp, const rnxopt_t *opt, const eph_t *eph);
 EXPORT int outrnxgnavb(FILE *fp, const rnxopt_t *opt, const geph_t *geph);
 EXPORT int outrnxhnavb(FILE *fp, const rnxopt_t *opt, const seph_t *seph);
+EXPORT int rnxcomment(rnxopt_t *opt, const char *format, ...);
 EXPORT int rtk_uncompress(const char *file, char *uncfile);
 EXPORT int convrnx(int format, rnxopt_t *opt, const char *file, char **ofile);
 EXPORT int  init_rnxctr (rnxctr_t *rnx);


### PR DESCRIPTION
…erflow

Noted a buffer overflow due to long receiver options, might have been a fault in my own devo code, and had a go at refactoring the code and added comment wrapping.

RINEX comments were being truncated to at most 60 characters and there was some code duplication. e.g. long file names and receiver options were being truncated and lost.

Abstract this into the new function rnxcomment() which handles comment overflow by wrapping to the next comment line with indentation. Handle overflow and truncation in this common function.

Comments now need to be added without blank entries in the comments array, and new entries are added starting from the first blank entry.