### PR TITLE
rtcm3: further sync with PocketSDR

### DIFF
--- a/src/rtcm3.c
+++ b/src/rtcm3.c
@@ -81,49 +81,49 @@ typedef struct {                    /* multi-signal-message header type */
 
 /* MSM signal ID table -------------------------------------------------------*/
 const char *msm_sig_gps[32] = {
-    /* GPS: ref [17] table 3.5-91 */
+    // GPS: ref [17] table 3.5-91.
     "", "1C", "1P", "1W", "",   "",   "",   "2C", "2P", "2W", "",   "",    //  1-12
     "", "",   "2S", "2L", "2X", "",   "",   "",   "",   "5I", "5Q", "5X",  // 13-24
     "", "",   "",   "",   "",   "1S", "1L", "1X"                           // 25-32
 };
 const char *msm_sig_glo[32] = {
-    /* GLONASS: ref [17] table 3.5-96 */
-#if 1 // Compatible with BNC, TODO resolve this difference
-    "",   "1C", "1P", "",   "",   "",   "", "2C", "2P", "4A", "4B", "4X",  //  1-12
-    "6A", "6B", "6X", "3I", "3Q", "3X", "", "",   "",   "",   "",   "",    // 13-24
-    "",   "",   "",   "",   "",   "",   "", ""};                           // 25-32
-#else // From PocketSDR 
+    // GLONASS: ref [17] table 3.5-96.
+    // 3I, 3Q, 3X, 4A, 4B, 4X, 6A, 6B, 6X are tentative from the
+    // PocketSDR extensions
     "", "1C", "1P", "",   "", "",   "",   "2C", "2P", "",   "",   "",    //  1-12
     "", "3I", "3Q", "3X", "", "4A", "4B", "4X", "",   "6A", "6B", "6X",  // 13-24
     "", "",   "",   "",   "", "",   "",   ""};                           // 25-32
-#endif
 const char *msm_sig_gal[32] = {
-    /* Galileo: ref [17] table 3.5-99 */
+    // Galileo: ref [17] table 3.5-99.
+    // 6D, 6P, 6Z, 7P, 7Z, 8D, 8P, 8X are tentative from the PocketSDR extensions
     "", "1C", "1A", "1B", "1X", "1Z", "",   "6C", "6A", "6B", "6X", "6Z",  //  1-12
     "", "7I", "7Q", "7X", "",   "8I", "8Q", "8X", "",   "5I", "5Q", "5X",  // 13-24
     "", "",   "",   "",   "",   "",   "",   ""};                           // 25-32
 const char *msm_sig_qzs[32] = {
-    /* QZSS: ref [17] table 3.5-105 */
-    "", "1C", "",   "",   "",   "",   "",   "",  "6S", "6L", "6X", "",    //  1-12
-    "", "",   "2S", "2L", "2X", "",   "",   "",  "",   "5I", "5Q", "5X",  // 13-24
-    "", "",   "",   "",   "",   "1S", "1L", "1X"};                        // 25-32
+    // QZSS: ref [17] table 3.5-105.
+    // 1E, 1Z, 1B, 6E, 6Z, 5D, 5P, 5Z are tentative from the PocketSDR extensions
+    "",   "1C", "",   "",   "1E", "1Z", "1B", "",  "6S", "6L", "6X", "6E",  //  1-12
+    "6Z", "",   "2S", "2L", "2X", "",   "",   "",  "",   "5I", "5Q", "5X",  // 13-24
+    "5D", "5P", "5Z", "",   "",   "1S", "1L", "1X"};                        // 25-32
 const char *msm_sig_sbs[32] = {
-    /* SBAS: ref [17] table 3.5-102 */
+    // SBAS: ref [17] table 3.5-102.
     "", "1C", "", "", "", "", "", "", "", "",   "",   "",    //  1-12
     "", "",   "", "", "", "", "", "", "", "5I", "5Q", "5X",  // 13-24
     "", "",   "", "", "", "", "", ""};                       // 25-32
 const char *msm_sig_cmp[32] = {
-    /* BeiDou: ref [17] table 3.5-108 */
-    // 7P and 7Z are from the PocketSDR extensions
-    "",   "2I", "2Q", "2X", "", "",   "",   "6I", "6Q", "6X", "",   "",    //  1-12
-    "",   "7I", "7Q", "7X", "", "",   "",   "",   "",   "5D", "5P", "5X",  // 13-24
+    // BeiDou: ref [17] table 3.5-108.
+    // 6D, 6P, 6Z, 7P, 7Z, 8D, 8P, 8X are tentative from the PocketSDR extensions
+    "",   "2I", "2Q", "2X", "", "",   "",   "6I", "6Q", "6X", "6D", "6P",  //  1-12
+    "6Z", "7I", "7Q", "7X", "", "8D", "8P", "8X", "",   "5D", "5P", "5X",  // 13-24
     "7D", "7P", "7Z", "",   "", "1D", "1P", "1X"};                         // 25-32
 const char *msm_sig_irn[32] = {
-    /* NavIC/IRNSS: ref [17] table 3.5-108.3 */
-    // 1D, 1P, 1X, 9B, 9C, 9X, 5B, 5C, and 5X are from the PocketSDR extensions
+    // NavIC/IRNSS: ref [17] table 3.5-108.3.
+    // 1D, 1P, 1X, 9B, 9C, 9X, 5B, 5C, and 5X are tentative from the
+    // PocketSDR extensions
     "",   "1D", "1P", "1X", "", "", "", "9A", "9B", "9C", "9X", "",    //  1-12
     "",   "",   "",   "",   "", "", "", "",   "",   "5A", "5B", "5C",  // 13-24
     "5X", "",   "",   "",   "", "", "", ""};                           // 25-32
+
 /* SSR signal and tracking mode IDs ------------------------------------------*/
 const uint8_t ssr_sig_gps[32]={
     CODE_L1C,CODE_L1P,CODE_L1W,CODE_L1S,CODE_L1L,CODE_L2C,CODE_L2D,CODE_L2S,


### PR DESCRIPTION
Received some clarification on the GLONASS signals https://github.com/tomojitakasu/PocketSDR/issues/28 and seems these are tentative, so propose following PocketSDR. Also adding more tentative signals for BeiDou from PocketSDR which but not yet the duplicate allocations for 1D 1P 1X https://github.com/tomojitakasu/PocketSDR/issues/29

The GLONASS signals extensions are apparently tentative, so adopt the PocketSDR tentative assignments.

Try to clarify the tentative signal assignments in comments.

Add tentative signal assignments for BeiDou 6D, 6P, 6Z, 8D, 8P, 8X from PocketSDR, missed.

Add tentative signal assignments for QZSS 1E, 1Z, 1B, 6E, 6Z, 5D, 5P, 5Z from PocketSDR, missed.