### PR TITLE
options: expand to handle more than 3 frequency indices

### DIFF
--- a/app/qtapp/appcmn_qt/maskoptdlg.cpp
+++ b/app/qtapp/appcmn_qt/maskoptdlg.cpp
@@ -26,17 +26,20 @@ void MaskOptDialog::setSnrMask(snrmask_t mask)
     QDoubleSpinBox *widgets[][9] = {
         { ui->sBMask_1_1, ui->sBMask_1_2, ui->sBMask_1_3, ui->sBMask_1_4, ui->sBMask_1_5, ui->sBMask_1_6, ui->sBMask_1_7, ui->sBMask_1_8, ui->sBMask_1_9 },
         { ui->sBMask_2_1, ui->sBMask_2_2, ui->sBMask_2_3, ui->sBMask_2_4, ui->sBMask_2_5, ui->sBMask_2_6, ui->sBMask_2_7, ui->sBMask_2_8, ui->sBMask_2_9 },
-        { ui->sBMask_3_1, ui->sBMask_3_2, ui->sBMask_3_3, ui->sBMask_3_4, ui->sBMask_3_5, ui->sBMask_3_6, ui->sBMask_3_7, ui->sBMask_3_8, ui->sBMask_3_9 }
+        { ui->sBMask_3_1, ui->sBMask_3_2, ui->sBMask_3_3, ui->sBMask_3_4, ui->sBMask_3_5, ui->sBMask_3_6, ui->sBMask_3_7, ui->sBMask_3_8, ui->sBMask_3_9 },
+        { ui->sBMask_4_1, ui->sBMask_4_2, ui->sBMask_4_3, ui->sBMask_4_4, ui->sBMask_4_5, ui->sBMask_4_6, ui->sBMask_4_7, ui->sBMask_4_8, ui->sBMask_4_9 },
+        { ui->sBMask_5_1, ui->sBMask_5_2, ui->sBMask_5_3, ui->sBMask_5_4, ui->sBMask_5_5, ui->sBMask_5_6, ui->sBMask_5_7, ui->sBMask_5_8, ui->sBMask_5_9 },
+        { ui->sBMask_6_1, ui->sBMask_6_2, ui->sBMask_6_3, ui->sBMask_6_4, ui->sBMask_6_5, ui->sBMask_6_6, ui->sBMask_6_7, ui->sBMask_6_8, ui->sBMask_6_9 }
     };
     
     ui->cBMaskEnabled1->setChecked(mask.ena[0]);
     ui->cBMaskEnabled2->setChecked(mask.ena[1]);
 
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < 6; i++) {
         for (int j = 0; j < 9; j++) {
             widgets[i][j]->setValue(mask.mask[i][j]);
         }
-	}
+    }
     updateEnable();
 }
 //---------------------------------------------------------------------------
@@ -46,12 +49,15 @@ snrmask_t MaskOptDialog::getSnrMask()
     QDoubleSpinBox *widgets[][9] = {
         { ui->sBMask_1_1, ui->sBMask_1_2, ui->sBMask_1_3, ui->sBMask_1_4, ui->sBMask_1_5, ui->sBMask_1_6, ui->sBMask_1_7, ui->sBMask_1_8, ui->sBMask_1_9 },
         { ui->sBMask_2_1, ui->sBMask_2_2, ui->sBMask_2_3, ui->sBMask_2_4, ui->sBMask_2_5, ui->sBMask_2_6, ui->sBMask_2_7, ui->sBMask_2_8, ui->sBMask_2_9 },
-        { ui->sBMask_3_1, ui->sBMask_3_2, ui->sBMask_3_3, ui->sBMask_3_4, ui->sBMask_3_5, ui->sBMask_3_6, ui->sBMask_3_7, ui->sBMask_3_8, ui->sBMask_3_9 }
+        { ui->sBMask_3_1, ui->sBMask_3_2, ui->sBMask_3_3, ui->sBMask_3_4, ui->sBMask_3_5, ui->sBMask_3_6, ui->sBMask_3_7, ui->sBMask_3_8, ui->sBMask_3_9 },
+        { ui->sBMask_4_1, ui->sBMask_4_2, ui->sBMask_4_3, ui->sBMask_4_4, ui->sBMask_4_5, ui->sBMask_4_6, ui->sBMask_4_7, ui->sBMask_4_8, ui->sBMask_4_9 },
+        { ui->sBMask_5_1, ui->sBMask_5_2, ui->sBMask_5_3, ui->sBMask_5_4, ui->sBMask_5_5, ui->sBMask_5_6, ui->sBMask_5_7, ui->sBMask_5_8, ui->sBMask_5_9 },
+        { ui->sBMask_6_1, ui->sBMask_6_2, ui->sBMask_6_3, ui->sBMask_6_4, ui->sBMask_6_5, ui->sBMask_6_6, ui->sBMask_6_7, ui->sBMask_6_8, ui->sBMask_6_9 }
     };
     
     mask.ena[0] = ui->cBMaskEnabled1->isChecked();
     mask.ena[1] = ui->cBMaskEnabled2->isChecked();
