### PR TITLE
rtkpos outsolstat: increase stat output buffer

### DIFF
--- a/src/rtkpos.c
+++ b/src/rtkpos.c
@@ -356,7 +356,7 @@ static void outsolstat(rtk_t *rtk,const nav_t *nav)
     swapsolstat();
 
     /* write solution status */
-    char buff[2*MAXSOLMSG+1];
+    char buff[3*MAXSOLMSG+1];
     int n=rtkoutstat(rtk,statlevel,buff);
     buff[n]='\0';
     

--- a/src/rtksvr.c
+++ b/src/rtksvr.c
@@ -71,7 +71,7 @@ static void saveoutbuf(rtksvr_t *svr, uint8_t *buff, int n, int index)
 static void writesol(rtksvr_t *svr, int index)
 {
     solopt_t solopt=solopt_default;
-    uint8_t buff[2*MAXSOLMSG+1];
+    uint8_t buff[3*MAXSOLMSG+1];
     int i,n;
     
     tracet(4,"writesol: index=%d\n",index);
@@ -79,7 +79,6 @@ static void writesol(rtksvr_t *svr, int index)
     for (i=0;i<2;i++) {
         
         if (svr->solopt[i].posf==SOLF_STAT) {
-            
             /* output solution status */
             rtksvrlock(svr);
             n=rtkoutstat(&svr->rtk,svr->solopt[i].sstat,(char *)buff);


### PR DESCRIPTION
With more frequencies, the number of $SAT lines increases and the static buffer was overflowing.