### PR TITLE
postpos: avoid over allocation in ifile[]

### DIFF
--- a/src/postpos.c
+++ b/src/postpos.c
@@ -1404,7 +1404,7 @@ extern int postpos(gtime_t ts, gtime_t te, double ti, double tu,
             closeses(&navs,&pcvss,&pcvsr);
             return 0;
         }
-        for (i=0;i<MAXINFILE;i++) {
+        for (i=0;i<n&&i<MAXINFILE;i++) {
             if (!(ifile[i]=(char *)malloc(1024))) {
                 for (;i>=0;i--) free(ifile[i]);
                 closeses(&navs,&pcvss,&pcvsr);


### PR DESCRIPTION
In the case of both a start and end time an over allocation to ifile[] was occurring, memory not free. Need only 'n' elements.