-    for (int i = 0; i < 3; i++)
+    for (int i = 0; i < 6; i++)
         for (int j = 0; j < 9; j++)
             mask.mask[i][j] = widgets[i][j]->value();
 
@@ -63,10 +69,13 @@ void MaskOptDialog::updateEnable()
     QDoubleSpinBox *widgets[][9] = {
         { ui->sBMask_1_1, ui->sBMask_1_2, ui->sBMask_1_3, ui->sBMask_1_4, ui->sBMask_1_5, ui->sBMask_1_6, ui->sBMask_1_7, ui->sBMask_1_8, ui->sBMask_1_9 },
         { ui->sBMask_2_1, ui->sBMask_2_2, ui->sBMask_2_3, ui->sBMask_2_4, ui->sBMask_2_5, ui->sBMask_2_6, ui->sBMask_2_7, ui->sBMask_2_8, ui->sBMask_2_9 },
-        { ui->sBMask_3_1, ui->sBMask_3_2, ui->sBMask_3_3, ui->sBMask_3_4, ui->sBMask_3_5, ui->sBMask_3_6, ui->sBMask_3_7, ui->sBMask_3_8, ui->sBMask_3_9 }
+        { ui->sBMask_3_1, ui->sBMask_3_2, ui->sBMask_3_3, ui->sBMask_3_4, ui->sBMask_3_5, ui->sBMask_3_6, ui->sBMask_3_7, ui->sBMask_3_8, ui->sBMask_3_9 },
+        { ui->sBMask_4_1, ui->sBMask_4_2, ui->sBMask_4_3, ui->sBMask_4_4, ui->sBMask_4_5, ui->sBMask_4_6, ui->sBMask_4_7, ui->sBMask_4_8, ui->sBMask_4_9 },
+        { ui->sBMask_5_1, ui->sBMask_5_2, ui->sBMask_5_3, ui->sBMask_5_4, ui->sBMask_5_5, ui->sBMask_5_6, ui->sBMask_5_7, ui->sBMask_5_8, ui->sBMask_5_9 },
+        { ui->sBMask_6_1, ui->sBMask_6_2, ui->sBMask_6_3, ui->sBMask_6_4, ui->sBMask_6_5, ui->sBMask_6_6, ui->sBMask_6_7, ui->sBMask_6_8, ui->sBMask_6_9 }
 	};
 
-    for (int i = 0; i < 3; i++)
+    for (int i = 0; i < 6; i++)
         for (int j = 0; j < 9; j++)
             widgets[i][j]->setEnabled(ui->cBMaskEnabled1->isChecked() || ui->cBMaskEnabled2->isChecked());
 

--- a/app/qtapp/appcmn_qt/maskoptdlg.ui
+++ b/app/qtapp/appcmn_qt/maskoptdlg.ui
@@ -31,7 +31,7 @@
     </widget>
    </item>
    <item row="4" column="0">
-    <widget class="QLabel" name="labelL2">
+    <widget class="QLabel" name="labelF2">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
        <horstretch>0</horstretch>
@@ -39,7 +39,7 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>L2</string>
+      <string>F2</string>
      </property>
     </widget>
    </item>
@@ -618,7 +618,7 @@
     </widget>
    </item>
    <item row="5" column="0">
-    <widget class="QLabel" name="labelL3">
+    <widget class="QLabel" name="labelF3">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
        <horstretch>0</horstretch>
@@ -629,7 +629,7 @@
       <string/>
      </property>
      <property name="text">
-      <string>L3</string>
+      <string>F3</string>
      </property>
     </widget>
    </item>
@@ -650,7 +650,7 @@
     </widget>
    </item>
    <item row="3" column="0">
-    <widget class="QLabel" name="labelL1">
+    <widget class="QLabel" name="labelF1">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
        <horstretch>0</horstretch>
