### PR TITLE
Sigindex common

### DIFF
--- a/src/rcv/novatel.c
+++ b/src/rcv/novatel.c
@@ -120,18 +120,18 @@
 #define SQR(x)          ((x)*(x))
 
 /* get fields (little-endian) ------------------------------------------------*/
-#define U1(p) (*((uint8_t *)(p)))
-#define I1(p) (*((int8_t  *)(p)))
-static uint16_t U2(uint8_t *p) {uint16_t u; memcpy(&u,p,2); return u;}
-static uint32_t U4(uint8_t *p) {uint32_t u; memcpy(&u,p,4); return u;}
-static int32_t  I4(uint8_t *p) {int32_t  i; memcpy(&i,p,4); return i;}
-static float    R4(uint8_t *p) {float    r; memcpy(&r,p,4); return r;}
-static double   R8(uint8_t *p) {double   r; memcpy(&r,p,8); return r;}
+#define U1(p) (*((const uint8_t *)(p)))
+#define I1(p) (*((const int8_t  *)(p)))
+static uint16_t U2(const uint8_t *p) {uint16_t u; memcpy(&u,p,2); return u;}
+static uint32_t U4(const uint8_t *p) {uint32_t u; memcpy(&u,p,4); return u;}
+static int32_t  I4(const uint8_t *p) {int32_t  i; memcpy(&i,p,4); return i;}
+static float    R4(const uint8_t *p) {float    r; memcpy(&r,p,4); return r;}
+static double   R8(const uint8_t *p) {double   r; memcpy(&r,p,8); return r;}
 
 /* extend sign ---------------------------------------------------------------*/
 static int32_t exsign(uint32_t v, int bits)
 {
-    return (int32_t)(v&(1<<(bits-1))?v|(~0u<<bits):v);
+    return (int32_t)((v&(1<<(bits-1)))?v|(~0u<<bits):v);
 }
 /* checksum ------------------------------------------------------------------*/
 static uint8_t chksum(const uint8_t *buff, int len)
@@ -321,206 +321,246 @@ static int decode_track_stat(uint32_t stat, int *sys, int *code, int *track,
     }
     return idx;
 }
