### PR TITLE
code2freq: separate BDS B1 and B1C which have different freq

### DIFF
--- a/app/consapp/convbin/convbin.c
+++ b/app/consapp/convbin/convbin.c
@@ -602,7 +602,8 @@ static int cmdopts(int argc, char **argv, rnxopt_t *opt, char **ifile,
     if (nf>=3) opt->freqtype|=FREQTYPE_L3;
     if (nf>=4) opt->freqtype|=FREQTYPE_L4;
     if (nf>=5) opt->freqtype|=FREQTYPE_L5;
-    if (nf>=6) opt->freqtype|=FREQTYPE_ALL;
+    if (nf>=6) opt->freqtype|=FREQTYPE_L6;
+    if (nf>=7) opt->freqtype|=FREQTYPE_ALL;
     
     if (!opt->trtcm.time) {
         get_filetime(*ifile,&opt->trtcm);

--- a/app/qtapp/appcmn_qt/freqdlg.ui
+++ b/app/qtapp/appcmn_qt/freqdlg.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>601</width>
+    <width>700</width>
     <height>309</height>
    </rect>
   </property>
@@ -112,6 +112,11 @@
        <string>L5</string>
       </property>
      </column>
+     <column>
+      <property name="text">
+       <string>L6</string>
+      </property>
+     </column>
      <item row="0" column="0">
       <property name="text">
        <string>L1</string>
@@ -136,6 +141,14 @@
        <set>AlignCenter</set>
       </property>
      </item>
+     <item row="0" column="2">
+      <property name="text">
+       <string>L6</string>
+      </property>
+      <property name="textAlignment">
+       <set>AlignCenter</set>
+      </property>
+     </item>
      <item row="0" column="3">
       <property name="text">
        <string>-</string>
@@ -145,6 +158,14 @@
       </property>
      </item>
      <item row="0" column="4">
+      <property name="text">
+       <string>-</string>
+      </property>
+      <property name="textAlignment">
+       <set>AlignCenter</set>
+      </property>
+     </item>
+     <item row="0" column="5">
       <property name="text">
        <string>-</string>
       </property>
@@ -192,6 +213,14 @@
        <set>AlignCenter</set>
       </property>
      </item>
+     <item row="1" column="5">
+      <property name="text">
+       <string>-</string>
+      </property>
+      <property name="textAlignment">
+       <set>AlignCenter</set>
+      </property>
+     </item>
      <item row="2" column="0">
       <property name="text">
        <string>E1</string>
@@ -232,6 +261,14 @@
        <set>AlignCenter</set>
       </property>
      </item>
+     <item row="2" column="5">
+      <property name="text">
+       <string>-</string>
+      </property>
+      <property name="textAlignment">
+       <set>AlignCenter</set>
+      </property>
+     </item>
      <item row="3" column="0">
       <property name="text">
        <string>L1</string>
@@ -265,6 +302,14 @@
       </property>
      </item>
      <item row="3" column="4">
+      <property name="text">
+       <string>-</string>
+      </property>
+      <property name="textAlignment">
+       <set>AlignCenter</set>
+      </property>
+     </item>
+     <item row="3" column="5">
       <property name="text">
        <string>-</string>
       </property>
@@ -312,6 +357,14 @@
        <set>AlignCenter</set>
       </property>
      </item>
+     <item row="4" column="5">
+      <property name="text">
+       <string>-</string>
+      </property>
+      <property name="textAlignment">
+       <set>AlignCenter</set>
+      </property>
+     </item>
      <item row="5" column="0">
       <property name="text">
        <string>L1</string>
@@ -352,6 +405,14 @@
        <set>AlignCenter</set>
       </property>
      </item>
+     <item row="5" column="5">
+      <property name="text">
+       <string>-</string>
+      </property>
+      <property name="textAlignment">
+       <set>AlignCenter</set>
+      </property>
+     </item>
      <item row="6" column="0">
       <property name="text">
        <string>B1</string>
@@ -385,6 +446,14 @@
       </property>
      </item>
      <item row="6" column="4">
+      <property name="text">
+       <string>B1C / B1A</string>
+      </property>
+      <property name="textAlignment">
+       <set>AlignCenter</set>
+      </property>
+     </item>
+     <item row="6" column="5">
       <property name="text">
        <string>B2ab</string>
       </property>

--- a/app/qtapp/rtkconv_qt/codeopt.cpp
+++ b/app/qtapp/rtkconv_qt/codeopt.cpp
@@ -514,30 +514,30 @@ void CodeOptDialog::updateEnable()
     ui->S25->setEnabled((navSystem & SYS_SBS) && (frequencyType & FREQTYPE_L3));
     ui->S26->setEnabled((navSystem & SYS_SBS) && (frequencyType & FREQTYPE_L3));
 
-    ui->C02->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L1));
-    ui->C07->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L1));
-    ui->C08->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L1));
-    ui->C12->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L1));
-    ui->C13->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L1));
+    ui->C02->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L5));
+    ui->C07->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L5));
+    ui->C08->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L5));
+    ui->C12->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L5));
+    ui->C13->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L5));
     ui->C18->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L1));
     ui->C26->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L3));
     ui->C27->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L2));
     ui->C28->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L2));
     ui->C29->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L2));
     ui->C33->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L4));
