### PR TITLE
eph.fit: improve handling, QZSS

### DIFF
--- a/src/rcv/crescent.c
+++ b/src/rcv/crescent.c
@@ -297,7 +297,7 @@ static int decode_creseph(raw_t *raw)
         word=U4(p+8+i*40+j*4)>>6;
         for (k=0;k<3;k++) buff[i*30+j*3+k]=(uint8_t)((word>>(8*(2-k)))&0xFF);
     }
-    if (!decode_frame(buff,&eph,NULL,NULL,NULL)) {
+    if (!decode_frame(buff,SYS_GPS,&eph,NULL,NULL,NULL)) {
         trace(2,"crescent bin 95 navigation frame error: prn=%d\n",prn);
         return -1;
     }

--- a/src/rcv/javad.c
+++ b/src/rcv/javad.c
@@ -833,7 +833,8 @@ static int decode_L1eph(int sat, raw_t *raw)
 {
     eph_t eph={0};
     
-    if (!decode_frame(raw->subfrm[sat-1],&eph,NULL,NULL,NULL)) return 0;
+    int sys = satsys(sat, NULL);
+    if (!decode_frame(raw->subfrm[sat-1],sys,&eph,NULL,NULL,NULL)) return 0;
     
     if (!strstr(raw->opt,"-EPHALL")) {
         if (eph.iode==raw->nav.eph[sat-1].iode&&
@@ -864,7 +865,7 @@ static int decode_L1ionutc(int sat, raw_t *raw)
     double ion[8],utc[8];
     int sys=satsys(sat,NULL);
 
-    if (!decode_frame(raw->subfrm[sat-1],NULL,NULL,ion,utc)) return 0;
+    if (!decode_frame(raw->subfrm[sat-1],sys,NULL,NULL,ion,utc)) return 0;
     
     adj_utcweek(raw->time,utc);
     if (sys==SYS_QZS) {

--- a/src/rcv/novatel.c
+++ b/src/rcv/novatel.c
@@ -543,7 +543,7 @@ static int decode_rawephemb(raw_t *raw)
     }
     memcpy(subframe,p+12,30*3); /* subframe 1-3 */
     
-    if (!decode_frame(subframe,&eph,NULL,NULL,NULL)) {
+    if (!decode_frame(subframe,SYS_GPS,&eph,NULL,NULL,NULL)) {
         trace(2,"oem4 rawephemb subframe error: prn=%d\n",prn);
         return -1;
     }
@@ -684,7 +684,7 @@ static int decode_qzssrawephemb(raw_t *raw)
     }
     memcpy(subfrm,p+12,90);
     
-    if (!decode_frame(subfrm,&eph,NULL,NULL,NULL)) {
+    if (!decode_frame(subfrm,SYS_QZS,&eph,NULL,NULL,NULL)) {
         trace(3,"oem4 qzssrawephemb ephemeris error: prn=%d\n",prn);
         return 0;
     }
@@ -726,7 +726,7 @@ static int decode_qzssrawsubframeb(raw_t *raw)
     memcpy(raw->subfrm[sat-1]+30*(id-1),p+8,30);
     
     if (id==3) {
-        if (!decode_frame(raw->subfrm[sat-1],&eph,NULL,NULL,NULL)) return 0;
+        if (!decode_frame(raw->subfrm[sat-1],SYS_QZS,&eph,NULL,NULL,NULL)) return 0;
         if (!strstr(raw->opt,"-EPHALL")) {
             if (eph.iodc==raw->nav.eph[sat-1].iodc&&
                 eph.iode==raw->nav.eph[sat-1].iode) return 0; /* unchanged */
@@ -738,7 +738,7 @@ static int decode_qzssrawsubframeb(raw_t *raw)
         return 2;
     }
     else if (id==4||id==5) {
-        if (!decode_frame(raw->subfrm[sat-1],NULL,NULL,ion,utc)) return 0;
+        if (!decode_frame(raw->subfrm[sat-1],SYS_QZS,NULL,NULL,ion,utc)) return 0;
         adj_utcweek(raw->time,utc);
         matcpy(raw->nav.ion_qzs,ion,8,1);
         matcpy(raw->nav.utc_qzs,utc,8,1);
@@ -1196,7 +1196,7 @@ static int decode_repb(raw_t *raw)
         trace(2,"oem3 repb satellite number error: prn=%d\n",prn);
         return -1;
     }
-    if (!decode_frame(p+4,&eph,NULL,NULL,NULL)) {
+    if (!decode_frame(p+4,SYS_GPS,&eph,NULL,NULL,NULL)) {
         trace(2,"oem3 repb subframe error: prn=%d\n",prn);
         return -1;
     }

--- a/src/rcv/septentrio.c
+++ b/src/rcv/septentrio.c
@@ -1541,7 +1541,7 @@ static int decode_gpsionutc(raw_t *raw, int sat)
 {
     double ion[8], utc[8];
 
-    if (!decode_frame(raw->subfrm[sat-1], NULL, NULL, ion, utc)) return 0;
+    if (!decode_frame(raw->subfrm[sat-1], SYS_GPS, NULL, NULL, ion, utc)) return 0;
 
     adj_utcweek(raw->time, &utc[3]);
     adj_utcweek(raw->time, &utc[5]);
@@ -1618,7 +1618,7 @@ static int decode_gpsrawcanav(raw_t *raw, int sys){
 
     if (id == 3) {
         eph_t eph = {0};
-        if (!decode_frame(raw->subfrm[sat-1], &eph, NULL, NULL, NULL))
+        if (!decode_frame(raw->subfrm[sat-1], sys, &eph, NULL, NULL, NULL))
             return 0;
 
         if (!strstr(raw->opt, "-EPHALL")) {
@@ -2226,7 +2226,7 @@ static int decode_gpsnav(raw_t *raw)
     if (eph.iode != iode3)
         trace(2, "SBF decode_gpsnav: mismatch of IODE in subframe 2 and 3: iode2=%d iode3=%d\n",
               eph.iode, iode3);
-    eph.fit = U1(raw->buff + 26) ? 0 : 4;
+    eph.fit = U1(raw->buff + 26) ? 6 : 4;
     /* byte 27: reserved */
     eph.tgd[0] = R4(raw->buff + 28);
     uint32_t tocs = U4(raw->buff + 32);
@@ -3106,7 +3106,7 @@ static int decode_qzssnav(raw_t *raw){
     eph.iodc = U2(raw->buff + 22);
     eph.iode = U1(raw->buff + 24);
     /* byte 25: IODE from frame 3 */
-    eph.fit = U1(raw->buff + 26);
+    eph.fit = U1(raw->buff + 26) ? 4 : 2;
     /* byte 27: reserved */
     if (R4(raw->buff + 28) != -2.e10) eph.tgd[0] = R4(raw->buff + 28);
     double toc = U4(raw->buff + 32);

--- a/src/rcv/skytraq.c
+++ b/src/rcv/skytraq.c
@@ -494,7 +494,8 @@ static int decode_ephem(int sat, raw_t *raw)
     
     trace(4,"decode_ephem: sat=%2d\n",sat);
     
-    if (!decode_frame(raw->subfrm[sat-1],&eph,NULL,NULL,NULL)) return 0;
+    int sys = satsys(sat, NULL);
+    if (!decode_frame(raw->subfrm[sat-1],sys,&eph,NULL,NULL,NULL)) return 0;
     
     if (!strstr(raw->opt,"-EPHALL")) {
         if (eph.iode==raw->nav.eph[sat-1].iode&&
@@ -514,12 +515,12 @@ static int decode_alm1(int sat, raw_t *raw)
     trace(4,"decode_alm1 : sat=%2d\n",sat);
     
     if (sys==SYS_GPS) {
-        decode_frame(raw->subfrm[sat-1],NULL,raw->nav.alm,raw->nav.ion_gps,
+        decode_frame(raw->subfrm[sat-1],sys,NULL,raw->nav.alm,raw->nav.ion_gps,
                      raw->nav.utc_gps);
         adj_utcweek(raw->time,raw->nav.utc_gps);
     }
     else if (sys==SYS_QZS) {
-        decode_frame(raw->subfrm[sat-1],NULL,raw->nav.alm,raw->nav.ion_qzs,
+        decode_frame(raw->subfrm[sat-1],sys,NULL,raw->nav.alm,raw->nav.ion_qzs,
                      raw->nav.utc_qzs);
         adj_utcweek(raw->time,raw->nav.utc_qzs);
     }
@@ -533,10 +534,10 @@ static int decode_alm2(int sat, raw_t *raw)
     trace(4,"decode_alm2 : sat=%2d\n",sat);
     
     if (sys==SYS_GPS) {
-        decode_frame(raw->subfrm[sat-1],NULL,raw->nav.alm,NULL,NULL);
+        decode_frame(raw->subfrm[sat-1],sys,NULL,raw->nav.alm,NULL,NULL);
     }
     else if (sys==SYS_QZS) {
-        decode_frame(raw->subfrm[sat-1],NULL,raw->nav.alm,raw->nav.ion_qzs,
+        decode_frame(raw->subfrm[sat-1],sys,NULL,raw->nav.alm,raw->nav.ion_qzs,
                      raw->nav.utc_qzs);
         adj_utcweek(raw->time,raw->nav.utc_qzs);
     }

--- a/src/rcv/ublox.c
+++ b/src/rcv/ublox.c
@@ -831,8 +831,8 @@ static void adj_utcweek(gtime_t time, double *utc)
 static int decode_eph(raw_t *raw, int sat)
 {
     eph_t eph={0};
-    
-    if (!decode_frame(raw->subfrm[sat-1],&eph,NULL,NULL,NULL)) return 0;
+    int sys = satsys(sat, NULL);
+    if (!decode_frame(raw->subfrm[sat-1],sys,&eph,NULL,NULL,NULL)) return 0;
     
     if (!strstr(raw->opt,"-EPHALL")) {
         if (eph.iode==raw->nav.eph[sat-1].iode&&
@@ -851,8 +851,7 @@ static int decode_ionutc(raw_t *raw, int sat)
 {
     double ion[8],utc[8];
     int sys=satsys(sat,NULL);
-    
-    if (!decode_frame(raw->subfrm[sat-1],NULL,NULL,ion,utc)) return 0;
+    if (!decode_frame(raw->subfrm[sat-1],sys,NULL,NULL,ion,utc)) return 0;
     
     adj_utcweek(raw->time,utc);
     if (sys==SYS_QZS) {

--- a/src/rinex.c
+++ b/src/rinex.c
@@ -1209,8 +1209,8 @@ static int decode_eph(double ver, int sat, gtime_t toc, const double *data,
         if (sys==SYS_GPS) {
             eph->fit=data[28];        /* fit interval (h) */
         }
-        else {
-            eph->fit=data[28]==0.0?1.0:2.0; /* fit interval (0:1h,1:>2h) */
+        else if (sys==SYS_QZS) {
+            eph->fit=data[28]==0.0?2:4; /* fit interval (0:2h,1:>2h) */
         }
     }
     else if (sys==SYS_GAL) { /* GAL ver.3 */
@@ -2743,7 +2743,7 @@ extern int outrnxnavb(FILE *fp, const rnxopt_t *opt, const eph_t *eph)
         outnavf(fp,eph->fit);
     }
     else if (sys==SYS_QZS) {
-        outnavf(fp,eph->fit>2.0?1.0:0.0);
+        outnavf(fp,eph->fit>2?1.0:0.0);
     }
     else if (sys==SYS_CMP) {
         outnavf(fp,eph->iodc); /* AODC */

--- a/src/rtcm3.c
+++ b/src/rtcm3.c
@@ -767,7 +767,7 @@ static int decode_type1019(rtcm_t *rtcm)
         eph.tgd[0]=getbits(rtcm->buff,i, 8)*P2_31;        i+= 8;
         eph.svh   =getbitu(rtcm->buff,i, 6);              i+= 6;
         eph.flag  =getbitu(rtcm->buff,i, 1);              i+= 1;
-        eph.fit   =getbitu(rtcm->buff,i, 1)?0.0:4.0; /* 0:4hr,1:>4hr */
+        eph.fit   =getbitu(rtcm->buff,i, 1)?6:4; /* 0:4hr,1:>4hr */
     }
     else {
         trace(2,"rtcm3 1019 length error: len=%d\n",rtcm->len);
@@ -1160,7 +1160,7 @@ static int decode_type1044(rtcm_t *rtcm)
         eph.svh   =getbitu(rtcm->buff,i, 6);              i+= 6;
         eph.tgd[0]=getbits(rtcm->buff,i, 8)*P2_31;        i+= 8;
         eph.iodc  =getbitu(rtcm->buff,i,10);              i+=10;
-        eph.fit   =getbitu(rtcm->buff,i, 1)?0.0:2.0; /* 0:2hr,1:>2hr */
+        eph.fit   =getbitu(rtcm->buff,i, 1)?4:2; /* 0:2hr,1:>2hr */
     }
     else {
         trace(2,"rtcm3 1044 length error: len=%d\n",rtcm->len);

--- a/src/rtcm3e.c
+++ b/src/rtcm3e.c
@@ -836,7 +836,7 @@ static int encode_type1019(rtcm_t *rtcm, int sync)
     setbits(rtcm->buff,i, 8,tgd      ); i+= 8;
     setbitu(rtcm->buff,i, 6,eph->svh ); i+= 6;
     setbitu(rtcm->buff,i, 1,eph->flag); i+= 1;
-    setbitu(rtcm->buff,i, 1,eph->fit>0.0?0:1); i+=1;
+    setbitu(rtcm->buff,i, 1,eph->fit>4?1:0); i+=1;
     rtcm->nbit=i;
     return 1;
 }
@@ -1092,7 +1092,7 @@ static int encode_type1044(rtcm_t *rtcm, int sync)
     setbitu(rtcm->buff,i, 6,eph->svh ); i+= 6;
     setbits(rtcm->buff,i, 8,tgd      ); i+= 8;
     setbitu(rtcm->buff,i,10,eph->iodc); i+=10;
-    setbitu(rtcm->buff,i, 1,eph->fit==2.0?0:1); i+=1;
+    setbitu(rtcm->buff,i, 1,eph->fit>2?1:0); i+=1;
     rtcm->nbit=i;
     return 1;
 }

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1643,7 +1643,7 @@ EXPORT uint32_t rtk_crc32 (const uint8_t *buff, int len);
 EXPORT uint32_t rtk_crc24q(const uint8_t *buff, int len);
 EXPORT uint16_t rtk_crc16 (const uint8_t *buff, int len);
 EXPORT int decode_word (uint32_t word, uint8_t *data);
-EXPORT int decode_frame(const uint8_t *buff, eph_t *eph, alm_t *alm,
+EXPORT int decode_frame(const uint8_t *buff, int sys, eph_t *eph, alm_t *alm,
                         double *ion, double *utc);
 EXPORT int test_glostr(const uint8_t *buff);
 EXPORT int decode_glostr(const uint8_t *buff, geph_t *geph, double *utc);


### PR DESCRIPTION
Notice this issue when comparing the septentrio nav output to that expected. The fit time was typically being output as zero in the RINEX nav, which was okay, but it could be better and the internal usage was not consistent.

Add a sys argument to decode_frame so that it can specialise for QZSS where the interpretation of the fit bit differs from GPS.

Rework some usage of the eph.fit which is defined in RTKLib to be in hours, so the decoded fit time, not the binary bit. It was not being consistently set. Now it is set to 4hrs for GPS when appropriate, and for now to 6hr when over 4hrs (it could be better decoded). For QZSS it is set to 2hrs when appropriate and to 4hrs when over 2hrs; QZSS appears to only use 2hr.

The fit time is not currently used by RTKLib, just past through.