-/* check code priority and return freq-index ---------------------------------*/
-static int checkpri(const char *opt, int sys, int code, int idx)
-{
-    int nex=NEXOBS;
-    
-    if (sys==SYS_GPS) {
-        if (strstr(opt,"-GL1L")&&idx==0) return (code==CODE_L1L)?0:-1;
-        if (strstr(opt,"-GL2S")&&idx==1) return (code==CODE_L2X)?1:-1;
-        if (strstr(opt,"-GL2P")&&idx==1) return (code==CODE_L2P)?1:-1;
-        if (code==CODE_L1L) return (nex<1)?-1:NFREQ;
-        if (code==CODE_L2S) return (nex<2)?-1:NFREQ+1;
-        if (code==CODE_L2P) return (nex<3)?-1:NFREQ+2;
+/* Decode RANGECMPB ----------------------------------------------------------*/
+static int decode_rangecmpb(raw_t *raw) {
+  double glo_bias = 0.0;
+  const char *q = strstr(raw->opt, "-GLOBIAS=");
+  if (q) sscanf(q, "-GLOBIAS=%lf", &glo_bias);
+
+  int pi = OEM4HLEN;
+  int nobs = U4(raw->buff + pi);
+  if (raw->len < OEM4HLEN + 4 + nobs * 24) {
+    trace(2, "oem4 rangecmpb length error: len=%d nobs=%d\n", raw->len, nobs);
+    return -1;
+  }
+  if (raw->outtype) {
+    sprintf(raw->msgtype+strlen(raw->msgtype), " nobs=%d", nobs);
+  }
+
+  if (fabs(timediff(raw->obs.data[0].time, raw->time)) > 1E-9) raw->obs.n = 0;
+
+  // First pass to identify the set of signals for each satellite
+  int sigp[MAXSAT] = {0};
+  int sigcode[MAXSAT][MAXCODE] = {{CODE_NONE}};
+  int sigidx[MAXSAT][MAXCODE] = {{-1}}, sigpri[MAXSAT][MAXCODE] = {{-1}};
+  pi = OEM4HLEN + 4;
+  for (int i = 0; i < nobs; i++, pi += 24) {
+    int sys, code, track, plock, clock, parity, halfc;
+    int idx =
+        decode_track_stat(U4(raw->buff + pi), &sys, &code, &track, &plock, &clock, &parity, &halfc);
+    if (idx < 0) continue;
+    int prn = U1(raw->buff + pi + 17);
+    if (sys == SYS_GLO) prn -= 37;
+    if (sys == SYS_SBS && prn >= MINPRNQZS_S && prn <= MAXPRNQZS_S && code == CODE_L1C) {
+      sys = SYS_QZS;
+      prn += 10;
+      code = CODE_L1Z; /* QZS L1S */
     }
-    else if (sys==SYS_GLO) {
-        if (strstr(opt,"-RL2C")&&idx==1) return (code==CODE_L2C)?1:-1;
-        if (code==CODE_L2C) return (nex<1)?-1:NFREQ;
+    int sat = satno(sys, prn);
+    if (!sat) {
+      trace(3, "oem4 rangecmpb satellite number error: sys=%d,prn=%d\n", sys, prn);
+      continue;
     }
-    else if (sys==SYS_GAL) {
-        if (strstr(opt,"-EL6B")&&idx==3) return (code==CODE_L6B)?3:-1;
-        if (code==CODE_L6B) return (nex<2)?-1:NFREQ;
+    if (sys == SYS_GLO && !parity) continue; /* Invalid if GLO parity unknown */
+    // Code unlock. Skip the observation if not locked to given another
+    // observation on the same frequency a chance of selection
+    if (!clock) continue;
+    sigp[sat] = 1;
+    sigcode[sat][code] = code;
+    sigidx[sat][code] = idx;
+    sigpri[sat][code] = getcodepri(sys, code, raw->opt);
+  }
+  // Resolve the frequence indices, for each noted satellite.
+  for (int sat = 0; sat < MAXSAT; sat++)
+    if (sigp[sat]) sigindex(MAXCODE, sigcode[sat], sigpri[sat], sigidx[sat]);
+
+  pi = OEM4HLEN + 4;
+  for (int i = 0; i < nobs; i++, pi += 24) {
+    int sys, code, track, plock, clock, parity, halfc;
+    int idx =
+        decode_track_stat(U4(raw->buff + pi), &sys, &code, &track, &plock, &clock, &parity, &halfc);
+    if (idx < 0) continue;
+    int prn = U1(raw->buff + pi + 17);
+    if (sys == SYS_GLO) prn -= 37;
+    if (sys == SYS_SBS && prn >= MINPRNQZS_S && prn <= MAXPRNQZS_S && code == CODE_L1C) {
+      sys = SYS_QZS;
+      prn += 10;
+      code = CODE_L1Z; /* QZS L1S */
     }
-    else if (sys==SYS_QZS) {
-        if (strstr(opt,"-JL1L")&&idx==0) return (code==CODE_L1L)?0:-1;
-        if (strstr(opt,"-JL1Z")&&idx==0) return (code==CODE_L1Z)?0:-1;
-        if (code==CODE_L1L) return (nex<1)?-1:NFREQ;
-        if (code==CODE_L1Z) return (nex<2)?-1:NFREQ+1;
+    int sat = satno(sys, prn);
+    if (!sat) {
+      trace(3, "oem4 rangecmpb satellite number error: sys=%d,prn=%d\n", sys, prn);
+      continue;
     }
-    else if (sys==SYS_CMP) {
-        if (strstr(opt,"-CL1P")&&idx==0) return (code==CODE_L1P)?0:-1;
-        if (strstr(opt,"-CL7D")&&idx==0) return (code==CODE_L7D)?0:-1;
-        if (code==CODE_L1P) return (nex<1)?-1:NFREQ;
-        if (code==CODE_L7D) return (nex<2)?-1:NFREQ+1;
+    if (sys == SYS_GLO && !parity) continue; /* Invalid if GLO parity unknown */
+
+    // Get the resolved frequency index
+    if (!sigp[sat]) continue;
+    idx = sigidx[sat][code];
+    if (idx < 0) continue;
+
+    double dop = exsign(U4(raw->buff + pi + 4) & 0xFFFFFFF, 28) / 256.0;
+    double psr = (U4(raw->buff + pi + 7) >> 4) / 128.0 + U1(raw->buff + pi + 11) * 2097152.0;
+
+    double freq = sat2freq(sat, code, &raw->nav), adr;
+    if (freq != 0.0) {
+      adr = I4(raw->buff + pi + 12) / 256.0;
+      double adr_rolls = (psr * freq / CLIGHT + adr) / MAXVAL;
+      adr = -adr + MAXVAL * floor(adr_rolls + (adr_rolls <= 0 ? -0.5 : 0.5));
+      if (sys == SYS_GLO) adr += glo_bias * freq / CLIGHT;
+    } else {
+      adr = 1e-9;
     }
-    return idx<NFREQ?idx:-1;
+    double lockt = (U4(raw->buff + pi + 18) & 0x1FFFFF) / 32.0; /* Lock time */
+
+    int lli;
+    if (raw->tobs[sat - 1][code].time != 0) {
+      double tt = timediff(raw->time, raw->tobs[sat - 1][code]);
+      lli = (lockt < 65535.968 && lockt - raw->lockt[sat - 1][code] + 0.05 <= tt) ? LLI_SLIP : 0;
+    } else {
+      lli = 0;
+    }
+    if (!parity) lli |= LLI_HALFC;
+    if (halfc) lli |= LLI_HALFA;
+    raw->tobs[sat - 1][code] = raw->time;
+    raw->lockt[sat - 1][code] = lockt;
+    raw->halfc[sat - 1][code] = halfc;
+
+    double snr = ((U2(raw->buff + pi + 20) & 0x3FF) >> 5) + 20.0;
+    if (!clock) continue;        /* Code unlock */
+    if (!plock) adr = dop = 0.0; /* Phase unlock */
+
+    int index = obsindex(&raw->obs, raw->time, sat);
+    if (index >= 0) {
+      raw->obs.data[index].L[idx] = adr;
+      raw->obs.data[index].P[idx] = psr;
+      raw->obs.data[index].D[idx] = (float)dop;
+      raw->obs.data[index].SNR[idx] = (uint16_t)(snr / SNR_UNIT + 0.5);
+      raw->obs.data[index].LLI[idx] = (uint8_t)lli;
+      raw->obs.data[index].code[idx] = (uint8_t)code;
+    }
+  }
+  return 1;
 }
-/* decode RANGECMPB ----------------------------------------------------------*/
-static int decode_rangecmpb(raw_t *raw)
-{
-    uint8_t *p=raw->buff+OEM4HLEN;
-    char *q;
-    double psr,adr,adr_rolls,lockt,tt,dop,snr,freq,glo_bias=0.0;
-    int i,index,nobs,prn,sat,sys,code,idx,track,plock,clock,parity,halfc,lli;
-    
-    if ((q=strstr(raw->opt,"-GLOBIAS="))) sscanf(q,"-GLOBIAS=%lf",&glo_bias);
-    
-    nobs=U4(p);
-    if (raw->len<OEM4HLEN+4+nobs*24) {
-        trace(2,"oem4 rangecmpb length error: len=%d nobs=%d\n",raw->len,nobs);
-        return -1;
+/* Decode RANGEB -------------------------------------------------------------*/
+static int decode_rangeb(raw_t *raw) {
+  double glo_bias = 0.0;
+  const char *q = strstr(raw->opt, "-GLOBIAS=");
+  if (q) sscanf(q, "-GLOBIAS=%lf", &glo_bias);
+
+  int pi = OEM4HLEN;
+  int nobs = U4(raw->buff + pi);
+  if (raw->len < OEM4HLEN + 4 + nobs * 44) {
+    trace(2, "oem4 rangeb length error: len=%d nobs=%d\n", raw->len, nobs);
+    return -1;
+  }
+  if (raw->outtype) {
+    sprintf(raw->msgtype+strlen(raw->msgtype), " nobs=%d", nobs);
+  }
+
+  if (fabs(timediff(raw->obs.data[0].time, raw->time)) > 1E-9) raw->obs.n = 0;
+
+  // First pass to identify the set of signals for each satellite
+  int sigp[MAXSAT] = {0};
+  int sigcode[MAXSAT][MAXCODE] = {{CODE_NONE}};
+  int sigidx[MAXSAT][MAXCODE] = {{-1}}, sigpri[MAXSAT][MAXCODE] = {{-1}};
+  pi = OEM4HLEN + 4;
+  for (int i = 0; i < nobs; i++, pi += 44) {
+    int sys, code, track, plock, clock, parity, halfc;
+    int idx = decode_track_stat(U4(raw->buff + pi + 40), &sys, &code, &track, &plock, &clock,
+                                &parity, &halfc);
+    if (idx < 0) continue;
+    int prn = U2(raw->buff + pi);
+    if (sys == SYS_GLO) prn -= 37;
+    if (sys == SYS_SBS && prn >= MINPRNQZS_S && prn <= MAXPRNQZS_S && code == CODE_L1C) {
+      sys = SYS_QZS;
+      prn += 10;
+      code = CODE_L1Z; /* QZS L1S */
     }
-    if (raw->outtype) {
-        sprintf(raw->msgtype+strlen(raw->msgtype)," nobs=%d",nobs);
+    int sat = satno(sys, prn);
+    if (!sat) {
+      trace(3, "oem4 rangeb satellite number error: sys=%d,prn=%d\n", sys, prn);
+      continue;
     }
-    for (i=0,p+=4;i<nobs;i++,p+=24) {
-        if ((idx=decode_track_stat(U4(p),&sys,&code,&track,&plock,&clock,
-                                   &parity,&halfc))<0) {
-            continue;
-        }
-        prn=U1(p+17);
-        if (sys==SYS_GLO) prn-=37;
-        if (sys==SYS_SBS&&prn>=MINPRNQZS_S&&prn<=MAXPRNQZS_S&&code==CODE_L1C) {
-            sys=SYS_QZS;
-            prn+=10;
-            code=CODE_L1Z; /* QZS L1S */
-        }
-        if (!(sat=satno(sys,prn))) {
-            trace(3,"oem4 rangecmpb satellite number error: sys=%d,prn=%d\n",sys,prn);
-            continue;
-        }
-        if (sys==SYS_GLO&&!parity) continue; /* invalid if GLO parity unknown */
-        
-        if ((idx=checkpri(raw->opt,sys,code,idx))<0) continue;
-        
-        dop=exsign(U4(p+4)&0xFFFFFFF,28)/256.0;
-        psr=(U4(p+7)>>4)/128.0+U1(p+11)*2097152.0;
-        
-        if ((freq=sat2freq(sat,(uint8_t)code,&raw->nav))!=0.0) {
-            adr=I4(p+12)/256.0;
-            adr_rolls=(psr*freq/CLIGHT+adr)/MAXVAL;
-            adr=-adr+MAXVAL*floor(adr_rolls+(adr_rolls<=0?-0.5:0.5));
-            if (sys==SYS_GLO) adr+=glo_bias*freq/CLIGHT;
-        }
-        else {
-            adr=1e-9;
-        }
-        lockt=(U4(p+18)&0x1FFFFF)/32.0; /* lock time */
-        
-        if (raw->tobs[sat-1][code].time!=0) {
-            tt=timediff(raw->time,raw->tobs[sat-1][code]);
-            lli=(lockt<65535.968&&lockt-raw->lockt[sat-1][code]+0.05<=tt)?LLI_SLIP:0;
-        }
-        else {
-            lli=0;
-        }
-        if (!parity) lli|=LLI_HALFC;
-        if (halfc  ) lli|=LLI_HALFA;
-        raw->tobs [sat-1][code]=raw->time;
-        raw->lockt[sat-1][code]=lockt;
-        raw->halfc[sat-1][code]=halfc;
-        
-        snr=((U2(p+20)&0x3FF)>>5)+20.0;
-        if (!clock) psr=0.0;     /* code unlock */
-        if (!plock) adr=dop=0.0; /* phase unlock */
-        
-        if (fabs(timediff(raw->obs.data[0].time,raw->time))>1E-9) {
-            raw->obs.n=0;
-        }
-        if ((index=obsindex(&raw->obs,raw->time,sat))>=0) {
-            raw->obs.data[index].L  [idx]=adr;
-            raw->obs.data[index].P  [idx]=psr;
-            raw->obs.data[index].D  [idx]=(float)dop;
-            raw->obs.data[index].SNR[idx]=(uint16_t)(snr/SNR_UNIT+0.5);
-            raw->obs.data[index].LLI[idx]=(uint8_t)lli;
-            raw->obs.data[index].code[idx]=(uint8_t)code;
-        }
+    if (sys == SYS_GLO && !parity) continue;
+    // Code unlock. Skip the observation if not locked to give another
+    // observation on the same frequency a chance of selection
+    if (!clock) continue;
+    sigp[sat] = 1;
+    sigcode[sat][code] = code;
+    sigidx[sat][code] = idx;
+    sigpri[sat][code] = getcodepri(sys, code, raw->opt);
+  }
+  // Resolve the frequence indices, for each noted satellite.
+  for (int sat = 0; sat < MAXSAT; sat++)
+    if (sigp[sat]) sigindex(MAXCODE, sigcode[sat], sigpri[sat], sigidx[sat]);
+
+  pi = OEM4HLEN + 4;
+  for (int i = 0; i < nobs; i++, pi += 44) {
+    int sys, code, track, plock, clock, parity, halfc;
+    int idx = decode_track_stat(U4(raw->buff + pi + 40), &sys, &code, &track, &plock, &clock,
+                                &parity, &halfc);
+    if (idx < 0) continue;
+    int prn = U2(raw->buff + pi);
+    if (sys == SYS_GLO) prn -= 37;
+    if (sys == SYS_SBS && prn >= MINPRNQZS_S && prn <= MAXPRNQZS_S && code == CODE_L1C) {
+      sys = SYS_QZS;
+      prn += 10;
+      code = CODE_L1Z; /* QZS L1S */
     }
-    return 1;
-}
-/* decode RANGEB -------------------------------------------------------------*/
-static int decode_rangeb(raw_t *raw)
-{
-    uint8_t *p=raw->buff+OEM4HLEN;
-    char *q;
-    double psr,adr,dop,snr,lockt,tt,freq,glo_bias=0.0;
-    int i,index,nobs,prn,sat,sys,code,idx,track,plock,clock,parity,halfc,lli;
-    int gfrq;
-    
-    if ((q=strstr(raw->opt,"-GLOBIAS="))) sscanf(q,"-GLOBIAS=%lf",&glo_bias);
-    
-    nobs=U4(p);
-    if (raw->len<OEM4HLEN+4+nobs*44) {
-        trace(2,"oem4 rangeb length error: len=%d nobs=%d\n",raw->len,nobs);
-        return -1;
+    int sat = satno(sys, prn);
+    if (!sat) {
+      trace(3, "oem4 rangeb satellite number error: sys=%d,prn=%d\n", sys, prn);
+      continue;
     }
-    if (raw->outtype) {
-        sprintf(raw->msgtype+strlen(raw->msgtype)," nobs=%d",nobs);
+    if (sys == SYS_GLO && !parity) continue;
+
+    // Get the resolved frequency index
+    if (!sigp[sat]) continue;
+    idx = sigidx[sat][code];
+    if (idx < 0) continue;
+
+    int gfrq = U2(raw->buff + pi + 2); /* GLONASS FCN+8 */
+    double psr = R8(raw->buff + pi + 4);
+    double adr = R8(raw->buff + pi + 16);
+    double dop = R4(raw->buff + pi + 28);
+    double snr = R4(raw->buff + pi + 32);
+    double lockt = R4(raw->buff + pi + 36);
+
+    if (sys == SYS_GLO) {
+      double freq = sat2freq(sat, code, &raw->nav);
+      adr -= glo_bias * freq / CLIGHT;
+      if (!raw->nav.glo_fcn[prn - 1]) {
+        raw->nav.glo_fcn[prn - 1] = gfrq; /* fcn+8 */
+      }
     }
-    for (i=0,p+=4;i<nobs;i++,p+=44) {
-        if ((idx=decode_track_stat(U4(p+40),&sys,&code,&track,&plock,&clock,
-                                   &parity,&halfc))<0) {
-            continue;
-        }
-        prn=U2(p);
-        if (sys==SYS_GLO) prn-=37;
-        if (sys==SYS_SBS&&prn>=MINPRNQZS_S&&prn<=MAXPRNQZS_S&&code==CODE_L1C) {
-            sys=SYS_QZS;
-            prn+=10;
-            code=CODE_L1Z; /* QZS L1S */
-        }
-        if (!(sat=satno(sys,prn))) {
-            trace(3,"oem4 rangeb satellite number error: sys=%d,prn=%d\n",sys,prn);
-            continue;
-        }
-        if (sys==SYS_GLO&&!parity) continue;
-        
-        if ((idx=checkpri(raw->opt,sys,code,idx))<0) continue;
-        
-        gfrq =U2(p+ 2); /* GLONASS FCN+8 */
-        psr  =R8(p+ 4);
-        adr  =R8(p+16);
-        dop  =R4(p+28);
-        snr  =R4(p+32);
-        lockt=R4(p+36);
-        
-        if (sys==SYS_GLO) {
-            freq=sat2freq(sat,(uint8_t)code,&raw->nav);
-            adr-=glo_bias*freq/CLIGHT;
-            if (!raw->nav.glo_fcn[prn-1]) {
-                raw->nav.glo_fcn[prn-1]=gfrq; /* fcn+8 */
-            }
-        }
-        if (raw->tobs[sat-1][code].time!=0) {
-            tt=timediff(raw->time,raw->tobs[sat-1][code]);
-            lli=lockt-raw->lockt[sat-1][code]+0.05<=tt?LLI_SLIP:0;
-        }
-        else {
-            lli=0;
-        }
-        if (!parity) lli|=LLI_HALFC;
-        if (halfc  ) lli|=LLI_HALFA;
-        raw->tobs [sat-1][code]=raw->time;
-        raw->lockt[sat-1][code]=lockt;
-        raw->halfc[sat-1][code]=halfc;
-        
-        if (!clock) psr=0.0;     /* code unlock */
-        if (!plock) adr=dop=0.0; /* phase unlock */
-        
-        if (fabs(timediff(raw->obs.data[0].time,raw->time))>1E-9) {
-            raw->obs.n=0;
-        }
-        if ((index=obsindex(&raw->obs,raw->time,sat))>=0) {
-            raw->obs.data[index].L  [idx]=-adr;
-            raw->obs.data[index].P  [idx]=psr;
-            raw->obs.data[index].D  [idx]=(float)dop;
-            raw->obs.data[index].SNR[idx]=(uint16_t)(snr/SNR_UNIT+0.5);
-            raw->obs.data[index].LLI[idx]=(uint8_t)lli;
-            raw->obs.data[index].code[idx]=(uint8_t)code;
-        }
+    int lli;
+    if (raw->tobs[sat - 1][code].time != 0) {
+      double tt = timediff(raw->time, raw->tobs[sat - 1][code]);
+      lli = lockt - raw->lockt[sat - 1][code] + 0.05 <= tt ? LLI_SLIP : 0;
+    } else {
+      lli = 0;
     }
-    return 1;
+    if (!parity) lli |= LLI_HALFC;
+    if (halfc) lli |= LLI_HALFA;
+    raw->tobs[sat - 1][code] = raw->time;
+    raw->lockt[sat - 1][code] = lockt;
+    raw->halfc[sat - 1][code] = halfc;
+
+    if (!clock) continue;        /* Code unlock */
+    if (!plock) adr = dop = 0.0; /* Phase unlock */
+
+    int index = obsindex(&raw->obs, raw->time, sat);
+    if (index >= 0) {
+      raw->obs.data[index].L[idx] = -adr;
+      raw->obs.data[index].P[idx] = psr;
+      raw->obs.data[index].D[idx] = (float)dop;
+      raw->obs.data[index].SNR[idx] = (uint16_t)(snr / SNR_UNIT + 0.5);
+      raw->obs.data[index].LLI[idx] = (uint8_t)lli;
+      raw->obs.data[index].code[idx] = (uint8_t)code;
+    }
+  }
+  return 1;
 }
 /* decode RAWEPHEMB ----------------------------------------------------------*/
 static int decode_rawephemb(raw_t *raw)
@@ -1364,15 +1404,6 @@ static int sync_oem3(uint8_t *buff, uint8_t data)
 *          option strings separated by spaces.
 *
 *          -EPHALL : input all ephemerides
-*          -GL1L   : select 1L for GPS L1 (default 1C)
-*          -GL2S   : select 2S for GPS L2 (default 2W)
-*          -GL2P   : select 2P for GPS L2 (default 2W)
-*          -RL2C   : select 2C for GLO G2 (default 2P)
-*          -EL6B   : select 6B for GAL E6 (default 6C)
-*          -JL1L   : select 1L for QZS L1 (default 1C)
-*          -JL1Z   : select 1Z for QZS L1 (default 1C)
-*          -CL1P   : select 1P for BDS B1 (default 2I)
-*          -CL7D   : select 7D for BDS B2 (default 7I)
 *          -GALINAV: select I/NAV for Galileo ephemeris (default: all)
 *          -GALFNAV: select F/NAV for Galileo ephemeris (default: all)
 *          -GLOBIAS=bias: GLONASS code-phase bias (m)

--- a/src/rcv/novatel.c
+++ b/src/rcv/novatel.c
@@ -408,18 +408,18 @@ static int decode_rangecmpb(raw_t *raw)
         }
         lockt=(U4(p+18)&0x1FFFFF)/32.0; /* lock time */
         
-        if (raw->tobs[sat-1][idx].time!=0) {
-            tt=timediff(raw->time,raw->tobs[sat-1][idx]);
-            lli=(lockt<65535.968&&lockt-raw->lockt[sat-1][idx]+0.05<=tt)?LLI_SLIP:0;
+        if (raw->tobs[sat-1][code].time!=0) {
+            tt=timediff(raw->time,raw->tobs[sat-1][code]);
+            lli=(lockt<65535.968&&lockt-raw->lockt[sat-1][code]+0.05<=tt)?LLI_SLIP:0;
         }
         else {
             lli=0;
         }
         if (!parity) lli|=LLI_HALFC;
         if (halfc  ) lli|=LLI_HALFA;
-        raw->tobs [sat-1][idx]=raw->time;
-        raw->lockt[sat-1][idx]=lockt;
-        raw->halfc[sat-1][idx]=halfc;
+        raw->tobs [sat-1][code]=raw->time;
+        raw->lockt[sat-1][code]=lockt;
+        raw->halfc[sat-1][code]=halfc;
         
         snr=((U2(p+20)&0x3FF)>>5)+20.0;
         if (!clock) psr=0.0;     /* code unlock */
@@ -492,18 +492,18 @@ static int decode_rangeb(raw_t *raw)
                 raw->nav.glo_fcn[prn-1]=gfrq; /* fcn+8 */
             }
         }
-        if (raw->tobs[sat-1][idx].time!=0) {
-            tt=timediff(raw->time,raw->tobs[sat-1][idx]);
-            lli=lockt-raw->lockt[sat-1][idx]+0.05<=tt?LLI_SLIP:0;
+        if (raw->tobs[sat-1][code].time!=0) {
+            tt=timediff(raw->time,raw->tobs[sat-1][code]);
+            lli=lockt-raw->lockt[sat-1][code]+0.05<=tt?LLI_SLIP:0;
         }
         else {
             lli=0;
         }
         if (!parity) lli|=LLI_HALFC;
         if (halfc  ) lli|=LLI_HALFA;
-        raw->tobs [sat-1][idx]=raw->time;
-        raw->lockt[sat-1][idx]=lockt;
-        raw->halfc[sat-1][idx]=halfc;
+        raw->tobs [sat-1][code]=raw->time;
+        raw->lockt[sat-1][code]=lockt;
+        raw->halfc[sat-1][code]=halfc;
         
         if (!clock) psr=0.0;     /* code unlock */
         if (!plock) adr=dop=0.0; /* phase unlock */
@@ -1087,18 +1087,19 @@ static int decode_rgeb(raw_t *raw)
             trace(2,"oem3 regb satellite number error: sys=%d prn=%d\n",sys,prn);
             continue;
         }
-        if (raw->tobs[sat-1][freq].time!=0) {
-            tt=timediff(raw->time,raw->tobs[sat-1][freq]);
-            lli=lockt-raw->lockt[sat-1][freq]+0.05<tt||
-                parity!=raw->halfc[sat-1][freq];
+        int code=freq==0?CODE_L1C:CODE_L2P;
+        if (raw->tobs[sat-1][code].time!=0) {
+            tt=timediff(raw->time,raw->tobs[sat-1][code]);
+            lli=lockt-raw->lockt[sat-1][code]+0.05<tt||
+                parity!=raw->halfc[sat-1][code];
         }
         else {
             lli=0;
         }
         if (!parity) lli|=2;
-        raw->tobs [sat-1][freq]=raw->time;
-        raw->lockt[sat-1][freq]=lockt;
-        raw->halfc[sat-1][freq]=parity;
+        raw->tobs [sat-1][code]=raw->time;
+        raw->lockt[sat-1][code]=lockt;
+        raw->halfc[sat-1][code]=parity;
         
         if (fabs(timediff(raw->obs.data[0].time,raw->time))>1E-9) {
             raw->obs.n=0;
@@ -1110,7 +1111,7 @@ static int decode_rgeb(raw_t *raw)
             raw->obs.data[index].SNR[freq]=
                 0.0<=snr&&snr<255.0?(uint16_t)(snr/SNR_UNIT+0.5):0;
             raw->obs.data[index].LLI[freq]=(uint8_t)lli;
-            raw->obs.data[index].code[freq]=freq==0?CODE_L1C:CODE_L2P;
+            raw->obs.data[index].code[freq]=code;
         }
     }
     return 1;
@@ -1153,18 +1154,19 @@ static int decode_rged(raw_t *raw)
         adr_rolls=floor((psr/(freq==0?WL1:WL2)-adr)/MAXVAL+0.5);
         adr=adr+MAXVAL*adr_rolls;
         
-        if (raw->tobs[sat-1][freq].time!=0) {
-            tt=timediff(raw->time,raw->tobs[sat-1][freq]);
-            lli=lockt-raw->lockt[sat-1][freq]+0.05<tt||
-                parity!=raw->halfc[sat-1][freq];
+        int code = freq==0?CODE_L1C:CODE_L2P;
+        if (raw->tobs[sat-1][code].time!=0) {
+            tt=timediff(raw->time,raw->tobs[sat-1][code]);
+            lli=lockt-raw->lockt[sat-1][code]+0.05<tt||
+                parity!=raw->halfc[sat-1][code];
         }
         else {
             lli=0;
         }
         if (!parity) lli|=2;
-        raw->tobs [sat-1][freq]=raw->time;
-        raw->lockt[sat-1][freq]=lockt;
-        raw->halfc[sat-1][freq]=parity;
+        raw->tobs [sat-1][code]=raw->time;
+        raw->lockt[sat-1][code]=lockt;
+        raw->halfc[sat-1][code]=parity;
         
         if (fabs(timediff(raw->obs.data[0].time,raw->time))>1E-9) {
             raw->obs.n=0;
@@ -1175,7 +1177,7 @@ static int decode_rged(raw_t *raw)
             raw->obs.data[index].D  [freq]=(float)dop;
             raw->obs.data[index].SNR[freq]=(uint16_t)(snr/SNR_UNIT+0.5);
             raw->obs.data[index].LLI[freq]=(uint8_t)lli;
-            raw->obs.data[index].code[freq]=freq==0?CODE_L1C:CODE_L2P;
+            raw->obs.data[index].code[freq]=code;
         }
     }
     return 1;

--- a/src/rcv/septentrio.c
+++ b/src/rcv/septentrio.c
@@ -76,8 +76,7 @@ typedef struct {
   uint8_t signalIdx[MEAS3_SYS_MAX][MEAS3_SAT_MAX][MEAS3_SIG_MAX];  // Reference signal indeces
   uint32_t slaveSignalMask[MEAS3_SYS_MAX][MEAS3_SAT_MAX];  // Mask of available slave signals
   int16_t prRate[MEAS3_SYS_MAX][MEAS3_SAT_MAX];  // Pseudo-range change rate in 64 mm steps
-  uint32_t lockt[MEAS3_SYS_MAX][MEAS3_SAT_MAX][NFREQ + NEXOBS];  // Lock time of the PLL, in ms
-  uint8_t halfc[MEAS3_SYS_MAX][MEAS3_SAT_MAX][NFREQ + NEXOBS];   // Half cycle ambiguity
+  uint32_t lockt[MEAS3_SYS_MAX][MEAS3_SAT_MAX][MAXCODE];  // Lock time of the PLL, in ms
 
   uint8_t constellationHeader[MEAS3_SYS_MAX][32];  // Copy of constellation header
 } Meas3_RefEpoch_t;
@@ -782,9 +781,9 @@ static int decode_measepoch(raw_t *raw)
         if (P1!=0.0 && freq1>0.0 && lock!=65535 && (I1(p+14) != -128 || U2(p+12) != 0)) {
             L1 = I1(p+14)*65.536 + U2(p+12)*0.001;
             raw->obuf.data[n].L[idx] = P1*freq1/CLIGHT + L1;
-            LLI = (lock<raw->lockt[sat-1][idx] ? 1 : 0) + ((info & (1<<2)) ? 2 : 0);
+            LLI = (lock<raw->lockt[sat-1][code] ? 1 : 0) + ((info & (1<<2)) ? 2 : 0);
             raw->obuf.data[n].LLI[idx] = (uint8_t)LLI;
-            raw->lockt[sat-1][idx] = lock;
+            raw->lockt[sat-1][code] = lock;
         }
         if (U1(p+15) != 255) {
             S1 = U1(p+15)*0.25 + ((sig==1 || sig==2) ? 0.0 : 10.0);
@@ -810,9 +809,9 @@ static int decode_measepoch(raw_t *raw)
             P2 = 0.0;
             freq2 = code2freq(sys, code, fcn);
             if (lock != 255) {
-                LLI = (lock<raw->lockt[sat-1][idx] ? 1 : 0) + ((info&(1<<2)) ? 2 : 0);
+                LLI = (lock<raw->lockt[sat-1][code] ? 1 : 0) + ((info&(1<<2)) ? 2 : 0);
                 raw->obuf.data[n].LLI[idx] = (uint8_t)LLI;
-                raw->lockt[sat-1][idx] = lock;
+                raw->lockt[sat-1][code] = lock;
             }
             if (U1(p+2) != 255) {
                 S2 = U1(p+2)*0.25 + ((sig==1 || sig==2) ? 0.0 : 10.0);
@@ -1105,7 +1104,7 @@ static int decode_meas3ranges(raw_t *raw) {
                             raw->obuf.data[n].L[masterFreqIndex] = pr / (CLIGHT/freqMaster) - 131.072 + (double)cmc * .001;
 
                         raw->obuf.data[n].LLI[masterFreqIndex] = (lockTime < raw->lockt[satNo-1][masterFreqIndex] ? LLI_SLIP : 0) | (lti3 == 0 ? LLI_HALFC : 0);
-                        raw->lockt[satNo-1][masterFreqIndex] = lockTime;
+                        raw->lockt[satNo-1][codeMaster] = lockTime;
                         raw->obuf.data[n].freq = glofnc+7;
                         sbf->meas3_freqAssignment[navsys][svid][0] = masterFreqIndex;
                     };
@@ -1151,7 +1150,7 @@ static int decode_meas3ranges(raw_t *raw) {
                             raw->obuf.data[n].L[masterFreqIndex] = raw->obuf.data[n].P[masterFreqIndex] / (CLIGHT/freqMaster) - 2097.152 + (double)cmc * .001;
 
                         raw->obuf.data[n].LLI[masterFreqIndex] = (lockTime < raw->lockt[satNo-1][masterFreqIndex] ? LLI_SLIP : 0) | (lti4 == 0 ? LLI_HALFC : 0);
-                        raw->lockt[satNo-1][masterFreqIndex] = lockTime;
+                        raw->lockt[satNo-1][codeMaster] = lockTime;
                         raw->obuf.data[n].freq = glofnc+7;
                         sbf->meas3_freqAssignment[navsys][svid][0] = masterFreqIndex;
                     };
@@ -1187,7 +1186,7 @@ static int decode_meas3ranges(raw_t *raw) {
                                                            master_reference->L[masterFreqIndex] - 32.768 + (double)cmc * .001;
 
                         raw->obuf.data[n].LLI[masterFreqIndex] = master_reference->LLI[masterFreqIndex];
-                        raw->lockt[satNo-1][masterFreqIndex] = sbf->meas3_refEpoch.lockt[navsys][svid][masterFreqIndex];
+                        raw->lockt[satNo-1][codeMaster] = sbf->meas3_refEpoch.lockt[navsys][svid][codeMaster];
                         raw->obuf.data[n].freq = glofnc+7;
                         sbf->meas3_freqAssignment[navsys][svid][0] = masterFreqIndex;
                     }
@@ -1213,7 +1212,7 @@ static int decode_meas3ranges(raw_t *raw) {
                             raw->obuf.data[n].L[masterFreqIndex] = (raw->obuf.data[n].P[masterFreqIndex] - masterReference->P[masterFreqIndex]) / (CLIGHT/freqMaster) + masterReference->L[masterFreqIndex] - 8.192 + (double)cmc * .001;
                         raw->obuf.data[n].SNR[masterFreqIndex] = (uint16_t)((masterReference->SNR[masterFreqIndex] * SNR_UNIT - 1.0 + CN0) / SNR_UNIT + 0.5);
                         raw->obuf.data[n].LLI[masterFreqIndex] = masterReference->LLI[masterFreqIndex];
-                        raw->lockt[satNo-1][masterFreqIndex] = sbf->meas3_refEpoch.lockt[navsys][svid][masterFreqIndex];
+                        raw->lockt[satNo-1][codeMaster] = sbf->meas3_refEpoch.lockt[navsys][svid][codeMaster];
                         raw->obuf.data[n].code[masterFreqIndex] = codeMaster;
                         raw->obuf.data[n].freq = glofnc+8;
                         sbf->meas3_freqAssignment[navsys][svid][0] = masterFreqIndex;
@@ -1238,12 +1237,12 @@ static int decode_meas3ranges(raw_t *raw) {
                     sbf->meas3_refEpoch.obsData[navsys][svid].L[masterFreqIndex] = raw->obuf.data[n].L[masterFreqIndex];
                     sbf->meas3_refEpoch.obsData[navsys][svid].SNR[masterFreqIndex] = raw->obuf.data[n].SNR[masterFreqIndex];
                     sbf->meas3_refEpoch.obsData[navsys][svid].LLI[masterFreqIndex] = raw->obuf.data[n].LLI[masterFreqIndex];
-                    sbf->meas3_refEpoch.lockt[navsys][svid][masterFreqIndex] = raw->lockt[satNo-1][masterFreqIndex];
+                    sbf->meas3_refEpoch.lockt[navsys][svid][codeMaster] = raw->lockt[satNo-1][codeMaster];
                 }
 
                 // update PLL lock time
-                if (satNo > 0  && raw->lockt[satNo-1][masterFreqIndex] > sbf->meas3_refEpoch.lockt[navsys][svid][masterFreqIndex])
-                    sbf->meas3_refEpoch.lockt[navsys][svid][masterFreqIndex] = raw->lockt[satNo-1][masterFreqIndex];
+                if (satNo > 0  && raw->lockt[satNo-1][codeMaster] > sbf->meas3_refEpoch.lockt[navsys][svid][codeMaster])
+                    sbf->meas3_refEpoch.lockt[navsys][svid][codeMaster] = raw->lockt[satNo-1][codeMaster];
 
                 /* decode slave data */
                 int slaveCnt = 0;
@@ -1288,7 +1287,7 @@ static int decode_meas3ranges(raw_t *raw) {
 
                                 raw->obuf.data[n].code[slaveFreqIndex] = codeSlave;
                                 raw->obuf.data[n].LLI[slaveFreqIndex] = (lockTime < raw->lockt[satNo-1][slaveFreqIndex] ? LLI_SLIP : 0) | (lti3 == 0 ? LLI_HALFC : 0);
-                                raw->lockt[satNo-1][slaveFreqIndex] = lockTime;
+                                raw->lockt[satNo-1][codeSlave] = lockTime;
                                 sbf->meas3_freqAssignment[navsys][svid][slaveCnt+1] = slaveFreqIndex;
                             }
 
@@ -1318,8 +1317,8 @@ static int decode_meas3ranges(raw_t *raw) {
                                     raw->obuf.data[n].SNR[slaveFreqIndex] = (uint16_t)((CN0 + 10.0) / SNR_UNIT + 0.5);
 
                                 raw->obuf.data[n].code[slaveFreqIndex] = codeSlave;
-                                raw->obuf.data[n].LLI[slaveFreqIndex] = (lockTime < raw->lockt[satNo-1][slaveFreqIndex] ? LLI_SLIP : 0) | (lti4 == 0 ? LLI_HALFC : 0);
-                                raw->lockt[satNo-1][slaveFreqIndex] = lockTime;
+                                raw->obuf.data[n].LLI[slaveFreqIndex] = (lockTime < raw->lockt[satNo-1][codeSlave] ? LLI_SLIP : 0) | (lti4 == 0 ? LLI_HALFC : 0);
+                                raw->lockt[satNo-1][codeSlave] = lockTime;
                                 sbf->meas3_freqAssignment[navsys][svid][slaveCnt+1] = slaveFreqIndex;
                             }
 
@@ -1351,7 +1350,7 @@ static int decode_meas3ranges(raw_t *raw) {
 
                                 raw->obuf.data[n].code[slaveFreqIndex] = codeSlave;
                                 raw->obuf.data[n].LLI[slaveFreqIndex] = slaveReference->LLI[slaveRefFreqIdx];
-                                raw->lockt[satNo-1][slaveFreqIndex] = sbf->meas3_refEpoch.lockt[navsys][svid][slaveCnt+1];
+                                raw->lockt[satNo-1][codeSlave] = sbf->meas3_refEpoch.lockt[navsys][svid][codeSlave];
                                 sbf->meas3_freqAssignment[navsys][svid][slaveCnt+1] = slaveFreqIndex;
                             }
 
@@ -1369,11 +1368,11 @@ static int decode_meas3ranges(raw_t *raw) {
                             sbf->meas3_refEpoch.obsData[navsys][svid].L[slaveFreqIndex] = raw->obuf.data[n].L[slaveFreqIndex];
                             sbf->meas3_refEpoch.obsData[navsys][svid].SNR[slaveFreqIndex] = raw->obuf.data[n].SNR[slaveFreqIndex];
                             sbf->meas3_refEpoch.obsData[navsys][svid].LLI[slaveFreqIndex] = raw->obuf.data[n].LLI[slaveFreqIndex];
-                            sbf->meas3_refEpoch.lockt[navsys][svid][slaveFreqIndex] = raw->lockt[satNo-1][slaveFreqIndex];
+                            sbf->meas3_refEpoch.lockt[navsys][svid][codeSlave] = raw->lockt[satNo-1][codeSlave];
                         }
 
-                        if (raw->lockt[satNo-1][slaveFreqIndex] > sbf->meas3_refEpoch.lockt[navsys][svid][slaveFreqIndex])
-                            sbf->meas3_refEpoch.lockt[navsys][svid][slaveFreqIndex] = raw->lockt[satNo-1][slaveFreqIndex];
+                        if (raw->lockt[satNo-1][codeSlave] > sbf->meas3_refEpoch.lockt[navsys][svid][codeSlave])
+                            sbf->meas3_refEpoch.lockt[navsys][svid][codeSlave] = raw->lockt[satNo-1][codeSlave];
 
                         slaveCnt++;
                         /* delete this bit of the mask */

--- a/src/rcv/ublox.c
+++ b/src/rcv/ublox.c
@@ -334,9 +334,9 @@ static int decode_rxmraw(raw_t *raw)
         }
         raw->obs.data[n].sat=sat;
         
-        if (raw->obs.data[n].LLI[0]&1) raw->lockt[sat-1][0]=0.0;
-        else if (tt<1.0||10.0<tt) raw->lockt[sat-1][0]=0.0;
-        else raw->lockt[sat-1][0]+=tt;
+        if (raw->obs.data[n].LLI[0]&LLI_SLIP) raw->lockt[sat-1][CODE_L1C]=0.0;
+        else if (tt<1.0||10.0<tt) raw->lockt[sat-1][CODE_L1C]=0.0;
+        else raw->lockt[sat-1][CODE_L1C]+=tt;
         
         for (j=1;j<NFREQ+NEXOBS;j++) {
             raw->obs.data[n].L[j]=raw->obs.data[n].P[j]=0.0;
@@ -358,7 +358,7 @@ static int decode_rxmrawx(raw_t *raw)
     gtime_t time;
     char *q,tstr[64];
     double tow,P,L,D,tn,tadj=0.0,toff=0.0;
-    int i,j,k,idx,sys,prn,sat,code,slip,halfv,halfc,LLI,n=0;
+    int i,j,k,idx,sys,prn,sat,slip,halfv,halfc,LLI,n=0;
     int week,nmeas,ver,gnss,svid,sigid,frqid,lockt,cn0,cpstd=0,prstd=0,tstat;
     int multicode=0, rcvstds=0;
 
@@ -452,14 +452,17 @@ static int decode_rxmrawx(raw_t *raw)
         if (sys==SYS_GLO&&!raw->nav.glo_fcn[prn-1]) {
             raw->nav.glo_fcn[prn-1]=frqid-7+8;
         }
+        int mcode, code;
         if (ver>=1) {
+            mcode=ubx_sig(sys,sigid);
             if (multicode)
-                code=ubx_sig(sys,sigid);
+                code=mcode;
             else
                 code=ubx_sig_combined(sys,sigid);
         }
         else {
-            code=(sys==SYS_CMP)?CODE_L2I:((sys==SYS_GAL)?CODE_L1X:CODE_L1C);
+            mcode=(sys==SYS_CMP)?CODE_L2I:((sys==SYS_GAL)?CODE_L1X:CODE_L1C);
+            code=mcode;
         }
         /* signal index in obs data */
         if ((idx=sig_idx(sys,code))<0) {
@@ -480,20 +483,20 @@ static int decode_rxmrawx(raw_t *raw)
         else
             halfv=(tstat&4)?1:0; /* half cycle valid */
         halfc=(tstat&8)?1:0; /* half cycle subtracted from phase */
-        slip=lockt==0||lockt*1E-3<raw->lockt[sat-1][idx]||
-             halfc!=raw->halfc[sat-1][idx];
+        slip=lockt==0||lockt*1E-3<raw->lockt[sat-1][mcode]||
+             halfc!=raw->halfc[sat-1][mcode];
         if (cpstd>=cpstd_slip) slip=LLI_SLIP;
-        if (slip) raw->lockflag[sat-1][idx]=slip;
-        raw->lockt[sat-1][idx]=lockt*1E-3;
+        if (slip) raw->lockflag[sat-1][mcode]=slip;
+        raw->lockt[sat-1][mcode]=lockt*1E-3;
         /* LLI: bit0=slip,bit1=half-cycle-unresolved */
         LLI=!halfv&&L!=0.0?LLI_HALFC:0;
         /* half cycle adjusted */
         LLI|=halfc?LLI_HALFA:0; 
         /* set cycle slip if half cycle subtract bit changed state */
-        LLI|=halfc!=raw->halfc[sat-1][idx]?LLI_SLIP:0;
-        raw->halfc[sat-1][idx]=halfc;
+        LLI|=halfc!=raw->halfc[sat-1][mcode]?LLI_SLIP:0;
+        raw->halfc[sat-1][mcode]=halfc;
         /* set cycle slip flag if first valid phase since slip */
-        if (L!=0.0) LLI|=raw->lockflag[sat-1][idx]>0.0?LLI_SLIP:0;
+        if (L!=0.0) LLI|=raw->lockflag[sat-1][mcode]>0?LLI_SLIP:0;
 
         for (j=0;j<n;j++) {
             if (raw->obs.data[j].sat==sat) break;
@@ -519,7 +522,8 @@ static int decode_rxmrawx(raw_t *raw)
         raw->obs.data[j].SNR[idx]=(uint16_t)(cn0*1.0/SNR_UNIT+0.5);
         raw->obs.data[j].LLI[idx]=(uint8_t)LLI;
         raw->obs.data[j].code[idx]=(uint8_t)code;
-        if (L!=0.0) raw->lockflag[sat-1][idx]=0; /* clear slip carry-forward flag if valid phase*/
+        /* clear slip carry-forward flag if valid phase*/
+        if (L!=0.0) raw->lockflag[sat-1][mcode]=0;
     }
     raw->time=time;
     raw->obs.n=n;
@@ -647,10 +651,13 @@ static int decode_trkmeas(raw_t *raw)
         snr  =U2(p+20)/256.0;
         adr  =I8(p+32)*P2_32+(flag&0x40?0.5:0.0);
         dop  =I4(p+40)*P2_10*10.0;
-        
+
+        int code=sys==SYS_CMP?CODE_L2I:CODE_L1C;
+
         /* set slip flag */
-        if (lock2==0||lock2<raw->lockt[sat-1][0]) raw->lockt[sat-1][1]=1.0;
-        raw->lockt[sat-1][0]=lock2;
+        int slip = 0;
+        if (lock2==0||lock2<raw->lockt[sat-1][code]) slip=1;
+        raw->lockt[sat-1][code]=lock2;
         
 #if 0 /* for debug */
         trace(2,"[%2d] qi=%d sys=%d prn=%3d frq=%2d flag=%02X ?=%02X %02X "
@@ -671,16 +678,15 @@ static int decode_trkmeas(raw_t *raw)
         raw->obs.data[n].L[0]=-adr;
         raw->obs.data[n].D[0]=(float)dop;
         raw->obs.data[n].SNR[0]=(uint16_t)(snr/SNR_UNIT+0.5);
-        raw->obs.data[n].code[0]=sys==SYS_CMP?CODE_L2I:CODE_L1C;
+        raw->obs.data[n].code[0]=code;
         raw->obs.data[n].Lstd[0]=8-qi;
-        raw->obs.data[n].LLI[0]=raw->lockt[sat-1][1]>0.0?1:0;
+        raw->obs.data[n].LLI[0]=slip?LLI_SLIP:0;
         if (sys==SYS_SBS) { /* half-cycle valid */
-            raw->obs.data[n].LLI[0]|=lock2>142?0:2;
+            raw->obs.data[n].LLI[0]|=lock2>142?0:LLI_HALFC;
         }
         else {
-            raw->obs.data[n].LLI[0]|=flag&0x80?0:2;
+            raw->obs.data[n].LLI[0]|=flag&0x80?0:LLI_HALFC;
         }
-        raw->lockt[sat-1][1]=0.0;
         /* adjust code measurements for GLONASS sats */
         if (sys==SYS_GLO&&frq>=-7&&frq<=7) {
             if (fw==2) raw->obs.data[n].P[0]+=(double)P_adj_fw2[frq+7];
@@ -777,8 +783,9 @@ static int decode_trkd5(raw_t *raw)
         adr=qi<6?0.0:I8(p+8)*P2_32+(flag&0x01?0.5:0.0);
         dop=I4(p+16)*P2_10/4.0;
         snr=U2(p+32)/256.0;
-        
-        if (snr<=10.0) raw->lockt[sat-1][1]=1.0;
+
+        int slip = 0;
+        if (snr<=10.0) slip=1;
         
 #if 0 /* for debug */
         trace(2,"[%2d] qi=%d sys=%d prn=%3d frq=%2d flag=%02X ts=%1.3f "
@@ -798,8 +805,7 @@ static int decode_trkd5(raw_t *raw)
         raw->obs.data[n].D[0]=(float)dop;
         raw->obs.data[n].SNR[0]=(uint16_t)(snr/SNR_UNIT+0.5);
         raw->obs.data[n].code[0]=sys==SYS_CMP?CODE_L2I:CODE_L1C;
-        raw->obs.data[n].LLI[0]=raw->lockt[sat-1][1]>0.0?1:0;
-        raw->lockt[sat-1][1]=0.0;
+        raw->obs.data[n].LLI[0]=slip?LLI_SLIP:0;
         
         for (j=1;j<NFREQ+NEXOBS;j++) {
             raw->obs.data[n].L[j]=raw->obs.data[n].P[j]=0.0;

--- a/src/rcv/unicore.c
+++ b/src/rcv/unicore.c
@@ -36,13 +36,12 @@
 
 
 /* get fields (little-endian) ------------------------------------------------*/
-#define U1(p) (*((uint8_t *)(p)))
-#define I1(p) (*((int8_t  *)(p)))
-static uint16_t U2(uint8_t* p) { uint16_t u; memcpy(&u, p, 2); return u; }
-static uint32_t U4(uint8_t* p) { uint32_t u; memcpy(&u, p, 4); return u; }
-static int32_t  I4(uint8_t* p) { int32_t  i; memcpy(&i, p, 4); return i; }
-static float    R4(uint8_t* p) { float    r; memcpy(&r, p, 4); return r; }
-static double   R8(uint8_t* p) { double   r; memcpy(&r, p, 8); return r; }
+#define U1(p) (*((const uint8_t *)(p)))
+#define I1(p) (*((const int8_t  *)(p)))
+static uint16_t U2(const uint8_t* p) { uint16_t u; memcpy(&u, p, 2); return u; }
+static uint32_t U4(const uint8_t* p) { uint32_t u; memcpy(&u, p, 4); return u; }
+static float    R4(const uint8_t* p) { float    r; memcpy(&r, p, 4); return r; }
+static double   R8(const uint8_t* p) { double   r; memcpy(&r, p, 8); return r; }
 
 
 /* sync header ---------------------------------------------------------------*/
@@ -94,42 +93,6 @@ static gtime_t adjweek(gtime_t time, double tow)
     if (tow < tow_p - 302400.0) tow += 604800.0;
     else if (tow > tow_p + 302400.0) tow -= 604800.0;
     return gpst2time(week, tow);
-}
-
-/* check code priority and return freq-index ---------------------------------*/
-static int checkpri(const char* opt, int sys, int code, int idx)
-{
-    int nex = NEXOBS;
-
-    if (sys == SYS_GPS) {
-        if (strstr(opt, "-GL1L") && idx == 0) return (code == CODE_L1L) ? 0 : -1;
-        if (strstr(opt, "-GL2S") && idx == 1) return (code == CODE_L2X) ? 1 : -1;
-        if (strstr(opt, "-GL2P") && idx == 1) return (code == CODE_L2P) ? 1 : -1;
-        if (code == CODE_L1L) return (nex < 1) ? -1 : NFREQ;
-        if (code == CODE_L2S) return (nex < 2) ? -1 : NFREQ + 1;
-        if (code == CODE_L2P) return (nex < 3) ? -1 : NFREQ + 2;
-    }
-    else if (sys == SYS_GLO) {
-        if (strstr(opt, "-RL2C") && idx == 1) return (code == CODE_L2C) ? 1 : -1;
-        if (code == CODE_L2C) return (nex < 1) ? -1 : NFREQ;
-    }
-    else if (sys == SYS_GAL) {
-        if (strstr(opt, "-EL6B") && idx == 3) return (code == CODE_L6B) ? 3 : -1;
-        if (code == CODE_L6B) return (nex < 2) ? -1 : NFREQ;
-    }
-    else if (sys == SYS_QZS) {
-        if (strstr(opt, "-JL1L") && idx == 0) return (code == CODE_L1L) ? 0 : -1;
-        if (strstr(opt, "-JL1Z") && idx == 0) return (code == CODE_L1Z) ? 0 : -1;
-        if (code == CODE_L1L) return (nex < 1) ? -1 : NFREQ;
-        if (code == CODE_L1Z) return (nex < 2) ? -1 : NFREQ + 1;
-    }
-    else if (sys == SYS_CMP) {
-        if (strstr(opt, "-CL1P") && idx == 0) return (code == CODE_L1P) ? 0 : -1;
-        if (strstr(opt, "-CL7D") && idx == 0) return (code == CODE_L7D) ? 0 : -1;
-        if (code == CODE_L1P) return (nex < 1) ? -1 : NFREQ;
-        if (code == CODE_L7D) return (nex < 2) ? -1 : NFREQ + 1;
-    }
-    return idx < NFREQ ? idx : -1;
 }
 
 /* signal type to obs code ---------------------------------------------------*/
@@ -214,20 +177,16 @@ static int sig2code(int sys, int sigtype, int l2c)
     return 0;
 }
 
-static int decode_track_stat(uint32_t stat, int* sys, int* code, int* plock, int* clock)
+static int decode_track_stat(uint32_t stat, int *sys, int *code, int *plock, int *clock)
 {
-    int satsys, sigtype, idx = -1;
-    int l2c;
-
     *code = CODE_NONE;
     *plock = (stat >> 10) & 1;
     *clock = (stat >> 12) & 1;
-    satsys = (stat >> 16) & 7;
-    sigtype = (stat >> 21) & 0x1F;
-    l2c = (stat >> 26) & 0x01;
+    int sysno = (stat >> 16) & 7;
+    int sigtype = (stat >> 21) & 0x1F;
+    int l2c = (stat >> 26) & 0x01;
 
-
-    switch (satsys) {
+    switch (sysno) {
     case 0: *sys = SYS_GPS; break;
     case 1: *sys = SYS_GLO; break;
     case 2: *sys = SYS_SBS; break;
@@ -239,6 +198,7 @@ static int decode_track_stat(uint32_t stat, int* sys, int* code, int* plock, int
         trace(2, "unicore unknown system: sys=%d\n", satsys);
         return -1;
     }
+    int idx = -1;
     if (!(*code = sig2code(*sys, sigtype, l2c)) || (idx = code2idx(*sys, *code)) < 0) {
         trace(2, "unicore signal type error: sys=%d sigtype=%d\n", *sys, sigtype);
         return -1;
@@ -721,18 +681,14 @@ static int decode_irnssephb(raw_t* raw) {
 // decode OBSVMB
 static int decode_obsvmb(raw_t* raw)
 {
-    uint8_t* p = raw->buff + HLEN;
-    char* q;
-    double psr, adr, dop, snr, lockt, tt, freq, glo_bias = 0.0;
-    int i, index, nobs, prn, sat, sys, code, idx, track, plock, clock, lli;
-    int gfrq;
-
-    if ((q = strstr(raw->opt, "-GLOBIAS="))) sscanf(q, "-GLOBIAS=%lf", &glo_bias);
+    double glo_bias = 0.0;
+    const char *q = strstr(raw->opt, "-GLOBIAS=");
+    if (q) sscanf(q, "-GLOBIAS=%lf", &glo_bias);
 
     int rcvstds = 0;
     if (strstr(raw->opt, "-RCVSTDS")) rcvstds = 1;
 
-    nobs = U4(p);
+    int nobs = U4(raw->buff + HLEN);
     if (nobs == 0)return 1;
     if (raw->len < HLEN + 4 + nobs * 40) {
         trace(2, "unicore obsvmb length error: len=%d nobs=%d\n", raw->len, nobs);
@@ -742,87 +698,124 @@ static int decode_obsvmb(raw_t* raw)
         sprintf(raw->msgtype + strlen(raw->msgtype), " nobs=%d", nobs);
     }
 
-    p += 4; // Number of observation messages
+    if (fabs(timediff(raw->obs.data[0].time, raw->time)) > 1E-9)
+      raw->obs.n = 0;
 
-    for (i = 0; i < nobs; i++, p += 40) {
-        uint32_t trk_stat = U4(p + 36);
-
-        if ((idx = decode_track_stat(trk_stat, &sys, &code, &plock, &clock)) < 0) {
-            continue;
-        }
-        prn = U2(p + 2);
-
-
+    // First pass to identify the set of signals for each satellite
+    gtime_t t0 = raw->obs.data[0].time;
+    int sigp[MAXSAT] = {0};
+    int sigcode[MAXSAT][MAXCODE] = {{CODE_NONE}};
+    int sigidx[MAXSAT][MAXCODE] = {{-1}}, sigpri[MAXSAT][MAXCODE] = {{-1}};
+    int pi = HLEN + 4; // Number of observation messages
+    for (int i = 0; i < nobs; i++, pi += 40) {
+        uint32_t trk_stat = U4(raw->buff + pi + 36);
+        int sys, code, plock, clock;
+        int idx = decode_track_stat(trk_stat, &sys, &code, &plock, &clock);
+        if (idx < 0) continue;
+        int prn = U2(raw->buff + pi + 2);
         if (sys == SYS_GLO) prn -= 37;
         if (sys == SYS_SBS && prn >= MINPRNQZS_S && prn <= MAXPRNQZS_S && code == CODE_L1C) {
             sys = SYS_QZS;
             prn += 10;
             code = CODE_L1Z; /* QZS L1S */
         }
-        if (!(sat = satno(sys, prn))) {
+        int sat = satno(sys, prn);
+        if (!sat) {
+            trace(3, "unicore obsvm satellite number error: sys=%d,prn=%d\n", sys, prn);
+            continue;
+        }
+        // Code unlock. Skip the observation if not locked to give another
+        // observation on the same frequency a chance of selection.
+        if (!clock) continue;
+        sigp[sat] = 1;
+        sigcode[sat][code] = code;
+        sigidx[sat][code] = idx;
+        sigpri[sat][code] = getcodepri(sys, code, raw->opt);
+    }
+    // Resolve the frequence indices, for each noted satellite.
+    for (int sat = 0; sat < MAXSAT; sat++)
+      if (sigp[sat]) sigindex(MAXCODE, sigcode[sat], sigpri[sat], sigidx[sat]);
+
+    pi = HLEN + 4; // Number of observation messages
+    for (int i = 0; i < nobs; i++, pi += 40) {
+        uint32_t trk_stat = U4(raw->buff + pi + 36);
+
+        int sys, code, plock, clock;
+        int idx = decode_track_stat(trk_stat, &sys, &code, &plock, &clock);
+        if (idx < 0) continue;
+        int prn = U2(raw->buff + pi + 2);
+
+        if (sys == SYS_GLO) prn -= 37;
+        if (sys == SYS_SBS && prn >= MINPRNQZS_S && prn <= MAXPRNQZS_S && code == CODE_L1C) {
+            sys = SYS_QZS;
+            prn += 10;
+            code = CODE_L1Z; // QZS L1S
+        }
+        int sat = satno(sys, prn);
+        if (!sat) {
             trace(3, "unicore obsvm satellite number error: sys=%d,prn=%d\n", sys, prn);
             continue;
         }
         //if (sys == SYS_GLO && !parity) continue;
 
-        if ((idx = checkpri(raw->opt, sys, code, idx)) < 0) continue;
+        // Get the resolved frequency index
+        if (!sigp[sat]) continue;
+        idx = sigidx[sat][code];
+        if (idx < 0) continue;
 
-        gfrq = U2(p) + 1; /* GLONASS FCN+8 */
-        psr = R8(p + 4);
-        adr = R8(p + 12);
-        dop = R4(p + 24);
-        snr = U2(p + 28) / 100.0;
-        lockt = R4(p + 32);
+        int gfrq = U2(raw->buff + pi) + 1; /* GLONASS FCN+8 */
+        double psr = R8(raw->buff + pi + 4);
+        double adr = R8(raw->buff + pi + 12);
+        double dop = R4(raw->buff + pi + 24);
+        double snr = U2(raw->buff + pi + 28) / 100.0;
+        double lockt = R4(raw->buff + pi + 32);
 
         if (sys == SYS_GLO) {
-            freq = sat2freq(sat, (uint8_t)code, &raw->nav);
+            double freq = sat2freq(sat, code, &raw->nav);
             adr -= glo_bias * freq / CLIGHT;
             if (!raw->nav.glo_fcn[prn - 1]) {
                 raw->nav.glo_fcn[prn - 1] = gfrq; /* fcn+8 */
             }
         }
+        int lli;
         if (raw->tobs[sat - 1][code].time != 0) {
-            tt = timediff(raw->time, raw->tobs[sat - 1][code]);
+            double tt = timediff(raw->time, raw->tobs[sat - 1][code]);
             lli = lockt - raw->lockt[sat - 1][code] + 0.05 <= tt ? LLI_SLIP : 0;
         }
         else {
             lli = 0;
         }
-        //      if (!parity) lli |= LLI_HALFC;
-        //      if (halfc) lli |= LLI_HALFA;
         raw->tobs[sat - 1][code] = raw->time;
         raw->lockt[sat - 1][code] = lockt;
         raw->halfc[sat - 1][code] = 0;
 
-        if (!clock) psr = 0.0;     /* code unlock */
-        if (!plock) adr = dop = 0.0; /* phase unlock */
+        if (!clock) continue;
+        if (!plock) adr = dop = 0.0; // phase valid
 
-        if (fabs(timediff(raw->obs.data[0].time, raw->time)) > 1E-9) {
-            raw->obs.n = 0;
-        }
-        if ((index = obsindex(&raw->obs, raw->time, sat)) >= 0) {
+        int index = obsindex(&raw->obs, raw->time, sat);
+        if (index >= 0) {
             raw->obs.data[index].L[idx] = -adr;
             raw->obs.data[index].P[idx] = psr;
             raw->obs.data[index].D[idx] = (float)dop;
             raw->obs.data[index].SNR[idx] = (uint16_t)(snr / SNR_UNIT + 0.5);
             raw->obs.data[index].LLI[idx] = (uint8_t)lli;
-            raw->obs.data[index].code[idx] = (uint8_t)code;
+            raw->obs.data[index].code[idx] = code;
             if (rcvstds) {
-                double pstd = U2(p + 20) * 0.01;  // Meters
+                double pstd = U2(raw->buff + pi + 20) * 0.01;  // Meters
                 // To RTKlib encoding
                 pstd = log2(pstd / 0.01) - 5;
                 pstd = pstd > 0 ? pstd : 0;
                 // Further limited to 9 in RINEX output
                 pstd = pstd <= 254 ? pstd : 254;
-                raw->obuf.data[index].Pstd[idx] = pstd + 0.5;
+                raw->obs.data[index].Pstd[idx] = pstd + 0.5;
 
-                double lstd = U2(p + 22) * 0.0001; // Cycles
+                double lstd = U2(raw->buff + pi + 22) * 0.0001; // Cycles
                 // To RTKlib encoding
                 lstd = lstd / 0.004;
                 lstd = lstd > 0 ? lstd : 0;
                 // Further limited to 9 in RINEX output
                 lstd = lstd <= 254 ? lstd : 254;
-                raw->obuf.data[index].Lstd[idx] = lstd + 0.5;
+                raw->obs.data[index].Lstd[idx] = lstd + 0.5;
             }
         }
     }

--- a/src/rcv/unicore.c
+++ b/src/rcv/unicore.c
@@ -781,18 +781,18 @@ static int decode_obsvmb(raw_t* raw)
                 raw->nav.glo_fcn[prn - 1] = gfrq; /* fcn+8 */
             }
         }
-        if (raw->tobs[sat - 1][idx].time != 0) {
-            tt = timediff(raw->time, raw->tobs[sat - 1][idx]);
-            lli = lockt - raw->lockt[sat - 1][idx] + 0.05 <= tt ? LLI_SLIP : 0;
+        if (raw->tobs[sat - 1][code].time != 0) {
+            tt = timediff(raw->time, raw->tobs[sat - 1][code]);
+            lli = lockt - raw->lockt[sat - 1][code] + 0.05 <= tt ? LLI_SLIP : 0;
         }
         else {
             lli = 0;
         }
         //      if (!parity) lli |= LLI_HALFC;
         //      if (halfc) lli |= LLI_HALFA;
-        raw->tobs[sat - 1][idx] = raw->time;
-        raw->lockt[sat - 1][idx] = lockt;
-        raw->halfc[sat - 1][idx] = 0;
+        raw->tobs[sat - 1][code] = raw->time;
+        raw->lockt[sat - 1][code] = lockt;
+        raw->halfc[sat - 1][code] = 0;
 
         if (!clock) psr = 0.0;     /* code unlock */
         if (!plock) adr = dop = 0.0; /* phase unlock */

--- a/src/rcvraw.c
+++ b/src/rcvraw.c
@@ -1316,10 +1316,11 @@ extern int init_raw(raw_t *raw, int format)
     raw->msgtype[0]='\0';
     for (i=0;i<MAXSAT;i++) {
         for (j=0;j<380;j++) raw->subfrm[i][j]=0;
-        for (j=0;j<NFREQ+NEXOBS;j++) {
-            raw->tobs [i][j]=time0;
-            raw->lockt[i][j]=0.0;
-            raw->halfc[i][j]=0;
+        for (int code=0; code<MAXCODE; code++) {
+            raw->tobs [i][code]=time0;
+            raw->lockt[i][code]=0.0;
+            raw->halfc[i][code]=0;
+            raw->lockflag[i][code]=0;
         }
         raw->icpp[i]=raw->off[i]=raw->prCA[i]=raw->dpCA[i]=0.0;
     }

--- a/src/rinex.c
+++ b/src/rinex.c
@@ -147,14 +147,13 @@ static const double ura_nominal[]={     /* URA nominal values */
     2048.0,4096.0,8192.0
 };
 /* type definition -----------------------------------------------------------*/
-typedef struct {                        /* signal index type */
-    int n;                              /* number of index */
-    int idx[MAXOBSTYPE];                /* signal freq-index */
-    int pos[MAXOBSTYPE];                /* signal index in obs data (-1:no) */
-    uint8_t pri [MAXOBSTYPE];           /* signal priority (15-0) */
-    uint8_t type[MAXOBSTYPE];           /* type (0:C,1:L,2:D,3:S) */
-    uint8_t code[MAXOBSTYPE];           /* obs-code (CODE_L??) */
-    double shift[MAXOBSTYPE];           /* phase shift (cycle) */
+typedef struct {              /* Signal index type */
+  int n;                      /* Number of observation types */
+  int code[MAXOBSTYPE];       /* Obs-code (CODE_L??) */
+  uint8_t type[MAXOBSTYPE];   /* Type (0:C,1:L,2:D,3:S) */
+  double shift[MAXOBSTYPE];   /* Phase shift (cycle) */
+  int idx[MAXOBSTYPE];        /* Signal freq-index, unresolved */
+  uint8_t pri[MAXOBSTYPE];    /* Signal priority (15-0) */
 } sigind_t;
 
 /* set string without tail space ---------------------------------------------*/
@@ -782,7 +781,7 @@ static int decode_obsdata(FILE *fp, char *buff, double ver, int mask,
     uint8_t lli[MAXOBSTYPE]={0};
     uint8_t std[MAXOBSTYPE]={0};
     char satid[8]="";
-    int i,j,n,m,q,stat=1,p[MAXOBSTYPE],k[16],l[16],r[16];
+    int i,j,stat=1;
 
     trace(4,"decode_obsdata: ver=%.2f\n",ver);
 
@@ -807,14 +806,24 @@ static int decode_obsdata(FILE *fp, char *buff, double ver, int mask,
         case SYS_IRN: ind=index+6; break;
         default:      ind=index  ; break;
     }
+    int sigcode[MAXCODE];
+    int codesig[MAXCODE] = {-1}, sigidx[MAXCODE], sigpri[MAXCODE], nsigs = 0;
     for (i=0,j=ver<=2.99?0:3;i<ind->n;i++,j+=16) {
 
         if (ver<=2.99&&j>=80) { /* ver.2 */
             if (!fgets(buff,MAXRNXLEN,fp)) break;
             j=0;
         }
-        if (stat) {
+        int code = ind->code[i];
+        if (stat && code != CODE_NONE) {
             val[i]=str2num(buff,j,14)+ind->shift[i];
+            if (ind->type[i] == 0 && val[i] != 0) {
+              codesig[code] = nsigs;
+              sigcode[nsigs] = code;
+              sigidx[nsigs] = ind->idx[code];
+              sigpri[nsigs] = ind->pri[code];
+              nsigs++;
+            }
             lli[i]=(uint8_t)str2num(buff,j+14,1)&3;
             /* measurement std from receiver */
             std[i]=(uint8_t)str2num(buff,j+15,1);
@@ -826,88 +835,33 @@ static int decode_obsdata(FILE *fp, char *buff, double ver, int mask,
         obs->P[i]=obs->L[i]=0.0; obs->D[i]=0.0f;
         obs->SNR[i]=obs->LLI[i]=obs->Lstd[i]=obs->Pstd[i]=obs->code[i]=0;
     }
-    /* assign position in observation data */
-    for (i=n=m=q=0;i<ind->n;i++) {
 
-        p[i]=(ver<=2.11)?ind->idx[i]:ind->pos[i];
-
-        if (ind->type[i]==0&&p[i]==0) k[n++]=i; /* C1? index */
-        if (ind->type[i]==0&&p[i]==1) l[m++]=i; /* C2? index */
-        if (ind->type[i]==0&&p[i]==2) r[q++]=i; /* C3? index */
-    }
-
-    /* if multiple codes (C1/P1,C2/P2), select higher priority */
-    if (ver<=2.11) {
-        if (n>=2) {
-            if (val[k[0]]==0.0&&val[k[1]]==0.0) {
-                p[k[0]]=-1; p[k[1]]=-1;
-            }
-            else if (val[k[0]]!=0.0&&val[k[1]]==0.0) {
-                p[k[0]]=0; p[k[1]]=-1;
-            }
-            else if (val[k[0]]==0.0&&val[k[1]]!=0.0) {
-                p[k[0]]=-1; p[k[1]]=0;
-            }
-            else if (ind->pri[k[1]]>ind->pri[k[0]]) {
-                p[k[1]]=0; p[k[0]]=NEXOBS<1?-1:NFREQ;
-            }
-            else {
-                p[k[0]]=0; p[k[1]]=NEXOBS<1?-1:NFREQ;
-            }
-        }
-        if (m>=2) {
-            if (val[l[0]]==0.0&&val[l[1]]==0.0) {
-                p[l[0]]=-1; p[l[1]]=-1;
-            }
-            else if (val[l[0]]!=0.0&&val[l[1]]==0.0) {
-                p[l[0]]=1; p[l[1]]=-1;
-            }
-            else if (val[l[0]]==0.0&&val[l[1]]!=0.0) {
-                p[l[0]]=-1; p[l[1]]=1; 
-            }
-            else if (ind->pri[l[1]]>ind->pri[l[0]]) {
-                p[l[1]]=1; p[l[0]]=NEXOBS<2?-1:NFREQ+1;
-            }
-            else {
-                p[l[0]]=1; p[l[1]]=NEXOBS<2?-1:NFREQ+1;
-            }
-        }
-        if (q>=2) {
-            if (val[r[0]]==0.0&&val[r[1]]==0.0) {
-                p[r[0]]=-1; p[r[1]]=-1;
-            }
-            else if (val[r[0]]!=0.0&&val[r[1]]==0.0) {
-                p[r[0]]=2; p[r[1]]=-1;
-            }
-            else if (val[r[0]]==0.0&&val[r[1]]!=0.0) {
-                p[r[0]]=-1; p[r[1]]=2;
-            }
-            else if (ind->pri[r[1]]>ind->pri[r[0]]) {
-                p[r[1]]=2; p[r[0]]=NEXOBS<3?-1:NFREQ+2;
-            }
-            else {
-                p[r[0]]=2; p[r[1]]=NEXOBS<3?-1:NFREQ+2;
-            }
-        }
-    }
+    // Get signal frequence index
+    sigindex(nsigs, sigcode, sigpri, sigidx);
     
     /* save observation data */
     for (i=0;i<ind->n;i++) {
-        if (p[i]<0||(val[i]==0.0&&lli[i]==0)) continue;
+        if (val[i] == 0.0 && lli[i] == 0) continue;
+        int code = ind->code[i];
+        if (code == CODE_NONE) continue;
+        int sig = codesig[code];
+        if (sig < 0) continue;
+        int freqidx = sigidx[sig];
+        if (freqidx < 0) continue;
         switch (ind->type[i]) {
-            case 0: obs->P[p[i]]=val[i];
-                    obs->code[p[i]]=ind->code[i];
-                    obs->Pstd[p[i]]=std[i]>0?std[i]:0;
+            case 0: obs->P[freqidx]=val[i];
+                    obs->code[freqidx]=ind->code[i];
+                    obs->Pstd[freqidx]=std[i]>0?std[i]:0;
                     break;
-            case 1: obs->L[p[i]]=val[i];
-                    obs->LLI[p[i]]=lli[i];
-                    obs->Lstd[p[i]]=std[i]>0?std[i]:0;
+            case 1: obs->L[freqidx]=val[i];
+                    obs->LLI[freqidx]=lli[i];
+                    obs->Lstd[freqidx]=std[i]>0?std[i]:0;
                     break;
-            case 2: obs->D[p[i]]=(float)val[i];                     break;
-            case 3: obs->SNR[p[i]]=(uint16_t)(val[i]/SNR_UNIT+0.5); break;
+            case 2: obs->D[freqidx]=(float)val[i];                     break;
+            case 3: obs->SNR[freqidx]=(uint16_t)(val[i]/SNR_UNIT+0.5); break;
         }
-        trace(4, "obs: i=%d f=%d P=%14.3f L=%14.3f LLI=%d code=%d\n",i,p[i],obs->P[p[i]],
-        obs->L[p[i]],obs->LLI[p[i]],obs->code[p[i]]);
+        trace(4, "obs: i=%d f=%d P=%14.3f L=%14.3f LLI=%d code=%d\n",i,freqidx,obs->P[freqidx],
+        obs->L[freqidx],obs->LLI[freqidx],obs->code[freqidx]);
     }
     trace(4,"decode_obsdata: time=%s sat=%2d\n",time_str(obs->time,0),obs->sat);
     return 1;
@@ -968,20 +922,20 @@ static int set_sysmask(const char *opt)
     return mask;
 }
 /* set signal index ----------------------------------------------------------*/
-static void set_index(double ver, int sys, const char *opt,
-                      char tobs[MAXOBSTYPE][4], sigind_t *ind)
+static void set_sys_index(double ver, int sys, const char *opt, char tobs[MAXOBSTYPE][4],
+                          sigind_t *ind)
 {
     const char *p;
-    char str[8],*optstr="";
-    double shift;
-    int i,j,k,n;
+    char *optstr="";
+    int i,n;
 
     for (i=n=0;*tobs[i];i++,n++) {
-        ind->code[i]=obs2code(tobs[i]+1);
-        ind->type[i]=(p=strchr(obscodes,tobs[i][0]))?(int)(p-obscodes):0;
-        ind->idx[i]=code2idx(sys,ind->code[i]);
-        ind->pri[i]=getcodepri(sys,ind->code[i],opt);
-        ind->pos[i]=-1;
+        int code = obs2code(tobs[i] + 1);
+        ind->code[i] = code;
+        const char *p = strchr(obscodes, tobs[i][0]);
+        ind->type[i]=p?(int)(p-obscodes):0;
+        ind->idx[code]=code2idx(sys,code);
+        ind->pri[code]=getcodepri(sys,code,opt);
     }
     /* parse phase shift options */
     switch (sys) {
@@ -994,6 +948,8 @@ static void set_index(double ver, int sys, const char *opt,
         case SYS_IRN: optstr="-IL%2s=%lf"; break;
     }
     for (p=opt;p&&(p=strchr(p,'-'));p++) {
+        char str[8];
+        double shift;
         if (sscanf(p,optstr,str,&shift)<2) continue;
         for (i=0;i<n;i++) {
             if (strcmp(code2obs(ind->code[i]),str)) continue;
@@ -1002,43 +958,39 @@ static void set_index(double ver, int sys, const char *opt,
                   tobs[i],shift);
         }
     }
-    /* assign index for highest priority code */
-    for (i=0;i<NFREQ;i++) {
-        for (j=0,k=-1;j<n;j++) {
-            if (ind->idx[j]==i&&ind->pri[j]&&(k<0||ind->pri[j]>ind->pri[k])) {
-                k=j;
-            }
-        }
-        if (k<0) continue;
-
-        for (j=0;j<n;j++) {
-            if (ind->code[j]==ind->code[k]) ind->pos[j]=i;
-        }
-    }
-    /* assign index of extended observation data */
-    for (i=0;i<NEXOBS;i++) {
-        for (j=0;j<n;j++) {
-            if (ind->code[j]&&ind->pri[j]&&ind->pos[j]<0) break;
-        }
-        if (j>=n) break;
-
-        for (k=0;k<n;k++) {
-            if (ind->code[k]==ind->code[j]) ind->pos[k]=NFREQ+i;
-        }
-    }
-    /* list rejected observation types */
-    for (i=0;i<n;i++) {
-        if (!ind->code[i]||!ind->pri[i]||ind->pos[i]>=0) continue;
-        trace(4,"reject obs type: sys=%2d, obs=%s\n",sys,tobs[i]);
-    }
     ind->n=n;
-
-#if 0 /* for debug */
-    for (i=0;i<n;i++) {
-        trace(2,"set_index: sys=%2d,tobs=%s code=%2d pri=%2d idx=%d pos=%d shift=%5.2f\n",
-              sys,tobs[i],ind->code[i],ind->pri[i],ind->idx[i],ind->pos[i],
-              ind->shift[i]);
+    
+#ifdef RTK_DISABLED /* for debug */
+    for (int i=0;i<n;i++) {
+        int c = ind->code[i];
+        trace(2,"set_index: sys=%2d tobs=%s code=%2d pri=%2d idx=%d shift=%5.2f\n",
+              sys,tobs[i],c,ind->pri[c],ind->idx[c],ind->shift[i]);
     }
+#endif
+}
+static void set_index(double ver, const char *opt, char tobs[][MAXOBSTYPE][4],
+                      sigind_t index[RNX_NUMSYS])
+{
+#if RNX_NUMSYS >= 1
+  set_sys_index(ver, SYS_GPS, opt, tobs[RNX_SYS_GPS], index);
+#endif
+#if RNX_NUMSYS >= 2
+  set_sys_index(ver, SYS_GLO, opt, tobs[RNX_SYS_GLO], index + 1);
+#endif
+#if RNX_NUMSYS >= 3
+  set_sys_index(ver, SYS_GAL, opt, tobs[RNX_SYS_GAL], index + 2);
+#endif
+#if RNX_NUMSYS >= 4
+  set_sys_index(ver, SYS_QZS, opt, tobs[RNX_SYS_QZS], index + 3);
+#endif
+#if RNX_NUMSYS >= 5
+  set_sys_index(ver, SYS_SBS, opt, tobs[RNX_SYS_SBS], index + 4);
+#endif
+#if RNX_NUMSYS >= 6
+  set_sys_index(ver, SYS_CMP, opt, tobs[RNX_SYS_CMP], index + 5);
+#endif
+#if RNX_NUMSYS >= 7
+  set_sys_index(ver, SYS_IRN, opt, tobs[RNX_SYS_IRN], index + 6);
 #endif
 }
 /* read RINEX observation data body ------------------------------------------*/
@@ -1047,7 +999,6 @@ static int readrnxobsb(FILE *fp, const char *opt, double ver, int *tsys,
                        sta_t *sta)
 {
     gtime_t time={0};
-    sigind_t index[RNX_NUMSYS]={{0}};
     char buff[MAXRNXLEN];
     int i=0,n=0,nsat=0,sats[MAXOBS]={0},mask;
     
@@ -1055,28 +1006,10 @@ static int readrnxobsb(FILE *fp, const char *opt, double ver, int *tsys,
     mask=set_sysmask(opt);
 
     /* set signal index */
-#if RNX_NUMSYS>=1
-    set_index(ver,SYS_GPS,opt,tobs[RNX_SYS_GPS],index  );
-#endif
-#if RNX_NUMSYS>=2
-    set_index(ver,SYS_GLO,opt,tobs[RNX_SYS_GLO],index+1);
-#endif
-#if RNX_NUMSYS>=3
-    set_index(ver,SYS_GAL,opt,tobs[RNX_SYS_GAL],index+2);
-#endif
-#if RNX_NUMSYS>=4
-    set_index(ver,SYS_QZS,opt,tobs[RNX_SYS_QZS],index+3);
-#endif
-#if RNX_NUMSYS>=5
-    set_index(ver,SYS_SBS,opt,tobs[RNX_SYS_SBS],index+4);
-#endif
-#if RNX_NUMSYS>=6
-    set_index(ver,SYS_CMP,opt,tobs[RNX_SYS_CMP],index+5);
-#endif
-#if RNX_NUMSYS>=7
-    set_index(ver,SYS_IRN,opt,tobs[RNX_SYS_IRN],index+6);
-#endif
-    
+    // Could hoist set_index into readrnxobs and rnxctr_t if a performance issue.
+    sigind_t index[RNX_NUMSYS]={{0}};
+    set_index(ver, opt, tobs, index);
+
     /* read record */
     while (fgets(buff,MAXRNXLEN,fp)) {
 
@@ -1101,6 +1034,7 @@ static int readrnxobsb(FILE *fp, const char *opt, double ver, int *tsys,
 
             /* decode RINEX observation data file header */
             decode_obsh(fp,buff,ver,tsys,tobs,NULL,sta);
+            set_index(ver, opt, tobs, index);
         }
         if (++i>nsat) return n;
     }

--- a/src/rinex.c
+++ b/src/rinex.c
@@ -913,20 +913,20 @@ static int decode_obsdata(FILE *fp, char *buff, double ver, int mask,
     return 1;
 }
 /* save cycle slips ----------------------------------------------------------*/
-static void saveslips(uint8_t slips[][NFREQ+NEXOBS], obsd_t *data)
+static void saveslips(uint8_t slips[][MAXCODE], obsd_t *data)
 {
-    int i;
-    for (i=0;i<NFREQ+NEXOBS;i++) {
-        if (data->LLI[i]&1) slips[data->sat-1][i]|=LLI_SLIP;
+    for (int i=0;i<NFREQ+NEXOBS;i++) {
+        int code = data->code[i];
+        if (data->LLI[i]&1) slips[data->sat-1][code]=1;
     }
 }
 /* restore cycle slips -------------------------------------------------------*/
-static void restslips(uint8_t slips[][NFREQ+NEXOBS], obsd_t *data)
+static void restslips(uint8_t slips[][MAXCODE], obsd_t *data)
 {
-    int i;
-    for (i=0;i<NFREQ+NEXOBS;i++) {
-        if (slips[data->sat-1][i]&1) data->LLI[i]|=LLI_SLIP;
-        slips[data->sat-1][i]=0;
+    for (int i=0;i<NFREQ+NEXOBS;i++) {
+        int code = data->code[i];
+        if (slips[data->sat-1][code]&1) data->LLI[i]|=LLI_SLIP;
+        slips[data->sat-1][code]=0;
     }
 }
 /* add observation data ------------------------------------------------------*/
@@ -1113,7 +1113,7 @@ static int readrnxobs(FILE *fp, gtime_t ts, gtime_t te, double tint,
 {
     gtime_t eventime={0},time0={0},time1={0};
     obsd_t *data;
-    uint8_t slips[MAXSAT][NFREQ+NEXOBS]={{0}};
+    uint8_t slips[MAXSAT][MAXCODE]={{0}};
     int i,n,n1=0,flag=0,stat=0;
     double dtime1=0;
 

--- a/src/rtcm.c
+++ b/src/rtcm.c
@@ -92,10 +92,12 @@ extern int init_rtcm(rtcm_t *rtcm)
     rtcm->msg[0]=rtcm->msgtype[0]=rtcm->opt[0]='\0';
     for (i=0;i<6;i++) rtcm->msmtype[i][0]='\0';
     rtcm->obsflag=rtcm->ephsat=0;
+    rtcm->stime = time0;
     for (i=0;i<MAXSAT;i++)
       for (int code=0;code<MAXCODE;code++) {
         rtcm->cp[i][code]=0.0;
-        rtcm->lock[i][code]=rtcm->loss[i][code]=0;
+        rtcm->lti[i][code]=rtcm->loss[i][code]=0;
+        rtcm->tobs[i][code] = time0;
         rtcm->lltime[i][code]=time0;
     }
     rtcm->nbyte=rtcm->nbit=rtcm->len=0;

--- a/src/rtcm.c
+++ b/src/rtcm.c
@@ -70,7 +70,7 @@ extern int init_rtcm(rtcm_t *rtcm)
     eph_t  eph0 ={0,-1,-1};
     geph_t geph0={0,-1};
     ssr_t ssr0={{{0}}};
-    int i,j;
+    int i;
     
     trace(3,"init_rtcm:\n");
     
@@ -92,10 +92,11 @@ extern int init_rtcm(rtcm_t *rtcm)
     rtcm->msg[0]=rtcm->msgtype[0]=rtcm->opt[0]='\0';
     for (i=0;i<6;i++) rtcm->msmtype[i][0]='\0';
     rtcm->obsflag=rtcm->ephsat=0;
-    for (i=0;i<MAXSAT;i++) for (j=0;j<NFREQ+NEXOBS;j++) {
-        rtcm->cp[i][j]=0.0;
-        rtcm->lock[i][j]=rtcm->loss[i][j]=0;
-        rtcm->lltime[i][j]=time0;
+    for (i=0;i<MAXSAT;i++)
+      for (int code=0;code<MAXCODE;code++) {
+        rtcm->cp[i][code]=0.0;
+        rtcm->lock[i][code]=rtcm->loss[i][code]=0;
+        rtcm->lltime[i][code]=time0;
     }
     rtcm->nbyte=rtcm->nbit=rtcm->len=0;
     rtcm->word=0;

--- a/src/rtcm2.c
+++ b/src/rtcm2.c
@@ -236,10 +236,10 @@ static int decode_type18(rtcm_t *rtcm)
         }
         if ((index=obsindex(&rtcm->obs,time,sat))>=0) {
             rtcm->obs.data[index].L[freq]=-cp/256.0;
-            rtcm->obs.data[index].LLI[freq]=rtcm->loss[sat-1][freq]!=loss;
-            rtcm->obs.data[index].code[freq]=
-                !freq?(code?CODE_L1P:CODE_L1C):(code?CODE_L2P:CODE_L2C);
-            rtcm->loss[sat-1][freq]=loss;
+            int lcode=!freq?(code?CODE_L1P:CODE_L1C):(code?CODE_L2P:CODE_L2C);
+            rtcm->obs.data[index].LLI[freq]=rtcm->loss[sat-1][lcode]!=loss;
+            rtcm->obs.data[index].code[freq]=lcode;
+            rtcm->loss[sat-1][lcode]=loss;
         }
     }
     rtcm->obsflag=!sync;
@@ -288,8 +288,8 @@ static int decode_type19(rtcm_t *rtcm)
         }
         if ((index=obsindex(&rtcm->obs,time,sat))>=0) {
             rtcm->obs.data[index].P[freq]=pr*0.02;
-            rtcm->obs.data[index].code[freq]=
-                !freq?(code?CODE_L1P:CODE_L1C):(code?CODE_L2P:CODE_L2C);
+            int pcode=!freq?(code?CODE_L1P:CODE_L1C):(code?CODE_L2P:CODE_L2C);
+            rtcm->obs.data[index].code[freq]=pcode;
         }
     }
     rtcm->obsflag=!sync;

--- a/src/rtcm3.c
+++ b/src/rtcm3.c
@@ -2125,55 +2125,15 @@ static int decode_ssr7(rtcm_t *rtcm, int sys, int subtype)
     }
     return 20;
 }
-/* get signal index ----------------------------------------------------------*/
-static void sigindex(int sys, const uint8_t *code, int n, const char *opt,
-                     int *idx)
-{
-    int i,nex,pri,pri_h[8]={0},index[8]={0},ex[32]={0};
-    
-    /* test code priority */
-    for (i=0;i<n;i++) {
-        if (!code[i]) continue;
-        
-        if (idx[i]>=NFREQ) { /* save as extended signal if idx >= NFREQ */
-            ex[i]=1;
-            continue;
-        }
-        /* code priority */
-        pri=getcodepri(sys,code[i],opt);
-        
-        /* select highest priority signal */
-        if (pri>pri_h[idx[i]]) {
-            if (index[idx[i]]) ex[index[idx[i]]-1]=1;
-            pri_h[idx[i]]=pri;
-            index[idx[i]]=i+1;
-        }
-        else ex[i]=1;
-    }
-    /* signal index in obs data */
-    for (i=nex=0;i<n;i++) {
-        if (ex[i]==0) ;
-        else if (nex<NEXOBS) idx[i]=NFREQ+nex++;
-        else { /* no space in obs data */
-            trace(2,"rtcm msm: no space in obs data sys=%d code=%d\n",sys,code[i]);
-            idx[i]=-1;
-        }
-#if 0 /* for debug */
-        trace(2,"sig pos: sys=%d code=%d ex=%d idx=%d\n",sys,code[i],ex[i],idx[i]);
-#endif
-    }
-}
 /* save obs data in MSM message ----------------------------------------------*/
 static void save_msm_obs(rtcm_t *rtcm, int sys, msm_h_t *h, const double *r,
                          const double *pr, const double *cp, const double *rr,
                          const double *rrf, const double *cnr, const int *lti, int locktype,
                          const int *ex, const int *half)
 {
-    const char *sig[32];
     double tt,freq;
-    uint8_t code[32];
     char *msm_type="",*q=NULL;
-    int i,j,k,type,prn,sat,fcn,index=0,idx[32];
+    int i,j,k,type,prn,sat,fcn,index=0;
     
     type=getbitu(rtcm->buff,24,12);
     
@@ -2187,6 +2147,9 @@ static void save_msm_obs(rtcm_t *rtcm, int sys, msm_h_t *h, const double *r,
         case SYS_IRN: msm_type=q=rtcm->msmtype[6]; break;
     }
     /* id to signal */
+    const char *sig[32];
+    int code[32];
+    int idx[32], pri[32];
     for (i=0;i<h->nsig;i++) {
         switch (sys) {
             case SYS_GPS: sig[i]=msm_sig_gps[h->sigs[i]-1]; break;
@@ -2201,7 +2164,8 @@ static void save_msm_obs(rtcm_t *rtcm, int sys, msm_h_t *h, const double *r,
         /* signal to rinex obs type */
         code[i]=obs2code(sig[i]);
         idx[i]=code2idx(sys,code[i]);
-        
+        pri[i] = getcodepri(sys, code[i], rtcm->opt);
+
         if (code[i]!=CODE_NONE) {
             if (q) q+=sprintf(q,"L%s%s",sig[i],i<h->nsig-1?",":"");
         }
@@ -2212,9 +2176,6 @@ static void save_msm_obs(rtcm_t *rtcm, int sys, msm_h_t *h, const double *r,
         }
     }
     trace(3,"rtcm3 %d: signals=%s\n",type,msm_type);
-    
-    /* get signal index */
-    sigindex(sys,code,h->nsig,rtcm->opt,idx);
     
     for (i=j=0;i<h->nsat;i++) {
         
@@ -2246,29 +2207,41 @@ static void save_msm_obs(rtcm_t *rtcm, int sys, msm_h_t *h, const double *r,
                 fcn=rtcm->nav.glo_fcn[prn-1]-8;
             }
         }
+
+        // Resolve signal frequency index, per satellite as the signal set can change
+        int sigidx[32];
+        for (int k = 0; k < h->nsig; k++) {
+          if (!h->cellmask[k + i * h->nsig])
+            sigidx[k] = -1;
+          else
+            sigidx[k] = idx[k];
+        }
+        sigindex(h->nsig, code, pri, sigidx);
+
         for (k=0;k<h->nsig;k++) {
             if (!h->cellmask[k+i*h->nsig]) continue;
             
-            if (sat&&index>=0&&idx[k]>=0) {
+            int freqidx = sigidx[k];
+            if (sat && index >= 0 && freqidx >= 0) {
                 freq=fcn<-7?0.0:code2freq(sys,code[k],fcn);
                 
                 /* pseudorange (m) */
                 if (r[i]!=0.0&&pr[j]>-1E12) {
-                    rtcm->obs.data[index].P[idx[k]]=r[i]+pr[j];
+                    rtcm->obs.data[index].P[freqidx]=r[i]+pr[j];
                 }
                 /* carrier-phase (cycle) */
                 if (r[i]!=0.0&&cp[j]>-1E12) {
-                    rtcm->obs.data[index].L[idx[k]]=(r[i]+cp[j])*freq/CLIGHT;
+                    rtcm->obs.data[index].L[freqidx]=(r[i]+cp[j])*freq/CLIGHT;
                 }
                 /* doppler (hz) */
                 if (rr&&rrf&&rrf[j]>-1E12) {
-                    rtcm->obs.data[index].D[idx[k]]=-(rr[i]+rrf[j])*freq/CLIGHT;
+                    rtcm->obs.data[index].D[freqidx]=-(rr[i]+rrf[j])*freq/CLIGHT;
                 }
-                int LLI = lossoflock(rtcm, sat, code[k], idx[k], lti[j], locktype, half[j], rtcm->obs.data[index].L[idx[k]]);
+                int LLI = lossoflock(rtcm, sat, code[k], freqidx, lti[j], locktype, half[j], rtcm->obs.data[index].L[freqidx]);
                 if (r[i] != 0.0 && cp[j] > -1E12 && half[j]) LLI |= LLI_HALFC;
-                rtcm->obs.data[index].LLI[idx[k]]=LLI;
-                rtcm->obs.data[index].SNR [idx[k]]=(uint16_t)(cnr[j]/SNR_UNIT+0.5);
-                rtcm->obs.data[index].code[idx[k]]=code[k];
+                rtcm->obs.data[index].LLI[freqidx]=LLI;
+                rtcm->obs.data[index].SNR [freqidx]=(uint16_t)(cnr[j]/SNR_UNIT+0.5);
+                rtcm->obs.data[index].code[freqidx]=code[k];
             }
             j++;
         }

--- a/src/rtcm3e.c
+++ b/src/rtcm3e.c
@@ -1995,12 +1995,13 @@ static void gen_msm_sig(rtcm_t *rtcm, int sys, int nsat, int nsig, int ncell,
         if (!(sat=to_satid(sys,data->sat))) continue;
         
         for (j=0;j<NFREQ+NEXOBS;j++) {
-            if (!(sig=to_sigid(sys,data->code[j]))) continue;
+            int code = data->code[j];
+            if (!(sig=to_sigid(sys,code))) continue;
             
             k=sat_ind[sat-1]-1;
             if ((cell=cell_ind[sig_ind[sig-1]-1+k*nsig])>=64) continue;
             
-            freq=code2freq(sys,data->code[j],fcn-7);
+            freq=code2freq(sys,code,fcn-7);
             lambda=freq==0.0?0.0:CLIGHT/freq;
             psrng_s=data->P[j]==0.0?0.0:data->P[j]-rrng[k];
             phrng_s=data->L[j]==0.0||lambda<=0.0?0.0: data->L[j]*lambda-rrng [k];
@@ -2008,13 +2009,13 @@ static void gen_msm_sig(rtcm_t *rtcm, int sys, int nsat, int nsig, int ncell,
             
             /* subtract phase - psudorange integer cycle offset */
             LLI=data->LLI[j];
-            if ((LLI&1)||fabs(phrng_s-rtcm->cp[data->sat-1][j])>1171.0) {
-                rtcm->cp[data->sat-1][j]=ROUND(phrng_s/lambda)*lambda;
+            if ((LLI&1)||fabs(phrng_s-rtcm->cp[data->sat-1][code])>1171.0) {
+                rtcm->cp[data->sat-1][code]=ROUND(phrng_s/lambda)*lambda;
                 LLI|=1;
             }
-            phrng_s-=rtcm->cp[data->sat-1][j];
+            phrng_s-=rtcm->cp[data->sat-1][code];
             
-            lt=locktime_d(data->time,rtcm->lltime[data->sat-1]+j,LLI);
+            lt=locktime_d(data->time,rtcm->lltime[data->sat-1]+code,LLI);
             
             if (psrng&&psrng_s!=0.0) psrng[cell-1]=psrng_s;
             if (phrng&&phrng_s!=0.0) phrng[cell-1]=phrng_s;

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1383,6 +1383,7 @@ EXPORT int  testsnr(int base, int freq, double el, double snr,
                     const snrmask_t *mask);
 EXPORT void setcodepri(int sys, int idx, const char *pri);
 EXPORT int  getcodepri(int sys, uint8_t code, const char *opt);
+EXPORT void sigindex(int n, const int *code, const int *pri, int *idx);
 
 /* matrix and vector functions -----------------------------------------------*/
 EXPORT double *mat  (int n, int m);

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -954,10 +954,10 @@ typedef struct {        /* RTCM control struct type */
     int obsflag;        /* obs data complete flag (1:ok,0:not complete) */
     int ephsat;         /* input ephemeris satellite number */
     int ephset;         /* input ephemeris set (0-1) */
-    double cp[MAXSAT][NFREQ+NEXOBS]; /* carrier-phase measurement */
-    uint16_t lock[MAXSAT][NFREQ+NEXOBS]; /* lock time */
-    uint16_t loss[MAXSAT][NFREQ+NEXOBS]; /* loss of lock count */
-    gtime_t lltime[MAXSAT][NFREQ+NEXOBS]; /* last lock time */
+    double cp[MAXSAT][MAXCODE]; /* carrier-phase measurement */
+    uint16_t lock[MAXSAT][MAXCODE]; /* lock time */
+    uint16_t loss[MAXSAT][MAXCODE]; /* loss of lock count */
+    gtime_t lltime[MAXSAT][MAXCODE]; /* last lock time */
     int nbyte;          /* number of bytes in message buffer */
     int nbit;           /* number of bits in word buffer */
     int len;            /* message length (bytes) */
@@ -1205,7 +1205,7 @@ typedef struct {        /* RTK control/result type */
 
 typedef struct {        /* receiver raw data control type */
     gtime_t time;       /* message time */
-    gtime_t tobs[MAXSAT][NFREQ+NEXOBS]; /* observation data time */
+    gtime_t tobs[MAXSAT][MAXCODE]; /* observation data time */
     obs_t obs;          /* observation data */
     obs_t obuf;         /* observation data buffer */
     nav_t nav;          /* satellite ephemerides */
@@ -1215,11 +1215,11 @@ typedef struct {        /* receiver raw data control type */
     sbsmsg_t sbsmsg;    /* SBAS message */
     char msgtype[256];  /* last message type */
     uint8_t subfrm[MAXSAT][380]; /* subframe buffer */
-    double lockt[MAXSAT][NFREQ+NEXOBS]; /* lock time (s) */
-    unsigned char lockflag[MAXSAT][NFREQ+NEXOBS]; /* used for carrying forward cycle slip */
+    double lockt[MAXSAT][MAXCODE]; /* lock time (s) */
+    unsigned char lockflag[MAXSAT][MAXCODE]; /* used for carrying forward cycle slip */
     double icpp[MAXSAT],off[MAXSAT],icpc; /* carrier params for ss2 */
     double prCA[MAXSAT],dpCA[MAXSAT]; /* L1/CA pseudorange/doppler for javad */
-    uint8_t halfc[MAXSAT][NFREQ+NEXOBS]; /* half-cycle resolved */
+    uint8_t halfc[MAXSAT][MAXCODE]; /* half-cycle resolved */
     char freqn[MAXOBS]; /* frequency number for javad */
     int nbyte;          /* number of bytes in message buffer */
     int len;            /* message length (bytes) */

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -955,8 +955,10 @@ typedef struct {        /* RTCM control struct type */
     int ephsat;         /* input ephemeris satellite number */
     int ephset;         /* input ephemeris set (0-1) */
     double cp[MAXSAT][MAXCODE]; /* carrier-phase measurement */
-    uint16_t lock[MAXSAT][MAXCODE]; /* lock time */
+    uint16_t lti[MAXSAT][MAXCODE]; /* lock time indicator */
     uint16_t loss[MAXSAT][MAXCODE]; /* loss of lock count */
+    gtime_t tobs[MAXSAT][MAXCODE];  /* Observation data time */
+    gtime_t stime;      /* Time of first epoch, for slip detection */
     gtime_t lltime[MAXSAT][MAXCODE]; /* last lock time */
     int nbyte;          /* number of bytes in message buffer */
     int nbit;           /* number of bits in word buffer */


### PR DESCRIPTION
There are multiple functions for resolving conflicting frequency indices. This proposes to add a common function sigindex() and uses it for RINEX and RTCM, and for a start the Unicore raw decoder (which seems a wip anyway). I have a wip change for septentrio too which works fine, but that needs other work. So now the same frequency index allocation can occur for data coming from a raw stream, as for a RTCM stream, and as for data converted to RINEX and reload - where this was not always the case before which was just a frustration. Also now these all use the same code priority options.

Some of the code paths were making static decisions or decisions applied to a larger set of observations, so not dynamic for each satellite observation. This proposal applies the resolution to each observation, so it can pack in an available signal for a frequency slot where that might not have occurred before. Now a signal for one satellite is not bumped into the extra-obs region just because another satellite has a higher priority signal for that frequency.

Limited testing on Unicore, as the only dataset found had just one epoch, but it did appear to improve the result with more signals reported. Could use some help with testing there, some more data sets. Did fix the std dev. too there; the prior patch was storing them to the wrong destination. Btw the Unicore converter found does not even appear to decode the Unicore format, just the novatel messages, and the signal mapping is still questionable? Do they even have a RINEX converter for their own format? If it were possible could an RTCM3 MSM7 stream be logged at the same time as a Unicore raw stream, so we can check for consistency.