-    ui->C39->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L5));
+    ui->C39->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L6));
     ui->C40->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L1));
     ui->C41->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L1));
     ui->C42->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L4));
     ui->C43->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L4));
-    ui->C56->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L1));
+    ui->C56->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L5));
     ui->C57->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L3));
     ui->C58->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L3));
     ui->C61->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L2));
     ui->C62->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L2));
     ui->C63->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L2));
-    ui->C64->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L5));
-    ui->C65->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L5));
+    ui->C64->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L6));
+    ui->C65->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L6));
     ui->C69->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L4));
     ui->C70->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L4));
     ui->C35->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L4));
@@ -555,7 +555,7 @@ void CodeOptDialog::updateEnable()
     ui->I12->setEnabled((navSystem & SYS_IRN) && (frequencyType & FREQTYPE_L3));
 
     if ((navSystem == (SYS_GPS | SYS_GAL | SYS_GLO | SYS_SBS | SYS_CMP | SYS_IRN | SYS_QZS)) &&
-        (frequencyType == (FREQTYPE_L1 | FREQTYPE_L2 | FREQTYPE_L3 | FREQTYPE_L4 | FREQTYPE_L5)))
+        (frequencyType == (FREQTYPE_L1 | FREQTYPE_L2 | FREQTYPE_L3 | FREQTYPE_L4 | FREQTYPE_L5 | FREQTYPE_L6)))
         ui->btnSetAll->setText(tr("Un&set All"));
 }
 //---------------------------------------------------------------------------

--- a/app/qtapp/rtkconv_qt/codeopt.cpp
+++ b/app/qtapp/rtkconv_qt/codeopt.cpp
@@ -107,8 +107,8 @@ void CodeOptDialog::setCodeMask(int i, const QString &mask)
         ui->S26->setChecked(mask[25] == '1');
     } else if (i == 5) { //BDS
         ui->C02->setChecked(mask[1] == '1');
+        ui->C07->setChecked(mask[6] == '1');
         ui->C08->setChecked(mask[7] == '1');
-        ui->C09->setChecked(mask[8] == '1');
         ui->C12->setChecked(mask[11] == '1');
         ui->C13->setChecked(mask[12] == '1');
         ui->C18->setChecked(mask[17] == '1');
@@ -240,8 +240,8 @@ QString CodeOptDialog::getCodeMask(int i)
         if (ui->S26->isChecked()) mask[25] = '1';
     } else if (i == 5) { // BDS
         if (ui->C02->isChecked()) mask[1] = '1';
+        if (ui->C07->isChecked()) mask[6] = '1';
         if (ui->C08->isChecked()) mask[7] = '1';
-        if (ui->C09->isChecked()) mask[8] = '1';
         if (ui->C12->isChecked()) mask[11] = '1';
         if (ui->C13->isChecked()) mask[12] = '1';
         if (ui->C18->isChecked()) mask[17] = '1';
@@ -372,8 +372,8 @@ void CodeOptDialog::setUnsetAll()
     ui->S26->setChecked(set);
 
     ui->C02->setChecked(set);
+    ui->C07->setChecked(set);
     ui->C08->setChecked(set);
-    ui->C09->setChecked(set);
     ui->C12->setChecked(set);
     ui->C13->setChecked(set);
     ui->C18->setChecked(set);
@@ -515,8 +515,8 @@ void CodeOptDialog::updateEnable()
     ui->S26->setEnabled((navSystem & SYS_SBS) && (frequencyType & FREQTYPE_L3));
 
     ui->C02->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L1));
