### PR TITLE
Index signal specific data using the signal code

### DIFF
--- a/src/convrnx.c
+++ b/src/convrnx.c
@@ -82,8 +82,8 @@ typedef struct {                /* stream file type */
     raw_t  raw;                 /* input receiver raw data */
     rnxctr_t rnx;               /* input RINEX control data */
     stas_t *stas;               /* station list */
-    uint8_t slips [MAXSAT][NFREQ+NEXOBS]; /* cycle slip flag cache */
-    halfc_t *halfc[MAXSAT][NFREQ+NEXOBS]; /* half-cycle ambiguity list */
+    uint8_t slips [MAXSAT][MAXCODE]; /* cycle slip flag cache */
+    halfc_t *halfc[MAXSAT][MAXCODE]; /* half-cycle ambiguity list */
     FILE   *fp;                 /* output file pointer */
 } strfile_t;
 
@@ -147,7 +147,6 @@ static strfile_t *gen_strfile(int format, const char *opt)
 {
     strfile_t *str;
     gtime_t time0={0};
-    int i,j;
     
     trace(3,"init_strfile:\n");
     
@@ -200,9 +199,10 @@ static strfile_t *gen_strfile(int format, const char *opt)
     }
 
     str->stas=NULL;
-    for (i=0;i<MAXSAT;i++) for (j=0;j<NFREQ+NEXOBS;j++) {
-        str->slips[i][j]=0;
-        str->halfc[i][j]=NULL;
+    for (int i=0;i<MAXSAT;i++)
+      for (int code=0;code<MAXCODE;code++) {
+        str->slips[i][code]=0;
+        str->halfc[i][code]=NULL;
     }
     str->fp=NULL;
     return str;
@@ -212,7 +212,6 @@ static void free_strfile(strfile_t *str)
 {
     stas_t *sp,*sp_next;
     halfc_t *hp,*hp_next;
-    int i,j;
 
     trace(3,"free_strfile:\n");
     
@@ -229,8 +228,9 @@ static void free_strfile(strfile_t *str)
         sp_next=sp->next;
         free(sp);
     }
-    for (i=0;i<MAXSAT;i++) for (j=0;j<NFREQ+NEXOBS;j++) {
-        for (hp=str->halfc[i][j];hp;hp=hp_next) {
+    for (int i=0;i<MAXSAT;i++)
+      for (int code=0;code<MAXCODE;code++) {
+        for (hp=str->halfc[i][code];hp;hp=hp_next) {
             hp_next=hp->next;
             free(hp);
         }
@@ -625,15 +625,15 @@ static void dump_stas(const strfile_t *str)
 #endif
 }
 /* add half-cycle ambiguity list ---------------------------------------------*/
-static int add_halfc(strfile_t *str, int sat, int idx, gtime_t time)
+static int add_halfc(strfile_t *str, int sat, int code, gtime_t time)
 {
     halfc_t *p;
     
     if (!(p=(halfc_t *)calloc(sizeof(halfc_t),1))) return 0;
     p->ts=p->te=time;
     p->stat=0;
-    p->next=str->halfc[sat-1][idx];
-    str->halfc[sat-1][idx]=p;
+    p->next=str->halfc[sat-1][code];
+    str->halfc[sat-1][code]=p;
     return 1;
 }
 /* update half-cycle ambiguity -----------------------------------------------*/
@@ -644,56 +644,59 @@ static void update_halfc(strfile_t *str, obsd_t *obs)
     for (i=0;i<NFREQ+NEXOBS;i++) {
         if (obs->L[i]==0.0) continue;
 
+        int code = obs->code[i];
+        if (code == CODE_NONE) continue;
+
         /* if no list, start list */
-        if (!str->halfc[sat-1][i]) {
-            if (!add_halfc(str,sat,i,obs->time)) continue;
+        if (!str->halfc[sat-1][code]) {
+            if (!add_halfc(str,sat,code,obs->time)) continue;
         }
         /* reset list if true cycle slip */
         if ((obs->LLI[i]&LLI_SLIP)&&!(obs->LLI[i]&(LLI_HALFA|LLI_HALFS))) {
-            str->halfc[sat-1][i]->stat=0;
+            str->halfc[sat-1][code]->stat=0;
         }
         if (obs->LLI[i]&LLI_HALFC) { /* halfcyc unresolved */
             /* if new list, set unresolved start epoch */
-            if (str->halfc[sat-1][i]->stat==0) {
-                str->halfc[sat-1][i]->ts=obs->time;
+            if (str->halfc[sat-1][code]->stat==0) {
+                str->halfc[sat-1][code]->ts=obs->time;
             }
             /* update unresolved end epoch and set status to active */
-            str->halfc[sat-1][i]->te=obs->time;
-            str->halfc[sat-1][i]->stat=1;
+            str->halfc[sat-1][code]->te=obs->time;
+            str->halfc[sat-1][code]->stat=1;
         } /* else if resolved, update status */
-        else if (str->halfc[sat-1][i]->stat==1) {
+        else if (str->halfc[sat-1][code]->stat==1) {
             if (obs->LLI[i]&LLI_HALFA) {
-                str->halfc[sat-1][i]->stat=2; /* resolved with add */
+                str->halfc[sat-1][code]->stat=2; /* resolved with add */
             }
             else if (obs->LLI[i]&LLI_HALFS) {
-                str->halfc[sat-1][i]->stat=3; /* resolved with subtract */
+                str->halfc[sat-1][code]->stat=3; /* resolved with subtract */
             }
             else {
-                str->halfc[sat-1][i]->stat=4; /* resolved with no adjust */
+                str->halfc[sat-1][code]->stat=4; /* resolved with no adjust */
             }
             /* create new list entry */
-            if (!add_halfc(str,sat,i,obs->time)) continue;
+            if (!add_halfc(str,sat,code,obs->time)) continue;
         }
     }
 }
 /* dump half-cycle ambiguity list --------------------------------------------*/
 static void dump_halfc(const strfile_t *str)
 {
-#if 0 /* for debug */
-    halfc_t *p;
-    char s0[8],s1[40],s2[40],*stats[]={"ADD","SUB","NON"};
-    int i,j;
-    
+#ifdef RTK_DISABLED /* for debug */
     trace(2,"# HALF-CYCLE AMBIGUITY CORRECTIONS\n");
     trace(2,"# %20s %22s %4s %3s %3s\n","START","END","SAT","FRQ","COR");
     
-    for (i=0;i<MAXSAT;i++) for (j=0;j<NFREQ+NEXOBS;j++) {
-        for (p=str->halfc[i][j];p;p=p->next) {
+    for (int i=0;i<MAXSAT;i++)
+      for (int code=0;code<MAXCODE;code++) {
+        const char *obs=code2obs(code);
+        for (halfc_t *p=str->halfc[i][code];p;p=p->next) {
             if (p->stat<=1) continue;
+            char s0[8],s1[40],s2[40];
             satno2id(i+1,s0);
             time2str(p->ts,s1,2);
             time2str(p->te,s2,2);
-            trace(2,"%s %s %4s %3d %3s\n",s1,s2,s0,j+1,stats[p->stat-2]);
+            const char *stats[]={"ADD","SUB","NON"};
+            trace(2,"%s %s %4s %2s %3s\n",s1,s2,s0,obs,stats[p->stat-2]);
         }
     }
 #endif
@@ -702,15 +705,16 @@ static void dump_halfc(const strfile_t *str)
 static void resolve_halfc(const strfile_t *str, obsd_t *data, int n)
 {
     halfc_t *p;
-    int i,j,sat;
+    int sat;
     
-    for (i=0;i<n;i++) for (j=0;j<NFREQ+NEXOBS;j++) {
+    for (int i=0;i<n;i++) {
         sat=data[i].sat;
-        
-        for (p=str->halfc[sat-1][j];p;p=p->next) {
-            if (p->stat<=1) continue;  /* unresolved half cycle */
-            if (timediff(data[i].time,p->ts)<-DTTOL||
-                timediff(data[i].time,p->te)> DTTOL) continue;
+        for (int j=0;j<NFREQ+NEXOBS;j++) {
+            int code = data[i].code[j];
+            for (p=str->halfc[sat-1][code];p;p=p->next) {
+                if (p->stat<=1) continue;  /* unresolved half cycle */
+                if (timediff(data[i].time,p->ts)<-DTTOL||
+                    timediff(data[i].time,p->te)> DTTOL) continue;
 
             if (p->stat==2) {    /* add half cycle */
                 data[i].L[j]+=0.5;
@@ -721,6 +725,7 @@ static void resolve_halfc(const strfile_t *str, obsd_t *data, int n)
             data[i].LLI[j]&=~LLI_HALFC;
         }
         data[i].LLI[j]&=~(LLI_HALFA|LLI_HALFS);
+        }
     }
 }
 /* scan input files ----------------------------------------------------------*/
@@ -757,14 +762,14 @@ static int scan_file(char **files, int nf, rnxopt_t *opt, strfile_t *str,
                     
                     /* update obs-types */
                     for (j=0;j<NFREQ+NEXOBS;j++) {
-                        int c=str->obs->data[i].code[j];
-                        if (c==CODE_NONE) continue;
+                        int cd=str->obs->data[i].code[j];
+                        if (cd==CODE_NONE) continue;
                         
                         for (k=0;k<n[l];k++) {
-                            if (codes[l][k]==c) break;
+                            if (codes[l][k]==cd) break;
                         }
                         if (k>=n[l]&&n[l]<32) {
-                            codes[l][n[l]++]=c;
+                            codes[l][n[l]++]=cd;
                         }
                         if (k<n[l]) {
                             if (str->obs->data[i].P[j]!=0.0) types[l][k]|=1;
@@ -971,21 +976,27 @@ static void outrnxevent(FILE *fp, const rnxopt_t *opt, gtime_t time, int event,
 /* save cycle slips ----------------------------------------------------------*/
 static void save_slips(strfile_t *str, obsd_t *data, int n)
 {
-    int i,j;
-    
-    for (i=0;i<n;i++) for (j=0;j<NFREQ+NEXOBS;j++) {
-        if (data[i].LLI[j]&LLI_SLIP) str->slips[data[i].sat-1][j]=1;
+    for (int i=0;i<n;i++)
+      for (int j=0;j<NFREQ+NEXOBS;j++) {
+          int sat = data[i].sat;
+          if (sat == 0) continue;
+          int code = data[i].code[j];
+          if (code == CODE_NONE) continue;
+          if (data[i].LLI[j]&LLI_SLIP) str->slips[sat-1][code]=1;
     }
 }
 /* restore cycle slips -------------------------------------------------------*/
 static void rest_slips(strfile_t *str, obsd_t *data, int n)
 {
-    int i,j;
-    
-    for (i=0;i<n;i++) for (j=0;j<NFREQ+NEXOBS;j++) {
-        if (data[i].L[j]!=0.0&&str->slips[data[i].sat-1][j]) {
-            data[i].LLI[j]|=LLI_SLIP;
-            str->slips[data[i].sat-1][j]=0;
+    for (int i=0;i<n;i++)
+      for (int j=0;j<NFREQ+NEXOBS;j++) {
+          int sat = data[i].sat;
+          if (sat == 0) continue;
+          int code = data[i].code[j];
+          if (code == CODE_NONE) continue;
+          if (data[i].L[j]!=0.0&&str->slips[sat-1][code]) {
+              data[i].LLI[j]|=LLI_SLIP;
+              str->slips[sat-1][code]=0;
         }
     }
 }
@@ -1025,14 +1036,19 @@ static void convobs(FILE **ofp, rnxopt_t *opt, strfile_t *str, int *n,
     /* save cycle slips */
     save_slips(str,str->obs->data,str->obs->n);
     
-    if (!screent_ttol(time,opt->ts,opt->te,opt->tint,opt->ttol)) return;
+    if (!screent_ttol(time,opt->ts,opt->te,opt->tint,opt->ttol)) {
+      if (str->staid!=*staid) { /* Station ID changed */
+        *staid=str->staid;
+      }
+      str->obs->flag = 0;
+      return;
+    }
     
-    /* restore cycle slips */
+    /* Restore cycle slips */
     rest_slips(str,str->obs->data,str->obs->n);
     
-    if (str->staid!=*staid) { /* station ID changed */
-        
-        if (*staid>=0) { /* output RINEX event */
+    if (str->staid!=*staid) { /* Station ID changed */
+        if (*staid>=0) { /* Output RINEX event */
             outrnxevent(ofp[0],opt,str->time,EVENT_NEWSITE,str->stas,str->staid);
         }
         *staid=str->staid;
@@ -1259,7 +1275,7 @@ static int convrnx_s(int sess, int format, rnxopt_t *opt, const char *file,
     FILE *ofp[NOUTFILE]={NULL};
     strfile_t *str;
     gtime_t tend[3]={{0}};
-    int i,j,nf,type,n[NOUTFILE+2]={0},mask[MAXEXFILE]={0},staid=-1,abort=0;
+    int j,nf,type,n[NOUTFILE+2]={0},mask[MAXEXFILE]={0},staid=-1,abort=0;
     char path[1024],*paths[NOUTFILE],s[NOUTFILE][1024];
     char *epath[MAXEXFILE]={0},*staname=*opt->staid?opt->staid:"0000";
     
@@ -1273,7 +1289,7 @@ static int convrnx_s(int sess, int format, rnxopt_t *opt, const char *file,
         return 0;
     }
     /* expand wild-cards in input file */
-    for (i=0;i<MAXEXFILE;i++) {
+    for (int i=0;i<MAXEXFILE;i++) {
         if (!(epath[i]=(char *)malloc(1024))) {
             for (i=0;i<MAXEXFILE;i++) free(epath[i]);
             return 0;
@@ -1284,7 +1300,7 @@ static int convrnx_s(int sess, int format, rnxopt_t *opt, const char *file,
         return 0;
     }
     if (!(str=gen_strfile(format,opt->rcvopt))) {
-        for (i=0;i<MAXEXFILE;i++) free(epath[i]);
+        for (int i=0;i<MAXEXFILE;i++) free(epath[i]);
         return 0;
     }
     if (format==STRFMT_RTCM2||format==STRFMT_RTCM3||format==STRFMT_RT17) {
@@ -1294,12 +1310,12 @@ static int convrnx_s(int sess, int format, rnxopt_t *opt, const char *file,
         str->time=timeadd(opt->ts,-1.0);
     }
     /* set GLONASS FCN in RINEX options */
-    for (i=0;i<MAXPRNGLO;i++) {
+    for (int i=0;i<MAXPRNGLO;i++) {
         str->nav->glo_fcn[i]=opt->glofcn[i]; /* FCN+8 */
     }
     /* scan input files */
     if (!scan_file(epath,nf,opt,str,mask)) {
-        for (i=0;i<MAXEXFILE;i++) free(epath[i]);
+        for (int i=0;i<MAXEXFILE;i++) free(epath[i]);
         free_strfile(str);
         return 0;
     }
@@ -1307,7 +1323,7 @@ static int convrnx_s(int sess, int format, rnxopt_t *opt, const char *file,
     setopt_file(format,epath,nf,mask,opt);
     
     /* replace keywords in output file */
-    for (i=0;i<NOUTFILE;i++) {
+    for (int i=0;i<NOUTFILE;i++) {
         paths[i]=s[i];
         if (reppath(ofile[i],paths[i],opt->ts.time?opt->ts:str->tstart,
                     staname,"")<0) {
@@ -1319,13 +1335,13 @@ static int convrnx_s(int sess, int format, rnxopt_t *opt, const char *file,
     }
     /* open output files */
     if (!openfile(ofp,paths,path,opt,str->nav)) {
-        for (i=0;i<MAXEXFILE;i++) free(epath[i]);
+        for (int i=0;i<MAXEXFILE;i++) free(epath[i]);
         free_strfile(str);
         return 0;
     }
     str->time=str->tstart;
     
-    for (i=0;i<nf&&!abort;i++) {
+    for (int i=0;i<nf&&!abort;i++) {
         if (!mask[i]) continue;
         
         /* open stream file */
@@ -1356,7 +1372,7 @@ static int convrnx_s(int sess, int format, rnxopt_t *opt, const char *file,
     closefile(ofp,opt,str->nav);
     
     /* remove empty output files */
-    for (i=0;i<NOUTFILE;i++) {
+    for (int i=0;i<NOUTFILE;i++) {
         if (ofp[i]&&n[i]<=0) remove(ofile[i]);
     }
     showstat(sess,opt->tstart,opt->tend,n);
@@ -1365,7 +1381,7 @@ static int convrnx_s(int sess, int format, rnxopt_t *opt, const char *file,
     unsetopt_file(opt);
     
     free_strfile(str);
-    for (i=0;i<MAXEXFILE;i++) free(epath[i]);
+    for (int i=0;i<MAXEXFILE;i++) free(epath[i]);
     
     return abort?-1:1;
 }

--- a/src/rcv/novatel.c
+++ b/src/rcv/novatel.c
@@ -414,18 +414,18 @@ static int decode_rangecmpb(raw_t *raw)
         }
         lockt=(U4(p+18)&0x1FFFFF)/32.0; /* lock time */
         
-        if (raw->tobs[sat-1][idx].time!=0) {
-            tt=timediff(raw->time,raw->tobs[sat-1][idx]);
-            lli=(lockt<65535.968&&lockt-raw->lockt[sat-1][idx]+0.05<=tt)?LLI_SLIP:0;
+        if (raw->tobs[sat-1][code].time!=0) {
+            tt=timediff(raw->time,raw->tobs[sat-1][code]);
+            lli=(lockt<65535.968&&lockt-raw->lockt[sat-1][code]+0.05<=tt)?LLI_SLIP:0;
         }
         else {
             lli=0;
         }
         if (!parity) lli|=LLI_HALFC;
         if (halfc  ) lli|=LLI_HALFA;
-        raw->tobs [sat-1][idx]=raw->time;
-        raw->lockt[sat-1][idx]=lockt;
-        raw->halfc[sat-1][idx]=halfc;
+        raw->tobs [sat-1][code]=raw->time;
+        raw->lockt[sat-1][code]=lockt;
+        raw->halfc[sat-1][code]=halfc;
         
         snr=((U2(p+20)&0x3FF)>>5)+20.0;
         if (!clock) psr=0.0;     /* code unlock */
@@ -498,18 +498,18 @@ static int decode_rangeb(raw_t *raw)
                 raw->nav.glo_fcn[prn-1]=gfrq; /* fcn+8 */
             }
         }
-        if (raw->tobs[sat-1][idx].time!=0) {
-            tt=timediff(raw->time,raw->tobs[sat-1][idx]);
-            lli=lockt-raw->lockt[sat-1][idx]+0.05<=tt?LLI_SLIP:0;
+        if (raw->tobs[sat-1][code].time!=0) {
+            tt=timediff(raw->time,raw->tobs[sat-1][code]);
+            lli=lockt-raw->lockt[sat-1][code]+0.05<=tt?LLI_SLIP:0;
         }
         else {
             lli=0;
         }
         if (!parity) lli|=LLI_HALFC;
         if (halfc  ) lli|=LLI_HALFA;
-        raw->tobs [sat-1][idx]=raw->time;
-        raw->lockt[sat-1][idx]=lockt;
-        raw->halfc[sat-1][idx]=halfc;
+        raw->tobs [sat-1][code]=raw->time;
+        raw->lockt[sat-1][code]=lockt;
+        raw->halfc[sat-1][code]=halfc;
         
         if (!clock) psr=0.0;     /* code unlock */
         if (!plock) adr=dop=0.0; /* phase unlock */
@@ -1093,18 +1093,19 @@ static int decode_rgeb(raw_t *raw)
             trace(2,"oem3 regb satellite number error: sys=%d prn=%d\n",sys,prn);
             continue;
         }
-        if (raw->tobs[sat-1][freq].time!=0) {
-            tt=timediff(raw->time,raw->tobs[sat-1][freq]);
-            lli=lockt-raw->lockt[sat-1][freq]+0.05<tt||
-                parity!=raw->halfc[sat-1][freq];
+        int code=freq==0?CODE_L1C:CODE_L2P;
+        if (raw->tobs[sat-1][code].time!=0) {
+            tt=timediff(raw->time,raw->tobs[sat-1][code]);
+            lli=lockt-raw->lockt[sat-1][code]+0.05<tt||
+                parity!=raw->halfc[sat-1][code];
         }
         else {
             lli=0;
         }
         if (!parity) lli|=2;
-        raw->tobs [sat-1][freq]=raw->time;
-        raw->lockt[sat-1][freq]=lockt;
-        raw->halfc[sat-1][freq]=parity;
+        raw->tobs [sat-1][code]=raw->time;
+        raw->lockt[sat-1][code]=lockt;
+        raw->halfc[sat-1][code]=parity;
         
         if (fabs(timediff(raw->obs.data[0].time,raw->time))>1E-9) {
             raw->obs.n=0;
@@ -1116,7 +1117,7 @@ static int decode_rgeb(raw_t *raw)
             raw->obs.data[index].SNR[freq]=
                 0.0<=snr&&snr<255.0?(uint16_t)(snr/SNR_UNIT+0.5):0;
             raw->obs.data[index].LLI[freq]=(uint8_t)lli;
-            raw->obs.data[index].code[freq]=freq==0?CODE_L1C:CODE_L2P;
+            raw->obs.data[index].code[freq]=code;
         }
     }
     return 1;
@@ -1159,18 +1160,19 @@ static int decode_rged(raw_t *raw)
         adr_rolls=floor((psr/(freq==0?WL1:WL2)-adr)/MAXVAL+0.5);
         adr=adr+MAXVAL*adr_rolls;
         
-        if (raw->tobs[sat-1][freq].time!=0) {
-            tt=timediff(raw->time,raw->tobs[sat-1][freq]);
-            lli=lockt-raw->lockt[sat-1][freq]+0.05<tt||
-                parity!=raw->halfc[sat-1][freq];
+        int code = freq==0?CODE_L1C:CODE_L2P;
+        if (raw->tobs[sat-1][code].time!=0) {
+            tt=timediff(raw->time,raw->tobs[sat-1][code]);
+            lli=lockt-raw->lockt[sat-1][code]+0.05<tt||
+                parity!=raw->halfc[sat-1][code];
         }
         else {
             lli=0;
         }
         if (!parity) lli|=2;
-        raw->tobs [sat-1][freq]=raw->time;
-        raw->lockt[sat-1][freq]=lockt;
-        raw->halfc[sat-1][freq]=parity;
+        raw->tobs [sat-1][code]=raw->time;
+        raw->lockt[sat-1][code]=lockt;
+        raw->halfc[sat-1][code]=parity;
         
         if (fabs(timediff(raw->obs.data[0].time,raw->time))>1E-9) {
             raw->obs.n=0;
@@ -1181,7 +1183,7 @@ static int decode_rged(raw_t *raw)
             raw->obs.data[index].D  [freq]=(float)dop;
             raw->obs.data[index].SNR[freq]=(uint16_t)(snr/SNR_UNIT+0.5);
             raw->obs.data[index].LLI[freq]=(uint8_t)lli;
-            raw->obs.data[index].code[freq]=freq==0?CODE_L1C:CODE_L2P;
+            raw->obs.data[index].code[freq]=code;
         }
     }
     return 1;

--- a/src/rcv/septentrio.c
+++ b/src/rcv/septentrio.c
@@ -76,8 +76,7 @@ typedef struct {
   uint8_t signalIdx[MEAS3_SYS_MAX][MEAS3_SAT_MAX][MEAS3_SIG_MAX];  // Reference signal indeces
   uint32_t slaveSignalMask[MEAS3_SYS_MAX][MEAS3_SAT_MAX];  // Mask of available slave signals
   int16_t prRate[MEAS3_SYS_MAX][MEAS3_SAT_MAX];  // Pseudo-range change rate in 64 mm steps
-  uint32_t lockt[MEAS3_SYS_MAX][MEAS3_SAT_MAX][NFREQ + NEXOBS];  // Lock time of the PLL, in ms
-  uint8_t halfc[MEAS3_SYS_MAX][MEAS3_SAT_MAX][NFREQ + NEXOBS];   // Half cycle ambiguity
+  uint32_t lockt[MEAS3_SYS_MAX][MEAS3_SAT_MAX][MAXCODE];  // Lock time of the PLL, in ms
 
   uint8_t constellationHeader[MEAS3_SYS_MAX][32];  // Copy of constellation header
 } Meas3_RefEpoch_t;
@@ -782,9 +781,9 @@ static int decode_measepoch(raw_t *raw)
         if (P1!=0.0 && freq1>0.0 && lock!=65535 && (I1(p+14) != -128 || U2(p+12) != 0)) {
             L1 = I1(p+14)*65.536 + U2(p+12)*0.001;
             raw->obuf.data[n].L[idx] = P1*freq1/CLIGHT + L1;
-            LLI = (lock<raw->lockt[sat-1][idx] ? 1 : 0) + ((info & (1<<2)) ? 2 : 0);
+            LLI = (lock<raw->lockt[sat-1][code] ? 1 : 0) + ((info & (1<<2)) ? 2 : 0);
             raw->obuf.data[n].LLI[idx] = (uint8_t)LLI;
-            raw->lockt[sat-1][idx] = lock;
+            raw->lockt[sat-1][code] = lock;
         }
         if (U1(p+15) != 255) {
             S1 = U1(p+15)*0.25 + ((sig==1 || sig==2) ? 0.0 : 10.0);
@@ -810,9 +809,9 @@ static int decode_measepoch(raw_t *raw)
             P2 = 0.0;
             freq2 = code2freq(sys, code, fcn);
             if (lock != 255) {
-                LLI = (lock<raw->lockt[sat-1][idx] ? 1 : 0) + ((info&(1<<2)) ? 2 : 0);
+                LLI = (lock<raw->lockt[sat-1][code] ? 1 : 0) + ((info&(1<<2)) ? 2 : 0);
                 raw->obuf.data[n].LLI[idx] = (uint8_t)LLI;
-                raw->lockt[sat-1][idx] = lock;
+                raw->lockt[sat-1][code] = lock;
             }
             if (U1(p+2) != 255) {
                 S2 = U1(p+2)*0.25 + ((sig==1 || sig==2) ? 0.0 : 10.0);
@@ -1105,7 +1104,7 @@ static int decode_meas3ranges(raw_t *raw) {
                             raw->obuf.data[n].L[masterFreqIndex] = pr / (CLIGHT/freqMaster) - 131.072 + (double)cmc * .001;
 
                         raw->obuf.data[n].LLI[masterFreqIndex] = (lockTime < raw->lockt[satNo-1][masterFreqIndex] ? LLI_SLIP : 0) | (lti3 == 0 ? LLI_HALFC : 0);
-                        raw->lockt[satNo-1][masterFreqIndex] = lockTime;
+                        raw->lockt[satNo-1][codeMaster] = lockTime;
                         raw->obuf.data[n].freq = glofnc+7;
                         sbf->meas3_freqAssignment[navsys][svid][0] = masterFreqIndex;
                     };
@@ -1151,7 +1150,7 @@ static int decode_meas3ranges(raw_t *raw) {
                             raw->obuf.data[n].L[masterFreqIndex] = raw->obuf.data[n].P[masterFreqIndex] / (CLIGHT/freqMaster) - 2097.152 + (double)cmc * .001;
 
                         raw->obuf.data[n].LLI[masterFreqIndex] = (lockTime < raw->lockt[satNo-1][masterFreqIndex] ? LLI_SLIP : 0) | (lti4 == 0 ? LLI_HALFC : 0);
-                        raw->lockt[satNo-1][masterFreqIndex] = lockTime;
+                        raw->lockt[satNo-1][codeMaster] = lockTime;
                         raw->obuf.data[n].freq = glofnc+7;
                         sbf->meas3_freqAssignment[navsys][svid][0] = masterFreqIndex;
                     };
@@ -1187,7 +1186,7 @@ static int decode_meas3ranges(raw_t *raw) {
                                                            master_reference->L[masterFreqIndex] - 32.768 + (double)cmc * .001;
 
                         raw->obuf.data[n].LLI[masterFreqIndex] = master_reference->LLI[masterFreqIndex];
-                        raw->lockt[satNo-1][masterFreqIndex] = sbf->meas3_refEpoch.lockt[navsys][svid][masterFreqIndex];
+                        raw->lockt[satNo-1][codeMaster] = sbf->meas3_refEpoch.lockt[navsys][svid][codeMaster];
                         raw->obuf.data[n].freq = glofnc+7;
                         sbf->meas3_freqAssignment[navsys][svid][0] = masterFreqIndex;
                     }
@@ -1213,7 +1212,7 @@ static int decode_meas3ranges(raw_t *raw) {
                             raw->obuf.data[n].L[masterFreqIndex] = (raw->obuf.data[n].P[masterFreqIndex] - masterReference->P[masterFreqIndex]) / (CLIGHT/freqMaster) + masterReference->L[masterFreqIndex] - 8.192 + (double)cmc * .001;
                         raw->obuf.data[n].SNR[masterFreqIndex] = (uint16_t)((masterReference->SNR[masterFreqIndex] * SNR_UNIT - 1.0 + CN0) / SNR_UNIT + 0.5);
                         raw->obuf.data[n].LLI[masterFreqIndex] = masterReference->LLI[masterFreqIndex];
-                        raw->lockt[satNo-1][masterFreqIndex] = sbf->meas3_refEpoch.lockt[navsys][svid][masterFreqIndex];
+                        raw->lockt[satNo-1][codeMaster] = sbf->meas3_refEpoch.lockt[navsys][svid][codeMaster];
                         raw->obuf.data[n].code[masterFreqIndex] = codeMaster;
                         raw->obuf.data[n].freq = glofnc+8;
                         sbf->meas3_freqAssignment[navsys][svid][0] = masterFreqIndex;
@@ -1238,12 +1237,12 @@ static int decode_meas3ranges(raw_t *raw) {
                     sbf->meas3_refEpoch.obsData[navsys][svid].L[masterFreqIndex] = raw->obuf.data[n].L[masterFreqIndex];
                     sbf->meas3_refEpoch.obsData[navsys][svid].SNR[masterFreqIndex] = raw->obuf.data[n].SNR[masterFreqIndex];
                     sbf->meas3_refEpoch.obsData[navsys][svid].LLI[masterFreqIndex] = raw->obuf.data[n].LLI[masterFreqIndex];
-                    sbf->meas3_refEpoch.lockt[navsys][svid][masterFreqIndex] = raw->lockt[satNo-1][masterFreqIndex];
+                    sbf->meas3_refEpoch.lockt[navsys][svid][codeMaster] = raw->lockt[satNo-1][codeMaster];
                 }
 
                 // update PLL lock time
-                if (satNo > 0  && raw->lockt[satNo-1][masterFreqIndex] > sbf->meas3_refEpoch.lockt[navsys][svid][masterFreqIndex])
-                    sbf->meas3_refEpoch.lockt[navsys][svid][masterFreqIndex] = raw->lockt[satNo-1][masterFreqIndex];
+                if (satNo > 0  && raw->lockt[satNo-1][codeMaster] > sbf->meas3_refEpoch.lockt[navsys][svid][codeMaster])
+                    sbf->meas3_refEpoch.lockt[navsys][svid][codeMaster] = raw->lockt[satNo-1][codeMaster];
 
                 /* decode slave data */
                 int slaveCnt = 0;
@@ -1288,7 +1287,7 @@ static int decode_meas3ranges(raw_t *raw) {
 
                                 raw->obuf.data[n].code[slaveFreqIndex] = codeSlave;
                                 raw->obuf.data[n].LLI[slaveFreqIndex] = (lockTime < raw->lockt[satNo-1][slaveFreqIndex] ? LLI_SLIP : 0) | (lti3 == 0 ? LLI_HALFC : 0);
-                                raw->lockt[satNo-1][slaveFreqIndex] = lockTime;
+                                raw->lockt[satNo-1][codeSlave] = lockTime;
                                 sbf->meas3_freqAssignment[navsys][svid][slaveCnt+1] = slaveFreqIndex;
                             }
 
@@ -1318,8 +1317,8 @@ static int decode_meas3ranges(raw_t *raw) {
                                     raw->obuf.data[n].SNR[slaveFreqIndex] = (uint16_t)((CN0 + 10.0) / SNR_UNIT + 0.5);
 
                                 raw->obuf.data[n].code[slaveFreqIndex] = codeSlave;
-                                raw->obuf.data[n].LLI[slaveFreqIndex] = (lockTime < raw->lockt[satNo-1][slaveFreqIndex] ? LLI_SLIP : 0) | (lti4 == 0 ? LLI_HALFC : 0);
-                                raw->lockt[satNo-1][slaveFreqIndex] = lockTime;
+                                raw->obuf.data[n].LLI[slaveFreqIndex] = (lockTime < raw->lockt[satNo-1][codeSlave] ? LLI_SLIP : 0) | (lti4 == 0 ? LLI_HALFC : 0);
+                                raw->lockt[satNo-1][codeSlave] = lockTime;
                                 sbf->meas3_freqAssignment[navsys][svid][slaveCnt+1] = slaveFreqIndex;
                             }
 
@@ -1351,7 +1350,7 @@ static int decode_meas3ranges(raw_t *raw) {
 
                                 raw->obuf.data[n].code[slaveFreqIndex] = codeSlave;
                                 raw->obuf.data[n].LLI[slaveFreqIndex] = slaveReference->LLI[slaveRefFreqIdx];
-                                raw->lockt[satNo-1][slaveFreqIndex] = sbf->meas3_refEpoch.lockt[navsys][svid][slaveCnt+1];
+                                raw->lockt[satNo-1][codeSlave] = sbf->meas3_refEpoch.lockt[navsys][svid][codeSlave];
                                 sbf->meas3_freqAssignment[navsys][svid][slaveCnt+1] = slaveFreqIndex;
                             }
 
@@ -1369,11 +1368,11 @@ static int decode_meas3ranges(raw_t *raw) {
                             sbf->meas3_refEpoch.obsData[navsys][svid].L[slaveFreqIndex] = raw->obuf.data[n].L[slaveFreqIndex];
                             sbf->meas3_refEpoch.obsData[navsys][svid].SNR[slaveFreqIndex] = raw->obuf.data[n].SNR[slaveFreqIndex];
                             sbf->meas3_refEpoch.obsData[navsys][svid].LLI[slaveFreqIndex] = raw->obuf.data[n].LLI[slaveFreqIndex];
-                            sbf->meas3_refEpoch.lockt[navsys][svid][slaveFreqIndex] = raw->lockt[satNo-1][slaveFreqIndex];
+                            sbf->meas3_refEpoch.lockt[navsys][svid][codeSlave] = raw->lockt[satNo-1][codeSlave];
                         }
 
-                        if (raw->lockt[satNo-1][slaveFreqIndex] > sbf->meas3_refEpoch.lockt[navsys][svid][slaveFreqIndex])
-                            sbf->meas3_refEpoch.lockt[navsys][svid][slaveFreqIndex] = raw->lockt[satNo-1][slaveFreqIndex];
+                        if (raw->lockt[satNo-1][codeSlave] > sbf->meas3_refEpoch.lockt[navsys][svid][codeSlave])
+                            sbf->meas3_refEpoch.lockt[navsys][svid][codeSlave] = raw->lockt[satNo-1][codeSlave];
 
                         slaveCnt++;
                         /* delete this bit of the mask */

--- a/src/rcv/unicore.c
+++ b/src/rcv/unicore.c
@@ -781,18 +781,18 @@ static int decode_obsvmb(raw_t* raw)
                 raw->nav.glo_fcn[prn - 1] = gfrq; /* fcn+8 */
             }
         }
-        if (raw->tobs[sat - 1][idx].time != 0) {
-            tt = timediff(raw->time, raw->tobs[sat - 1][idx]);
-            lli = lockt - raw->lockt[sat - 1][idx] + 0.05 <= tt ? LLI_SLIP : 0;
+        if (raw->tobs[sat - 1][code].time != 0) {
+            tt = timediff(raw->time, raw->tobs[sat - 1][code]);
+            lli = lockt - raw->lockt[sat - 1][code] + 0.05 <= tt ? LLI_SLIP : 0;
         }
         else {
             lli = 0;
         }
         //      if (!parity) lli |= LLI_HALFC;
         //      if (halfc) lli |= LLI_HALFA;
-        raw->tobs[sat - 1][idx] = raw->time;
-        raw->lockt[sat - 1][idx] = lockt;
-        raw->halfc[sat - 1][idx] = 0;
+        raw->tobs[sat - 1][code] = raw->time;
+        raw->lockt[sat - 1][code] = lockt;
+        raw->halfc[sat - 1][code] = 0;
 
         if (!clock) psr = 0.0;     /* code unlock */
         if (!plock) adr = dop = 0.0; /* phase unlock */

--- a/src/rcvraw.c
+++ b/src/rcvraw.c
@@ -1316,10 +1316,11 @@ extern int init_raw(raw_t *raw, int format)
     raw->msgtype[0]='\0';
     for (i=0;i<MAXSAT;i++) {
         for (j=0;j<380;j++) raw->subfrm[i][j]=0;
-        for (j=0;j<NFREQ+NEXOBS;j++) {
-            raw->tobs [i][j]=time0;
-            raw->lockt[i][j]=0.0;
-            raw->halfc[i][j]=0;
+        for (int code=0; code<MAXCODE; code++) {
+            raw->tobs [i][code]=time0;
+            raw->lockt[i][code]=0.0;
+            raw->halfc[i][code]=0;
+            raw->lockflag[i][code]=0;
         }
         raw->icpp[i]=raw->off[i]=raw->prCA[i]=raw->dpCA[i]=0.0;
     }

--- a/src/rinex.c
+++ b/src/rinex.c
@@ -915,20 +915,20 @@ static int decode_obsdata(FILE *fp, char *buff, double ver, int mask,
     return 1;
 }
 /* save cycle slips ----------------------------------------------------------*/
-static void saveslips(uint8_t slips[][NFREQ+NEXOBS], obsd_t *data)
+static void saveslips(uint8_t slips[][MAXCODE], obsd_t *data)
 {
-    int i;
-    for (i=0;i<NFREQ+NEXOBS;i++) {
-        if (data->LLI[i]&1) slips[data->sat-1][i]|=LLI_SLIP;
+    for (int i=0;i<NFREQ+NEXOBS;i++) {
+        int code = data->code[i];
+        if (data->LLI[i]&1) slips[data->sat-1][code]=1;
     }
 }
 /* restore cycle slips -------------------------------------------------------*/
-static void restslips(uint8_t slips[][NFREQ+NEXOBS], obsd_t *data)
+static void restslips(uint8_t slips[][MAXCODE], obsd_t *data)
 {
-    int i;
-    for (i=0;i<NFREQ+NEXOBS;i++) {
-        if (slips[data->sat-1][i]&1) data->LLI[i]|=LLI_SLIP;
-        slips[data->sat-1][i]=0;
+    for (int i=0;i<NFREQ+NEXOBS;i++) {
+        int code = data->code[i];
+        if (slips[data->sat-1][code]&1) data->LLI[i]|=LLI_SLIP;
+        slips[data->sat-1][code]=0;
     }
 }
 /* add observation data ------------------------------------------------------*/
@@ -1115,7 +1115,7 @@ static int readrnxobs(FILE *fp, gtime_t ts, gtime_t te, double tint,
 {
     gtime_t eventime={0},time0={0},time1={0};
     obsd_t *data;
-    uint8_t slips[MAXSAT][NFREQ+NEXOBS]={{0}};
+    uint8_t slips[MAXSAT][MAXCODE]={{0}};
     int i,n,n1=0,flag=0,stat=0;
     double dtime1=0;
 

--- a/src/rtcm.c
+++ b/src/rtcm.c
@@ -70,7 +70,7 @@ extern int init_rtcm(rtcm_t *rtcm)
     eph_t  eph0 ={0,-1,-1};
     geph_t geph0={0,-1};
     ssr_t ssr0={{{0}}};
-    int i,j;
+    int i;
     
     trace(3,"init_rtcm:\n");
     
@@ -92,10 +92,11 @@ extern int init_rtcm(rtcm_t *rtcm)
     rtcm->msg[0]=rtcm->msgtype[0]=rtcm->opt[0]='\0';
     for (i=0;i<6;i++) rtcm->msmtype[i][0]='\0';
     rtcm->obsflag=rtcm->ephsat=0;
-    for (i=0;i<MAXSAT;i++) for (j=0;j<NFREQ+NEXOBS;j++) {
-        rtcm->cp[i][j]=0.0;
-        rtcm->lock[i][j]=rtcm->loss[i][j]=0;
-        rtcm->lltime[i][j]=time0;
+    for (i=0;i<MAXSAT;i++)
+      for (int code=0;code<MAXCODE;code++) {
+        rtcm->cp[i][code]=0.0;
+        rtcm->lock[i][code]=rtcm->loss[i][code]=0;
+        rtcm->lltime[i][code]=time0;
     }
     rtcm->nbyte=rtcm->nbit=rtcm->len=0;
     rtcm->word=0;

--- a/src/rtcm2.c
+++ b/src/rtcm2.c
@@ -236,10 +236,10 @@ static int decode_type18(rtcm_t *rtcm)
         }
         if ((index=obsindex(&rtcm->obs,time,sat))>=0) {
             rtcm->obs.data[index].L[freq]=-cp/256.0;
-            rtcm->obs.data[index].LLI[freq]=rtcm->loss[sat-1][freq]!=loss;
-            rtcm->obs.data[index].code[freq]=
-                !freq?(code?CODE_L1P:CODE_L1C):(code?CODE_L2P:CODE_L2C);
-            rtcm->loss[sat-1][freq]=loss;
+            int lcode=!freq?(code?CODE_L1P:CODE_L1C):(code?CODE_L2P:CODE_L2C);
+            rtcm->obs.data[index].LLI[freq]=rtcm->loss[sat-1][lcode]!=loss;
+            rtcm->obs.data[index].code[freq]=lcode;
+            rtcm->loss[sat-1][lcode]=loss;
         }
     }
     rtcm->obsflag=!sync;
@@ -288,8 +288,8 @@ static int decode_type19(rtcm_t *rtcm)
         }
         if ((index=obsindex(&rtcm->obs,time,sat))>=0) {
             rtcm->obs.data[index].P[freq]=pr*0.02;
-            rtcm->obs.data[index].code[freq]=
-                !freq?(code?CODE_L1P:CODE_L1C):(code?CODE_L2P:CODE_L2C);
+            int pcode=!freq?(code?CODE_L1P:CODE_L1C):(code?CODE_L2P:CODE_L2C);
+            rtcm->obs.data[index].code[freq]=pcode;
         }
     }
     rtcm->obsflag=!sync;

--- a/src/rtcm3e.c
+++ b/src/rtcm3e.c
@@ -2013,12 +2013,13 @@ static void gen_msm_sig(rtcm_t *rtcm, int sys, int nsat, int nsig, int ncell,
         if (!(sat=to_satid(sys,data->sat))) continue;
         
         for (j=0;j<NFREQ+NEXOBS;j++) {
-            if (!(sig=to_sigid(sys,data->code[j]))) continue;
+            int code = data->code[j];
+            if (!(sig=to_sigid(sys,code))) continue;
             
             k=sat_ind[sat-1]-1;
             if ((cell=cell_ind[sig_ind[sig-1]-1+k*nsig])>=64) continue;
             
-            freq=code2freq(sys,data->code[j],fcn-7);
+            freq=code2freq(sys,code,fcn-7);
             lambda=freq==0.0?0.0:CLIGHT/freq;
             psrng_s=data->P[j]==0.0?0.0:data->P[j]-rrng[k];
             phrng_s=data->L[j]==0.0||lambda<=0.0?0.0: data->L[j]*lambda-rrng [k];
@@ -2026,13 +2027,13 @@ static void gen_msm_sig(rtcm_t *rtcm, int sys, int nsat, int nsig, int ncell,
             
             /* subtract phase - psudorange integer cycle offset */
             LLI=data->LLI[j];
-            if ((LLI&1)||fabs(phrng_s-rtcm->cp[data->sat-1][j])>1171.0) {
-                rtcm->cp[data->sat-1][j]=ROUND(phrng_s/lambda)*lambda;
+            if ((LLI&1)||fabs(phrng_s-rtcm->cp[data->sat-1][code])>1171.0) {
+                rtcm->cp[data->sat-1][code]=ROUND(phrng_s/lambda)*lambda;
                 LLI|=1;
             }
-            phrng_s-=rtcm->cp[data->sat-1][j];
+            phrng_s-=rtcm->cp[data->sat-1][code];
             
-            lt=locktime_d(data->time,rtcm->lltime[data->sat-1]+j,LLI);
+            lt=locktime_d(data->time,rtcm->lltime[data->sat-1]+code,LLI);
             
             if (psrng&&psrng_s!=0.0) psrng[cell-1]=psrng_s;
             if (phrng&&phrng_s!=0.0) phrng[cell-1]=phrng_s;

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -954,10 +954,10 @@ typedef struct {        /* RTCM control struct type */
     int obsflag;        /* obs data complete flag (1:ok,0:not complete) */
     int ephsat;         /* input ephemeris satellite number */
     int ephset;         /* input ephemeris set (0-1) */
-    double cp[MAXSAT][NFREQ+NEXOBS]; /* carrier-phase measurement */
-    uint16_t lock[MAXSAT][NFREQ+NEXOBS]; /* lock time */
-    uint16_t loss[MAXSAT][NFREQ+NEXOBS]; /* loss of lock count */
-    gtime_t lltime[MAXSAT][NFREQ+NEXOBS]; /* last lock time */
+    double cp[MAXSAT][MAXCODE]; /* carrier-phase measurement */
+    uint16_t lock[MAXSAT][MAXCODE]; /* lock time */
+    uint16_t loss[MAXSAT][MAXCODE]; /* loss of lock count */
+    gtime_t lltime[MAXSAT][MAXCODE]; /* last lock time */
     int nbyte;          /* number of bytes in message buffer */
     int nbit;           /* number of bits in word buffer */
     int len;            /* message length (bytes) */
@@ -1206,7 +1206,7 @@ typedef struct {        /* RTK control/result type */
 
 typedef struct {        /* receiver raw data control type */
     gtime_t time;       /* message time */
-    gtime_t tobs[MAXSAT][NFREQ+NEXOBS]; /* observation data time */
+    gtime_t tobs[MAXSAT][MAXCODE]; /* observation data time */
     obs_t obs;          /* observation data */
     obs_t obuf;         /* observation data buffer */
     nav_t nav;          /* satellite ephemerides */
@@ -1216,11 +1216,11 @@ typedef struct {        /* receiver raw data control type */
     sbsmsg_t sbsmsg;    /* SBAS message */
     char msgtype[256];  /* last message type */
     uint8_t subfrm[MAXSAT][380]; /* subframe buffer */
-    double lockt[MAXSAT][NFREQ+NEXOBS]; /* lock time (s) */
-    unsigned char lockflag[MAXSAT][NFREQ+NEXOBS]; /* used for carrying forward cycle slip */
+    double lockt[MAXSAT][MAXCODE]; /* lock time (s) */
+    unsigned char lockflag[MAXSAT][MAXCODE]; /* used for carrying forward cycle slip */
     double icpp[MAXSAT],off[MAXSAT],icpc; /* carrier params for ss2 */
     double prCA[MAXSAT],dpCA[MAXSAT]; /* L1/CA pseudorange/doppler for javad */
-    uint8_t halfc[MAXSAT][NFREQ+NEXOBS]; /* half-cycle resolved */
+    uint8_t halfc[MAXSAT][MAXCODE]; /* half-cycle resolved */
     char freqn[MAXOBS]; /* frequency number for javad */
     int nbyte;          /* number of bytes in message buffer */
     int len;            /* message length (bytes) */


### PR DESCRIPTION
This is just a part of work to improve multi-frequency support. This addresses some subtle issues, and this plumbing needs fixing one way or another and this seems the simplest. There were changes in the set and ordering of signals mapping to the frequency index and state was mixed up on such changes. There are various signal priority strategies used in the code, some are currently fixed orderings, some not.

Even the ublox decoder was not keeping separate state per signal, rather state per frequency index. Perhaps the ublox encoding is static for a given configuration, tracking at most two signals, in which case the ordering of the frequency index could not change, but perhaps not. It was certainly an issue in many paths.

This change is intended to be rather neutral, not attempting to fix other issues, just changing the indexing. There might be some subtly differences in some paths where the signal frequency index could change, where state is no longer mixed up.

This might help make some of the signal to frequency index priority functions more flexible. For example, it might be possible to just pack in extra signals into the NEXOBS set, in no particular order, as the consumers might not be assuming a fixed order. Useful for decoding signals to RINEX or RTCM paths etc.

Only the observation data is still indexed by the frequency index. The problems have been narrow.

Rather than the signal frequency index which is still used in the observation structure to keep that compact.

When there are many signals the set of signals can change and when the priorities are recomputed the frequency index can change so the frequency index is not a reliable key for this state. This is not an issue with just one signal, or perhaps two, but with more than NFREQ signals there were subtle issues as the priories changed and the state was mixed up.

There are a good few structures with just one array of data for each signal and these have been expanded from being NFREQ+NEXOBS to MAXCODE so that the signal code can be used as the index. This is a little wasteful of memory but simple.