### PR TITLE
convrnx: clear the raw buffered subframes when opening a new file

### DIFF
--- a/src/convrnx.c
+++ b/src/convrnx.c
@@ -300,6 +300,8 @@ static int open_strfile(strfile_t *str, const char *file)
             return 0;
         }
         str->raw.time=str->time;
+        // Clear the buffered subframes. Less risk of undetected iod wrapping.
+        memset(str->raw.subfrm,0,sizeof(str->raw.subfrm));
     }
     else if (str->format==STRFMT_RINEX) {
         if (!(str->fp=fopen(file,"r"))) {


### PR DESCRIPTION
Noticed some odd sets of raw subframes and is was due to subframes from the end of one pass being mixed with subframes from the start of the next. The iod consistency checks should catch this, but still there is the unlikely chance of iod wrapping letter an inconsistent set through.

Less risk of undetected iod wrapping.