### PR TITLE
rtkpos intpres: move static data to rtk_t

### DIFF
--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1201,6 +1201,8 @@ typedef struct {        /* RTK control/result type */
     prcopt_t opt;       /* processing options */
     int initial_mode;   /* initial positioning mode */
     int epoch;          /* epoch number */
+    int intpres_nb;     // Time interpolation of residuals, number of previous base observations.
+    obsd_t intpres_obsb[MAXOBS]; // Time interpolation of residuals, previous base observations.
 } rtk_t;
 
 typedef struct {        /* receiver raw data control type */


### PR DESCRIPTION
Static data is not thread safe. Use stack allocated data for all the scratch data, and move the remaining static data into the rtk_t structure. This also allows it to be reinitialized.

Should be not change to the function, this is just to move the data. Might avoid a startup glitch on restart now.
