### PR TITLE
sbas subtype7: guard the number of satellites

### DIFF
--- a/src/sbas.c
+++ b/src/sbas.c
@@ -196,7 +196,7 @@ static int decode_sbstype6(const sbsmsg_t *msg, sbssat_t *sbssat)
     for (i=0;i<4;i++) {
         iodf[i]=getbitu(msg->msg,14+i*2,2);
     }
-    /* Limited to 51 to avoid overflow of iodf[] */
+    /* As most 51 entries in the message */
     for (i=0;i<sbssat->nsat&&i<=51;i++) {
         if (sbssat->sat[i].fcorr.iodf!=iodf[i/13]) continue;
         udre=getbitu(msg->msg,22+i*4,4);
@@ -216,7 +216,8 @@ static int decode_sbstype7(const sbsmsg_t *msg, sbssat_t *sbssat)
     
     sbssat->tlat=getbitu(msg->msg,14,4);
     
-    for (i=0;i<sbssat->nsat&&i<MAXSAT;i++) {
+    /* As most 51 entries in the message */
+    for (i=0;i<sbssat->nsat&&i<=51;i++) {
         sbssat->sat[i].fcorr.ai=getbitu(msg->msg,22+i*4,4);
     }
     return 1;


### PR DESCRIPTION
The subtype7 messages have at most data for the first 51 masked satellites, so guard this as had already been done for subtype6 messages.