@@ -658,17 +658,502 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>L1</string>
+      <string>F1</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="10">
+
+   <item row="6" column="0">
+    <widget class="QLabel" name="labelF4">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>F4</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <widget class="QDoubleSpinBox" name="sBMask_4_1">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="2">
+    <widget class="QDoubleSpinBox" name="sBMask_4_2">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="3">
+    <widget class="QDoubleSpinBox" name="sBMask_4_3">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="4">
+    <widget class="QDoubleSpinBox" name="sBMask_4_4">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="5">
+    <widget class="QDoubleSpinBox" name="sBMask_4_5">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="6">
+    <widget class="QDoubleSpinBox" name="sBMask_4_6">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="7">
+    <widget class="QDoubleSpinBox" name="sBMask_4_7">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="8">
+    <widget class="QDoubleSpinBox" name="sBMask_4_8">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="9">
+    <widget class="QDoubleSpinBox" name="sBMask_4_9">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+
+   <item row="7" column="0">
+    <widget class="QLabel" name="labelF5">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>F5</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QDoubleSpinBox" name="sBMask_5_1">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="2">
+    <widget class="QDoubleSpinBox" name="sBMask_5_2">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="3">
+    <widget class="QDoubleSpinBox" name="sBMask_5_3">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="4">
+    <widget class="QDoubleSpinBox" name="sBMask_5_4">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="5">
+    <widget class="QDoubleSpinBox" name="sBMask_5_5">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="6">
+    <widget class="QDoubleSpinBox" name="sBMask_5_6">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="7">
+    <widget class="QDoubleSpinBox" name="sBMask_5_7">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="8">
+    <widget class="QDoubleSpinBox" name="sBMask_5_8">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="9">
+    <widget class="QDoubleSpinBox" name="sBMask_5_9">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+
+   <item row="8" column="0">
+    <widget class="QLabel" name="labelF6">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>F6</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <widget class="QDoubleSpinBox" name="sBMask_6_1">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="2">
+    <widget class="QDoubleSpinBox" name="sBMask_6_2">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="3">
+    <widget class="QDoubleSpinBox" name="sBMask_6_3">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="4">
+    <widget class="QDoubleSpinBox" name="sBMask_6_4">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="5">
+    <widget class="QDoubleSpinBox" name="sBMask_6_5">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="6">
+    <widget class="QDoubleSpinBox" name="sBMask_6_6">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="7">
+    <widget class="QDoubleSpinBox" name="sBMask_6_7">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="8">
+    <widget class="QDoubleSpinBox" name="sBMask_6_8">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="9">
+    <widget class="QDoubleSpinBox" name="sBMask_6_9">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text" stdset="0">
+      <string>0,00 dBHz</string>
+     </property>
+     <property name="suffix">
+      <string> dBHz</string>
+     </property>
+     <property name="maximum">
+      <double>90.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+
+   <item row="9" column="0" colspan="10">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
+
   </layout>
  </widget>
  <tabstops>
@@ -701,6 +1186,33 @@
   <tabstop>sBMask_3_7</tabstop>
   <tabstop>sBMask_3_8</tabstop>
   <tabstop>sBMask_3_9</tabstop>
+  <tabstop>sBMask_4_1</tabstop>
+  <tabstop>sBMask_4_2</tabstop>
+  <tabstop>sBMask_4_3</tabstop>
+  <tabstop>sBMask_4_4</tabstop>
+  <tabstop>sBMask_4_5</tabstop>
+  <tabstop>sBMask_4_6</tabstop>
+  <tabstop>sBMask_4_7</tabstop>
+  <tabstop>sBMask_4_8</tabstop>
+  <tabstop>sBMask_4_9</tabstop>
+  <tabstop>sBMask_5_1</tabstop>
+  <tabstop>sBMask_5_2</tabstop>
+  <tabstop>sBMask_5_3</tabstop>
+  <tabstop>sBMask_5_4</tabstop>
+  <tabstop>sBMask_5_5</tabstop>
+  <tabstop>sBMask_5_6</tabstop>
+  <tabstop>sBMask_5_7</tabstop>
+  <tabstop>sBMask_5_8</tabstop>
+  <tabstop>sBMask_5_9</tabstop>
+  <tabstop>sBMask_6_1</tabstop>
+  <tabstop>sBMask_6_2</tabstop>
+  <tabstop>sBMask_6_3</tabstop>
+  <tabstop>sBMask_6_4</tabstop>
+  <tabstop>sBMask_6_5</tabstop>
+  <tabstop>sBMask_6_6</tabstop>
+  <tabstop>sBMask_6_7</tabstop>
+  <tabstop>sBMask_6_8</tabstop>
+  <tabstop>sBMask_6_9</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/app/qtapp/appcmn_qt/navi_post_opt.cpp
+++ b/app/qtapp/appcmn_qt/navi_post_opt.cpp
@@ -685,6 +685,7 @@ void OptDialog::updateOptions()
     if (ui->cBNavSys7->isChecked()) processingOptions.navsys |= SYS_IRN;
     processingOptions.elmin = ui->cBElevationMask->currentText().toDouble() * D2R;
     // snrmask: already set by calling mask dialog