+    ui->C07->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L1));
     ui->C08->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L1));
-    ui->C09->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L1));
     ui->C12->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L1));
     ui->C13->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L1));
     ui->C18->setEnabled((navSystem & SYS_CMP) && (frequencyType & FREQTYPE_L1));

--- a/app/qtapp/rtkconv_qt/codeopt.ui
+++ b/app/qtapp/rtkconv_qt/codeopt.ui
@@ -1617,7 +1617,7 @@
         </widget>
        </item>
        <item row="3" column="2">
-        <widget class="QCheckBox" name="C09">
+        <widget class="QCheckBox" name="C08">
          <property name="toolTip">
           <string>Pilot</string>
          </property>
@@ -1692,7 +1692,7 @@
         </widget>
        </item>
        <item row="3" column="1">
-        <widget class="QCheckBox" name="C08">
+        <widget class="QCheckBox" name="C07">
          <property name="toolTip">
           <string>Data</string>
          </property>

--- a/app/qtapp/rtkconv_qt/convopt.cpp
+++ b/app/qtapp/rtkconv_qt/convopt.cpp
@@ -94,6 +94,7 @@ void ConvOptDialog::updateUi()
     ui->cBFreq3->setChecked(frequencyType & FREQTYPE_L3);
     ui->cBFreq4->setChecked(frequencyType & FREQTYPE_L4);
     ui->cBFreq5->setChecked(frequencyType & FREQTYPE_L5);
+    ui->cBFreq6->setChecked(frequencyType & FREQTYPE_L6);
 
     ui->lEExcludedSatellites->setText(excludedSatellites);
     ui->cBTraceLevel->setCurrentIndex(traceLevel);
@@ -164,6 +165,7 @@ void ConvOptDialog::accept()
     if (ui->cBFreq3->isChecked()) frequencyType |= FREQTYPE_L3;
     if (ui->cBFreq4->isChecked()) frequencyType |= FREQTYPE_L4;
     if (ui->cBFreq5->isChecked()) frequencyType |= FREQTYPE_L5;
+    if (ui->cBFreq6->isChecked()) frequencyType |= FREQTYPE_L6;
 
     excludedSatellites = ui->lEExcludedSatellites->text();
     traceLevel = ui->cBTraceLevel->currentIndex();
@@ -198,6 +200,7 @@ void ConvOptDialog::showMaskDialog()
     if (ui->cBFreq3->isChecked()) frequencyType |= FREQTYPE_L3;
     if (ui->cBFreq4->isChecked()) frequencyType |= FREQTYPE_L4;
     if (ui->cBFreq5->isChecked()) frequencyType |= FREQTYPE_L5;
+    if (ui->cBFreq6->isChecked()) frequencyType |= FREQTYPE_L6;
 
     codeOptDialog->setFrequencyType(frequencyType);
 
@@ -230,6 +233,7 @@ void ConvOptDialog::updateEnable()
     ui->cBFreq3->setEnabled(ui->cBRinexVersion->currentIndex() >=1 );
     ui->cBFreq4->setEnabled(ui->cBRinexVersion->currentIndex() >=1 );
     ui->cBFreq5->setEnabled(ui->cBRinexVersion->currentIndex() >=1 );
