### PR TITLE
convrnx: add option to sort observation data by satellite index

### DIFF
--- a/app/consapp/convbin/convbin.c
+++ b/app/consapp/convbin/convbin.c
@@ -129,6 +129,7 @@ static const char *help[]={
 "     -ot          include time correction in rinex nav header [off]",
 "     -ol          include leap seconds in rinex nav header [off]",
 "     -halfc       half-cycle ambiguity correction [off]",
+"     -sortsats    sort observations by the RTKLib satellite index [off]",
 "     -mask   [sig[,...]] signal mask(s) (sig={G|R|E|J|S|C|I}L{1C|1P|1W|...})",
 "     -nomask [sig[,...]] signal no mask (same as above)",
 "     -x sat       exclude satellite",
@@ -500,6 +501,9 @@ static int cmdopts(int argc, char **argv, rnxopt_t *opt, char **ifile,
         }
         else if (!strcmp(argv[i],"-halfc")) {
             opt->halfcyc=1;
+        }
+        else if (!strcmp(argv[i],"-sortsats")) {
+            opt->sortsats=1;
         }
         else if (!strcmp(argv[i],"-mask")&&i+1<argc) {
             for (j=0;j<RNX_NUMSYS;j++) {

--- a/src/convrnx.c
+++ b/src/convrnx.c
@@ -990,6 +990,12 @@ static int screent_ttol(gtime_t time, gtime_t ts, gtime_t te, double tint,
            (ts.time==0||timediff(time,ts)>=-ttol)&&
            (te.time==0||timediff(time,te)<  ttol);
 }
+/* Order observation data by the RTKLib satellite index */
+static int cmpobs(const void *p1, const void *p2)
+{
+    obsd_t *obs1 = (obsd_t *)p1, *obs2 = (obsd_t *)p2;
+    return obs1->sat > obs2->sat;
+}
 /* convert observation data --------------------------------------------------*/
 static void convobs(FILE **ofp, rnxopt_t *opt, strfile_t *str, int *n,
                     gtime_t *tend, int *staid)
@@ -1032,6 +1038,10 @@ static void convobs(FILE **ofp, rnxopt_t *opt, strfile_t *str, int *n,
     /* resolve half-cycle ambiguity */
     if (opt->halfcyc) {
         resolve_halfc(str,str->obs->data,str->obs->n);
+    }
+    /* Sort observation data by the RTKLib satellite index */
+    if (opt->sortsats) {
+        qsort(str->obs->data, str->obs->n, sizeof(obsd_t), cmpobs);
     }
     /* output RINEX observation data */
     outrnxobsb(ofp[0],opt,str->obs->data,str->obs->n,str->obs->flag);

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1135,6 +1135,7 @@ typedef struct {        /* RINEX options type */
     int autopos;        /* auto approx position */
     int phshift;        /* phase shift correction */
     int halfcyc;        /* half cycle correction */
+    int sortsats;       /* Sort by satellite index */
     int sep_nav;        /* separated nav files */
     gtime_t tstart;     /* first obs time */
     gtime_t tend;       /* last obs time */


### PR DESCRIPTION
This helped compare rtklib output rinex observation files vs other. Other rinex files could also be filtered through convbin to have the same ordering before a text comparison. Is there a better tool to compare rinex files, something that can actually note the numerical differences and ignore lsb diffs?

Using the RTKLib satellite index.

Adds -sortsats to convbin