### PR TITLE
RINEX input_rnxctr: correct the ephemeris set for GAL

### DIFF
--- a/src/rinex.c
+++ b/src/rinex.c
@@ -2000,7 +2000,7 @@ extern int input_rnxctr(rnxctr_t *rnx, FILE *fp)
     }
     else { /* other ephemeris */
         sys=satsys(eph.sat,&prn);
-        set=(sys==SYS_GAL&&(eph.code&(1<<9)))?1:0; /* GAL 0:I/NAV,1:F/NAV */
+        set=(sys==SYS_GAL&&(eph.code&((1<<8)|(1<<1))))?1:0; /* GAL 0:I/NAV,1:F/NAV */
         rnx->nav.eph[eph.sat-1+MAXSAT*set]=eph;
         rnx->time=eph.ttr;
         rnx->ephsat=eph.sat;


### PR DESCRIPTION
Spotted this code that does not appear correct. The RINEX 3 spec details the code bits as follows so the current code checking bit 9 for a f/nav set seems wrong.

> Bit 0 set: I/NAV E1-B
> Bit 1 set: F/NAV E5a-I
> Bit 2 set: I/NAV E5b-I
> Bits 0 and 2 : Both can be set if the navigation messages were merged,
> however, bits 0-2 cannot all be set, as the I/NAV and F/NAV messages contain different information
> Bit 3 reserved for Galileo internal use
> Bit 4 reserved for Galileo internal use
> Bit 8 set: af0-af2, Toc, SISA are for E5a,E1
> Bit 9 set: af0-af2, Toc, SISA are for E5b,E1
> Bits 8-9 : exclusive (only one bit can be set)

Set 0 is used for I/NAV and set 1 for F/NAV. The ephemeris structure code slot has bit 8 set for E5a,E1 or bit 9 set for E5b,E1. F/NAV is for channel E5a-I, not channel E5b-I. For I/NAV on channel E1B neither bit 8 or 9 would be set. So checking bit 8 should distinguish F/NAV from I/NAV and when set the ephemeris should go to set 1.

Also bit 1 is expected to be set for F/NAV E5a-I so also use the F/NAV set in this case.