### PR TITLE
rtkpos: detect code changes per frequency index

### DIFF
--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1161,6 +1161,7 @@ typedef struct {        /* satellite status type */
     uint16_t snr_rover [NFREQ]; /* rover signal strength (0.25 dBHz) */
     uint16_t snr_base  [NFREQ]; /* base signal strength (0.25 dBHz) */
     uint8_t fix [NFREQ]; /* ambiguity fix flag (1:float,2:fix,3:hold) */
+    int code[NFREQ][2];  // Current code per frequency index for the base and rover.
     uint8_t slip[NFREQ]; /* cycle-slip flag */
     uint8_t half[NFREQ]; /* half-cycle valid flag */
     int lock [NFREQ];   /* lock counter of phase */


### PR DESCRIPTION
This addresses an issue noted with https://github.com/rtklibexplorer/RTKLIB/pull/502 and should unblock that path.

The code is currently limited to one bias per satellite and pair of receiver signals. If one of these signals changes then flag a slip to have the bias reinitialized. Otherwise such changes can throw off the solution.

The expected observation code is initialized when first seen, and typically does not change, but the processing is now robust to signal changes. This initialization accepts different signals at the same frequency index across a system, but just one signal at a time for a particular satellite and receiver per frequency index.