+    processingOptions.snrmask = snrmask;
     processingOptions.sateph = ui->cBSatelliteEphemeris->currentIndex();
     processingOptions.modear = ui->cBAmbiguityResolutionGPS->currentIndex();
     processingOptions.glomodear = ui->cBAmbiguityResolutionGLO->currentIndex();
@@ -712,7 +713,10 @@ void OptDialog::updateOptions()
 
     processingOptions.eratio[0] = ui->sBMeasurementErrorR1->value();
     processingOptions.eratio[1] = ui->sBMeasurementErrorR2->value();
-    processingOptions.eratio[2] = ui->sBMeasurementErrorR5->value();
+    processingOptions.eratio[2] = ui->sBMeasurementErrorR3->value();
+    processingOptions.eratio[3] = ui->sBMeasurementErrorR4->value();
+    processingOptions.eratio[4] = ui->sBMeasurementErrorR5->value();
+    processingOptions.eratio[5] = ui->sBMeasurementErrorR6->value();
     processingOptions.err[0] = 0;
     processingOptions.err[1] = ui->sBMeasurementError2->value();
     processingOptions.err[2] = ui->sBMeasurementError3->value();
@@ -958,7 +962,10 @@ void OptDialog::load(const QString &file)
     current_referencePositionType = ui->cBReferencePositionType->currentIndex();
     ui->sBMeasurementErrorR1->setValue(prcopt.eratio[0]);
     ui->sBMeasurementErrorR2->setValue(prcopt.eratio[1]);
-    ui->sBMeasurementErrorR5->setValue(prcopt.eratio[2]);
+    ui->sBMeasurementErrorR3->setValue(prcopt.eratio[2]);
+    ui->sBMeasurementErrorR4->setValue(prcopt.eratio[3]);
+    ui->sBMeasurementErrorR5->setValue(prcopt.eratio[4]);
+    ui->sBMeasurementErrorR6->setValue(prcopt.eratio[5]);
     ui->sBMeasurementError2->setValue(prcopt.err[1]);
     ui->sBMeasurementError3->setValue(prcopt.err[2]);
     ui->sBMeasurementError4->setValue(prcopt.err[3]);
@@ -1131,7 +1138,10 @@ void OptDialog::save(const QString &file)
     }
     procOpts.eratio[0] = ui->sBMeasurementErrorR1->value();
     procOpts.eratio[1] = ui->sBMeasurementErrorR2->value();
-    procOpts.eratio[2] = ui->sBMeasurementErrorR5->value();
+    procOpts.eratio[2] = ui->sBMeasurementErrorR3->value();
+    procOpts.eratio[3] = ui->sBMeasurementErrorR4->value();
+    procOpts.eratio[4] = ui->sBMeasurementErrorR5->value();
+    procOpts.eratio[5] = ui->sBMeasurementErrorR6->value();
     procOpts.err[0] = 0;
     procOpts.err[1] = ui->sBMeasurementError2->value();
     procOpts.err[2] = ui->sBMeasurementError3->value();
@@ -1304,7 +1314,10 @@ void OptDialog::saveOptions(QSettings &settings)
     }
     settings.setValue("prcopt/eratio0", ui->sBMeasurementErrorR1->value());
     settings.setValue("prcopt/eratio1", ui->sBMeasurementErrorR2->value());
-    settings.setValue("prcopt/eratio5", ui->sBMeasurementErrorR5->value());
+    settings.setValue("prcopt/eratio2", ui->sBMeasurementErrorR3->value());
+    settings.setValue("prcopt/eratio3", ui->sBMeasurementErrorR4->value());
+    settings.setValue("prcopt/eratio4", ui->sBMeasurementErrorR5->value());
+    settings.setValue("prcopt/eratio5", ui->sBMeasurementErrorR6->value());
     settings.setValue("prcopt/err1", ui->sBMeasurementError2->value());
     settings.setValue("prcopt/err2", ui->sBMeasurementError3->value());
     settings.setValue("prcopt/err3", ui->sBMeasurementError4->value());
@@ -1500,7 +1513,10 @@ void OptDialog::loadOptions(QSettings &settings)
     current_referencePositionType = settings.value("setting/refpostype", 0).toInt();
     ui->sBMeasurementErrorR1->setValue(settings.value("prcopt/eratio0", 100.0).toDouble());
     ui->sBMeasurementErrorR2->setValue(settings.value("prcopt/eratio1", 100.0).toDouble());