+    ui->cBFreq6->setEnabled(ui->cBRinexVersion->currentIndex() >=1 );
     ui->cBPhaseShift->setEnabled(ui->cBRinexVersion->currentIndex() >=4 );
 }
 //---------------------------------------------------------------------------

--- a/app/qtapp/rtkconv_qt/convopt.ui
+++ b/app/qtapp/rtkconv_qt/convopt.ui
@@ -751,6 +751,13 @@
           </widget>
          </item>
          <item>
+          <widget class="QCheckBox" name="cBFreq6">
+           <property name="text">
+            <string>L6</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QPushButton" name="btnMask">
            <property name="toolTip">
             <string>Edit code mask</string>
@@ -943,6 +950,7 @@
   <tabstop>cBFreq3</tabstop>
   <tabstop>cBFreq4</tabstop>
   <tabstop>cBFreq5</tabstop>
+  <tabstop>cBFreq6</tabstop>
   <tabstop>btnMask</tabstop>
   <tabstop>btnFcn</tabstop>
   <tabstop>btnFrequencies</tabstop>

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -268,13 +268,13 @@ static char *obscodes[MAXCODE + 1]={       /* observation code strings */
 };
 static char codepris[7][MAXFREQ][16]={  /* code priority for each freq-index */
     /* L1/E1/B1 L2/E5b/B2b L5/E5a/B2a E6/LEX/B3 E5(a+b)         */
-    {"CPYWMNSLX","CPYWMNDLSX","IQX"    ,""       ,""       ,""}, /* GPS */
-    {"CPABX"   ,"CPABX"     ,"IQX"     ,""       ,""       ,""}, /* GLO */
-    {"CABXZ"   ,"XIQ"       ,"XIQ"     ,"ABCXZ"  ,"IQX"    ,""}, /* GAL */
-    {"CLSXZBE" ,"LSX"       ,"IQXDPZ"  ,"LSXEZ"  ,""       ,""}, /* QZS */
-    {"C"       ,"IQX"       ,""        ,""       ,""       ,""}, /* SBS */
-    {"IQXDPSLZAN","IQXDPZ"  ,"DPX"     ,"IQXDPZA" ,"DPX"    ,""}, /* BDS */
-    {"ABCX"    ,"ABCX"      ,"DPX"     ,""       ,""       ,""}  /* IRN */
+    {"CPYWMNSLX","CPYWMNDLSX","IQX"    ,""       ,""        ,""}, /* GPS */
+    {"CPABX"   ,"CPABX"     ,"IQX"     ,""       ,""        ,""}, /* GLO */
+    {"CABXZ"   ,"XIQ"       ,"XIQ"     ,"ABCXZ"  ,"IQX"     ,""}, /* GAL */
+    {"CLSXZBE" ,"LSX"       ,"IQXDPZ"  ,"LSXEZ"  ,""        ,""}, /* QZS */
+    {"C"       ,"IQX"       ,""        ,""       ,""        ,""}, /* SBS */
+    {"IQX"     ,"IQXDPZ"    ,"DPX"     ,"IQXDPZA","DPXSLZAN","DPX"}, /* BDS */
+    {"ABCX"    ,"ABCX"      ,"DPX"     ,""       ,""        ,""}  /* IRN */
 };
 static fatalfunc_t *fatalfunc=NULL; /* fatal callback function */
 
