### PR TITLE
convmain: misc cleanup constant use

### DIFF
--- a/app/qtapp/rtkconv_qt/convmain.cpp
+++ b/app/qtapp/rtkconv_qt/convmain.cpp
@@ -901,7 +901,11 @@ void MainWindow::convertFile()
     conversionThread->rnxopt.freqtype = convOptDialog->frequencyType;
     for (i = 0; i < 2; i++)
         rnxcomment(&conversionThread->rnxopt, "%s", qPrintable(convOptDialog->comment[i]));
-    for (i = 0; i < 7; i++) strncpy(conversionThread->rnxopt.mask[i], qPrintable(convOptDialog->codeMask[i]), 63);
+    for (i = 0; i < RNX_NUMSYS; i++) {
+        /* strncpy is appropriate here, the elements are accessed randomly */
+        strncpy(conversionThread->rnxopt.mask[i], qPrintable(convOptDialog->codeMask[i]), sizeof(conversionThread->rnxopt.mask[i]));
+        conversionThread->rnxopt.mask[i][MAXCODE] = '\0';
+    }
     conversionThread->rnxopt.autopos = convOptDialog->autoPosition;
     conversionThread->rnxopt.phshift = convOptDialog->phaseShift;
     conversionThread->rnxopt.halfcyc = convOptDialog->halfCycle;

--- a/app/winapp/rtkconv/convmain.cpp
+++ b/app/winapp/rtkconv/convmain.cpp
@@ -954,8 +954,7 @@ void __fastcall TMainWindow::ConvertFile(void)
 	rnxopt.obstype=ObsType;
 	rnxopt.freqtype=FreqType;
 	for (i=0;i<2;i++) rnxcomment(&rnxopt, "%s", Comment[i].c_str());
-	for (i=0;i<7;i++) strcpy(rnxopt.mask[i],CodeMask[i].c_str());
-        for (i=0;i<7;i++) {
+        for (i=0;i<RNX_NUMSYS;i++) {
             /* strncpy is appropriate here, the elements are accessed randomly */
             strncpy(rnxopt.mask[i],CodeMask[i].c_str(),sizeof(rnxopt.mask[i]));
             rnxopt.mask[i][MAXCODE]='\0';


### PR DESCRIPTION
Looks like merge issues. Need to correct the mask length to cover all the codes. Redundant copy on win app. Avoid some more baked in constants.