-    ui->sBMeasurementErrorR5->setValue(settings.value("prcopt/eratio5", 100.0).toDouble());
+    ui->sBMeasurementErrorR3->setValue(settings.value("prcopt/eratio2", 100.0).toDouble());
+    ui->sBMeasurementErrorR4->setValue(settings.value("prcopt/eratio3", 100.0).toDouble());
+    ui->sBMeasurementErrorR5->setValue(settings.value("prcopt/eratio4", 100.0).toDouble());
+    ui->sBMeasurementErrorR6->setValue(settings.value("prcopt/eratio5", 100.0).toDouble());
     ui->sBMeasurementError2->setValue(settings.value("prcopt/err1", 0.003).toDouble());
     ui->sBMeasurementError3->setValue(settings.value("prcopt/err2", 0.003).toDouble());
     ui->sBMeasurementError4->setValue(settings.value("prcopt/err3", 0.0).toDouble());

--- a/app/qtapp/appcmn_qt/navi_post_opt.ui
+++ b/app/qtapp/appcmn_qt/navi_post_opt.ui
@@ -1894,10 +1894,90 @@
             </property>
            </widget>
           </item>
+          <item row="1" column="1">
+           <widget class="QDoubleSpinBox" name="sBMeasurementErrorR1">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the ratio of standard deviations of pseudorange errors to carrier-phase errors for F1 (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-eratio1&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="decimals">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <double>10000.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>300.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QDoubleSpinBox" name="sBMeasurementErrorR2">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the ratio of standard deviations of pseudorange errors to carrier-phase errors for F2 (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-eratio2&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="decimals">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <double>10000.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>300.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="QDoubleSpinBox" name="sBMeasurementErrorR3">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the ratio of standard deviations of pseudorange errors to carrier-phase errors for F3 (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-eratio5&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="decimals">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <double>10000.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>100.000000000000000</double>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="4">
+           <widget class="QDoubleSpinBox" name="sBMeasurementErrorR4">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the ratio of standard deviations of pseudorange errors to carrier-phase errors for F4 (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-eratio6&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="decimals">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <double>10000.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>100.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="5">
            <widget class="QDoubleSpinBox" name="sBMeasurementErrorR5">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the ratio of standard deviations of pseudorange errors to carrier-phase errors for L5 (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-eratio5&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the ratio of standard deviations of pseudorange errors to carrier-phase errors for F5 (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-eratio7&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="decimals">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <double>10000.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>100.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="6">
+           <widget class="QDoubleSpinBox" name="sBMeasurementErrorR6">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the ratio of standard deviations of pseudorange errors to carrier-phase errors for F6 (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-eratio8&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="decimals">
              <number>1</number>
@@ -1933,38 +2013,6 @@
             </property>
             <property name="buddy">
              <cstring>sBMeasurementError4</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2" colspan="2">
-           <widget class="QDoubleSpinBox" name="sBMeasurementErrorR2">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the ratio of standard deviations of pseudorange errors to carrier-phase errors for L2 (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-eratio2&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="decimals">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <double>10000.000000000000000</double>
-            </property>
-            <property name="value">
-             <double>300.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QDoubleSpinBox" name="sBMeasurementErrorR1">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the ratio of standard deviations of pseudorange errors to carrier-phase errors for L1 (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-eratio1&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="decimals">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <double>10000.000000000000000</double>
-            </property>
-            <property name="value">
-             <double>300.000000000000000</double>
             </property>
            </widget>
           </item>
@@ -2041,7 +2089,7 @@
              <bool>true</bool>
             </property>
             <property name="text">
-             <string>Code/Carrier-Phase Error Ratio L1/L2/L5</string>
+             <string>Code/Carrier-Phase Error Ratios</string>
             </property>
             <property name="buddy">
              <cstring>sBMeasurementErrorR1</cstring>
@@ -3491,7 +3539,10 @@
   <tabstop>cBDebugTrace</tabstop>
   <tabstop>sBMeasurementErrorR1</tabstop>
   <tabstop>sBMeasurementErrorR2</tabstop>
+  <tabstop>sBMeasurementErrorR3</tabstop>
+  <tabstop>sBMeasurementErrorR4</tabstop>
   <tabstop>sBMeasurementErrorR5</tabstop>
+  <tabstop>sBMeasurementErrorR6</tabstop>
   <tabstop>sBMeasurementError2</tabstop>
   <tabstop>sBMeasurementError3</tabstop>
   <tabstop>sBMeasurementError4</tabstop>

--- a/app/qtapp/rtknavi_qt/mondlg.cpp
+++ b/app/qtapp/rtknavi_qt/mondlg.cpp
@@ -386,7 +386,7 @@ void MonitorDialog::setRtk()
     int width[] = {500, 500};
 
     ui->tWConsole->setColumnCount(2);
-    ui->tWConsole->setRowCount(52 + NFREQ*2);
+    ui->tWConsole->setRowCount(49 + NFREQ * 3);
     ui->tWConsole->setHorizontalHeaderLabels(header);
 
     for (int i = 0; (i < ui->tWConsole->columnCount()) && (i < 2); i++)
@@ -407,7 +407,7 @@ void MonitorDialog::showRtk()
     const QString sol[] = {tr("-"), tr("Fix"), tr("Float"), tr("SBAS"), tr("DGPS"), tr("Single"), tr("PPP"), tr("Dead Reckoning")};
     const QString mode[] = {tr("Single"), tr("DGPS"), tr("Kinematic"), tr("Static"), tr("Static-Start"), tr("Moving-Base"),
                             tr("Fixed"), tr("PPP-Kinematic"), tr("PPP-Static"), tr("PPP-Fixed")};
-    const QString freq[] = {tr("-"), tr("L1"), tr("L1+L2"), tr("L1+L2+L5"), tr("L1+L2+L5+L6"), tr("L1+L2+L5+L6+L7")};
+    const QString freq[] = {tr("-"), tr("L1"), tr("L1+L2"), tr("L1+L2+L5"), tr("L1+L2+L5+L6"), tr("L1+L2+L5+L6+L7"), tr("L1+L2+L5+L6+L7+L8"), tr("L1+L2+L5+L6+L7+L9")};
     double *del, *off, rt[3] = {0}, dop[4] = {0};
     double azel[MAXSAT * 2], pos[3], vel[3], rr[3] = {0}, enu[3] = {0};
     int row, j, k, cycle, state, rtkstat, nsat0, nsat1, prcout, nave;
@@ -471,7 +471,7 @@ void MonitorDialog::showRtk()
     if (rtk.opt.navsys & SYS_IRN) navsys = navsys + tr("NavIC ");
     if (rtk.opt.navsys & SYS_SBS) navsys = navsys + tr("SBAS ");
 
-    if (ui->tWConsole->rowCount() < 55) return;
+    if (ui->tWConsole->rowCount() < 49 + NFREQ * 3) return;
 
     row = 0;
 
@@ -488,31 +488,26 @@ void MonitorDialog::showRtk()
     ui->tWConsole->item(row++, 1)->setText(mode[rtk.opt.mode < 0 || rtk.opt.mode > 9 ? 0 : rtk.opt.mode ]);
 
     ui->tWConsole->item(row,   0)->setText(tr("Frequencies"));
-    ui->tWConsole->item(row++, 1)->setText(freq[rtk.opt.nf > 5 ? 0 : rtk.opt.nf]);
+    ui->tWConsole->item(row++, 1)->setText(freq[rtk.opt.nf > 7 ? 0 : rtk.opt.nf]);
 
     ui->tWConsole->item(row,   0)->setText(tr("Elevation Mask"));
     ui->tWConsole->item(row++, 1)->setText(QString::number(rtk.opt.elmin * R2D, 'f', 0) + " deg");
 
-    ui->tWConsole->item(row,   0)->setText(tr("SNR Mask L1 (dBHz)"));
-    ui->tWConsole->item(row++, 1)->setText(!rtk.opt.snrmask.ena[0] ? "" :
-                              QStringLiteral("%1, %2, %3, %4, %5, %6, %7, %8, %9")
-                              .arg(rtk.opt.snrmask.mask[0][0], 0).arg(rtk.opt.snrmask.mask[0][1], 0).arg(rtk.opt.snrmask.mask[0][2], 0)
-                              .arg(rtk.opt.snrmask.mask[0][3], 0).arg(rtk.opt.snrmask.mask[0][4], 0).arg(rtk.opt.snrmask.mask[0][5], 0)
-                              .arg(rtk.opt.snrmask.mask[0][6], 0).arg(rtk.opt.snrmask.mask[0][7], 0).arg(rtk.opt.snrmask.mask[0][8], 0));
-
-    ui->tWConsole->item(row,   0)->setText(tr("SNR Mask L2 (dBHz)"));
-    ui->tWConsole->item(row++, 1)->setText(!rtk.opt.snrmask.ena[0] ? "" :
-                              QStringLiteral("%1, %2, %3, %4, %5, %6, %7, %8, %9")
-                              .arg(rtk.opt.snrmask.mask[1][0], 0).arg(rtk.opt.snrmask.mask[1][1], 0).arg(rtk.opt.snrmask.mask[1][2], 0)
-                              .arg(rtk.opt.snrmask.mask[1][3], 0).arg(rtk.opt.snrmask.mask[1][4], 0).arg(rtk.opt.snrmask.mask[1][5], 0)
-                              .arg(rtk.opt.snrmask.mask[1][6], 0).arg(rtk.opt.snrmask.mask[1][7], 0).arg(rtk.opt.snrmask.mask[1][8], 0));
-
-    ui->tWConsole->item(row,   0)->setText(tr("SNR Mask L5 (dBHz)"));
-    ui->tWConsole->item(row++, 1)->setText(!rtk.opt.snrmask.ena[0] ? "" :
-                              QStringLiteral("%1, %2, %3, %4, %5, %6, %7, %8, %9")
-                              .arg(rtk.opt.snrmask.mask[2][0], 0).arg(rtk.opt.snrmask.mask[2][1], 0).arg(rtk.opt.snrmask.mask[2][2], 0)
-                              .arg(rtk.opt.snrmask.mask[2][3], 0).arg(rtk.opt.snrmask.mask[2][4], 0).arg(rtk.opt.snrmask.mask[2][5], 0)
-                              .arg(rtk.opt.snrmask.mask[2][6], 0).arg(rtk.opt.snrmask.mask[2][7], 0).arg(rtk.opt.snrmask.mask[2][8], 0));
+    for (int i = 0; i < NFREQ; i++) {
+      ui->tWConsole->item(row, 0)->setText(tr("SNR Mask F") + QString::number(i + 1) + tr(" (dBHz)"));
+      ui->tWConsole->item(row++, 1)->setText(!rtk.opt.snrmask.ena[0]
+                                               ? ""
+                                               : QStringLiteral("%1, %2, %3, %4, %5, %6, %7, %8, %9")
+                                                   .arg(rtk.opt.snrmask.mask[i][0], 0)
+                                                   .arg(rtk.opt.snrmask.mask[i][1], 0)
+                                                   .arg(rtk.opt.snrmask.mask[i][2], 0)
+                                                   .arg(rtk.opt.snrmask.mask[i][3], 0)
+                                                   .arg(rtk.opt.snrmask.mask[i][4], 0)
+                                                   .arg(rtk.opt.snrmask.mask[i][5], 0)
+                                                   .arg(rtk.opt.snrmask.mask[i][6], 0)
+                                                   .arg(rtk.opt.snrmask.mask[i][7], 0)
+                                                   .arg(rtk.opt.snrmask.mask[i][8], 0));
+    }
 
     ui->tWConsole->item(row,   0)->setText(tr("Rec Dynamic/Earth Tides Correction"));
     ui->tWConsole->item(row++, 1)->setText(QStringLiteral("%1, %2").arg(rtk.opt.dynamics ? tr("ON") : tr("OFF"), rtk.opt.tidecorr ? tr("ON") : tr("OFF")));

--- a/src/options.c
+++ b/src/options.c
@@ -38,12 +38,12 @@ static filopt_t filopt_;
 static double elmask_,elmaskar_,elmaskhold_;
 static double antpos_[2][3];
 static char exsats_[1024];
-static char snrmask_[NFREQ][1024];
+static char snrmask_[MAXFREQ][1024];
 
 /* system options table ------------------------------------------------------*/
 #define SWTOPT  "0:off,1:on"
 #define MODOPT  "0:single,1:dgps,2:kinematic,3:static,4:static-start,5:movingbase,6:fixed,7:ppp-kine,8:ppp-static,9:ppp-fixed"
-#define FRQOPT  "1:l1,2:l1+l2,3:l1+l2+l5,4:l1+l2+l5+l6"
+#define FRQOPT  "1:l1,2:l1+l2,3:l1+l2+l5,4:l1+l2+l5+l6,5:l1+l2+l5+l6+l7,6:l1+l2+l5+l6+l7+l8"
 #define TYPOPT  "0:forward,1:backward,2:combined,3:combined-nophasereset"
 #define IONOPT  "0:off,1:brdc,2:sbas,3:dual-freq,4:est-stec,5:ionex-tec,6:qzs-brdc"
 #define TRPOPT  "0:off,1:saas,2:sbas,3:est-ztd,4:est-ztdgrad"
@@ -74,6 +74,9 @@ EXPORT opt_t sysopts[]={
     {"pos1-snrmask_L1", 2,  (void *)snrmask_[0],         ""     },
     {"pos1-snrmask_L2", 2,  (void *)snrmask_[1],         ""     },
     {"pos1-snrmask_L5", 2,  (void *)snrmask_[2],         ""     },
+    {"pos1-snrmask_L6", 2,  (void *)snrmask_[3],         ""     },
+    {"pos1-snrmask_L7", 2,  (void *)snrmask_[4],         ""     },
+    {"pos1-snrmask_L8", 2,  (void *)snrmask_[5],         ""     },
     {"pos1-dynamics",   3,  (void *)&prcopt_.dynamics,   SWTOPT },
     {"pos1-tidecorr",   3,  (void *)&prcopt_.tidecorr,   TIDEOPT},
     {"pos1-ionoopt",    3,  (void *)&prcopt_.ionoopt,    IONOPT },
@@ -140,6 +143,9 @@ EXPORT opt_t sysopts[]={
     {"stats-eratio1",   1,  (void *)&prcopt_.eratio[0],  ""     },
     {"stats-eratio2",   1,  (void *)&prcopt_.eratio[1],  ""     },
     {"stats-eratio5",   1,  (void *)&prcopt_.eratio[2],  ""     },
+    {"stats-eratio6",   1,  (void *)&prcopt_.eratio[3],  ""     },
+    {"stats-eratio7",   1,  (void *)&prcopt_.eratio[4],  ""     },
+    {"stats-eratio8",   1,  (void *)&prcopt_.eratio[5],  ""     },
     {"stats-errphase",  1,  (void *)&prcopt_.err[1],     "m"    },
     {"stats-errphaseel",1,  (void *)&prcopt_.err[2],     "m"    },
     {"stats-errphasebl",1,  (void *)&prcopt_.err[3],     "m/10km"},
@@ -440,7 +446,7 @@ static void buff2sysopts(void)
         }
     }
     /* snrmask */
-    for (i=0;i<NFREQ;i++) {
+    for (i=0;i<MAXFREQ;i++) {
         for (j=0;j<9;j++) prcopt_.snrmask.mask[i][j]=0.0;
         strcpy(buff,snrmask_[i]);
         char *q;
@@ -495,7 +501,7 @@ static void sysopts2buff(void)
         }
     }
     /* snrmask */
-    for (i=0;i<NFREQ;i++) {
+    for (i=0;i<MAXFREQ;i++) {
         snrmask_[i][0]='\0';
         p=snrmask_[i];
         for (j=0;j<9;j++) {

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -210,7 +210,7 @@ const prcopt_t prcopt_default={ /* defaults processing options */
     1,1,1,1,0,                  /* armaxiter,estion,esttrop,dynamics,tidecorr */
     1,0,0,0,0,                  /* niter,codesmooth,intpref,sbascorr,sbassatsel */
     0,0,                        /* rovpos,refpos */
-    {300.0,300.0,300.0},        /* eratio[] */
+    {300.0,300.0,300.0,300.0,300.0,300.0}, /* eratio[] */
     {100.0,0.003,0.003,0.0,1.0,52.0,0.0,0.0}, /* err[-,base,el,bl,dop,snr_max,snr,rcverr] */
     {30.0,0.03,0.3},            /* std[] */
     {1E-4,1E-3,1E-4,1E-1,1E-2,0.0}, /* prn[] */

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -999,7 +999,7 @@ typedef struct {        /* option type */
 
 typedef struct {        /* SNR mask type */
     int ena[2];         /* enable flag {rover,base} */
-    double mask[NFREQ][9]; /* mask (dBHz) at 5,10,...85 deg */
+    double mask[MAXFREQ][9]; /* mask (dBHz) at 5,10,...85 deg */
 } snrmask_t;
 
 typedef struct {        /* processing options type */
@@ -1035,7 +1035,7 @@ typedef struct {        /* processing options type */
     int refpos;         /* base position for relative mode */
                         /* (0:pos in prcopt,  1:average of single pos, */
                         /*  2:read from file, 3:rinex header, 4:rtcm pos) */
-    double eratio[NFREQ]; /* code/phase error ratio */
+    double eratio[MAXFREQ]; /* code/phase error ratio */
     double err[8];      /* observation error terms */
                         /* [reserved,constant,elevation,baseline,doppler,snr-max,snr, rcv_std] */
     double std[3];      /* initial-state std [0]bias,[1]iono [2]trop */


### PR DESCRIPTION
These were the bare minimum option additions for more than 3 frequencies. The naming of these options does not seem great, the L6 and L7 and L8, but it's workable and something is needed. Without a SNR mask and eratio the extra signals are not really usable.

Give an option for pos1-frequency to be up to 6 frequency indices, adding values 5, and 6.

Expand the SNR masks to 6 frequency indices, up from 3, adding pos1-snrmask_L6, pos1-snrmask_L7, and pos1-snrmask_L8 (just to follow existing sequence).

Expand the eratio parameters to 6 frequency indices, up from 3, adding stats-eratio6, stats-eratio7, stats-eratio8 (just to follow existing sequence).