@@ -674,12 +674,12 @@ static int code2freq_BDS(uint8_t code, double *freq)
     char *obs=code2obs(code);
 
     switch (obs[0]) {
-        case '1': *freq=FREQL1;    return 0; /* B1C */
         case '2': *freq=FREQ1_CMP; return 0; /* B1I */
-        case '7': *freq=FREQ2_CMP; return 1; /* B2b */
+        case '7': *freq=FREQ2_CMP; return 1; /* B2,B2b */
         case '5': *freq=FREQL5;    return 2; /* B2a */
         case '6': *freq=FREQ3_CMP; return 3; /* B3 */
-        case '8': *freq=FREQE5ab;  return 4; /* B2ab */
+        case '1': *freq=FREQL1;    return 4; /* B1C,B1A */
+        case '8': *freq=FREQE5ab;  return 5; /* B2ab */
     }
     return -1;
 }
@@ -700,15 +700,15 @@ static int code2freq_IRN(uint8_t code, double *freq)
 * args   : int    sys       I   satellite system (SYS_???)
 *          uint8_t code     I   obs code (CODE_???)
 * return : frequency index (-1: error)
-*                       0     1     2     3     4
-*           --------------------------------------
-*            GPS       L1    L2    L5     -     -
-*            GLONASS   G1    G2    G3     -     -  (G1=G1,G1a,G2=G2,G2a)
-*            Galileo   E1    E5b   E5a   E6   E5ab
-*            QZSS      L1    L2    L5    L6     -
-*            SBAS      L1     -    L5     -     -
-*            BDS       B1    B2b   B2a   B3   B2ab
-*            NavIC     L5     S    L1     -     -
+*                       0     1     2     3     4     5
+*           ---------------------------------------------
+*            GPS       L1    L2    L5     -     -     -
+*            GLONASS   G1    G2    G3     -     -     -  (G1=G1,G1a,G2=G2,G2a)
+*            Galileo   E1    E5b   E5a   E6   E5ab    -
+*            QZSS      L1    L2    L5    L6     -     -
+*            SBAS      L1     -    L5     -     -     -
+*            BDS       B1    B2b   B2a   B3   B1C   B2ab
+*            NavIC     L5     S    L1     -     -     -
 *-----------------------------------------------------------------------------*/
 extern int code2idx(int sys, uint8_t code)
 {

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -289,12 +289,13 @@ extern "C" {
 #define OBSTYPE_SNR 0x08                /* observation type: SNR */
 #define OBSTYPE_ALL 0xFF                /* observation type: all */
 
-#define FREQTYPE_L1 0x01                /* frequency type: L1/E1/B1 */
-#define FREQTYPE_L2 0x02                /* frequency type: L2/E5b/B2 */
-#define FREQTYPE_L3 0x04                /* frequency type: L5/E5a/L3 */
-#define FREQTYPE_L4 0x08                /* frequency type: L6/E6/B3 */
-#define FREQTYPE_L5 0x10                /* frequency type: E5ab */
-#define FREQTYPE_ALL 0xFF               /* frequency type: all */
+#define FREQTYPE_L1 0x01                /* Frequency type: L1/G1/E1/B1 */
+#define FREQTYPE_L2 0x02                /* Frequency type: L2/G2/E5b/B2 */
+#define FREQTYPE_L3 0x04                /* Frequency type: L5/G3/E5a/B2a */
+#define FREQTYPE_L4 0x08                /* Frequency type: L6/E6/B3 */
+#define FREQTYPE_L5 0x10                /* Frequency type: E5ab/B1C/B1A */
+#define FREQTYPE_L6 0x20                /* Frequency type: B2ab */
+#define FREQTYPE_ALL 0xFF               /* Frequency type: all */
 
 #define CODE_NONE   0                   /* obs code: none or unknown */
 #define CODE_L1C    1                   /* obs code: L1C/A,G1C/A,E1C (GPS,GLO,GAL,QZS,SBS) */


### PR DESCRIPTION
B1 and B1C have different frequencies, B1 1561.098 MHz, B1C/B1A 1575.42 MHz. The frequency indices are assumed to represent different frequencies (with the exception of GLONASS where there are frequency deltas per satellite for some signals) and these signals are not going to mix in RTK solutions.

B1 (2I) is most common and is kept at index 0. B1C (1P) is less common and is moved to index 4, bumping the rare 8P signal to index 5.