### PR TITLE
pntpos: pass in the receiver index; and antpos fix

### DIFF
--- a/app/qtapp/rtkplot_qt/plotdata.cpp
+++ b/app/qtapp/rtkplot_qt/plotdata.cpp
@@ -1213,7 +1213,7 @@ void Plot::updateObservation(int nobs)
 
         if (plotOptDialog->getReceiverPosition() == 0) { // single point position
             opt.err[0] = 900.0;
-            pntpos(observation.data + i, j - i, &navigation, &opt, &sol, azel, NULL, msg);
+            pntpos(observation.data + i, j - i, &navigation, &opt, 0, &sol, azel, NULL, msg);
             matcpy(rr, sol.rr, 3, 1);
             ecef2pos(rr, pos);
         } else if (plotOptDialog->getReceiverPosition() == 1) { // lat/lon/height

--- a/app/winapp/rtkplot/plotdata.cpp
+++ b/app/winapp/rtkplot/plotdata.cpp
@@ -1223,7 +1223,7 @@ void __fastcall TPlot::UpdateObs(int nobs)
             char msg[128];
             
             opt.err[0]=900.0;
-            pntpos(Obs.data+i,j-i,&Nav,&opt,&sol,azel,NULL,msg);
+            pntpos(Obs.data+i,j-i,&Nav,&opt,0,&sol,azel,NULL,msg);
             matcpy(rr,sol.rr,3,1);
             ecef2pos(rr,pos);
         }

--- a/src/convrnx.c
+++ b/src/convrnx.c
@@ -1215,7 +1215,7 @@ static void setopt_apppos(strfile_t *str, rnxopt_t *opt)
     prcopt.navsys=opt->navsys;
     
     /* point positioning with last obs data */
-    if (!pntpos(str->obs->data,str->obs->n,str->nav,&prcopt,&sol,NULL,NULL,
+    if (!pntpos(str->obs->data,str->obs->n,str->nav,&prcopt,0,&sol,NULL,NULL,
                 msg)) {
         trace(2,"point position error (%s)\n",msg);
         return;

--- a/src/postpos.c
+++ b/src/postpos.c
@@ -783,7 +783,7 @@ static void freeobsnav(obs_t *obs, nav_t *nav)
     free(nav->seph); nav->seph=NULL; nav->ns=nav->nsmax=0;
 }
 /* average of single position ------------------------------------------------*/
-static int avepos(double *ra, int rcv, const obs_t *obs, const nav_t *nav,
+static int avepos(double *ra, int base, const obs_t *obs, const nav_t *nav,
                   const prcopt_t *opt)
 {
     obsd_t data[MAXOBS];
@@ -792,11 +792,11 @@ static int avepos(double *ra, int rcv, const obs_t *obs, const nav_t *nav,
     int i,j,n=0,m,iobs;
     char msg[128];
 
-    trace(3,"avepos: rcv=%d obs.n=%d\n",rcv,obs->n);
+    trace(3,"avepos: base=%d obs.n=%d\n",base,obs->n);
 
     for (i=0;i<3;i++) ra[i]=0.0;
 
-    for (iobs=0;(m=nextobsf(obs,&iobs,rcv))>0;iobs+=m) {
+    for (iobs=0;(m=nextobsf(obs,&iobs,base+1))>0;iobs+=m) {
 
         for (i=j=0;i<m&&i<MAXOBS;i++) {
             data[j]=obs->data[iobs+i];
@@ -805,7 +805,7 @@ static int avepos(double *ra, int rcv, const obs_t *obs, const nav_t *nav,
         }
         if (j<=0||!screent(data[0].time,ts,ts,1.0)) continue; /* only 1 hz */
 
-        if (!pntpos(data,j,nav,opt,&sol,NULL,NULL,msg)) continue;
+        if (!pntpos(data,j,nav,opt,base,&sol,NULL,NULL,msg)) continue;
 
         for (i=0;i<3;i++) ra[i]+=sol.rr[i];
         n++;
@@ -851,47 +851,50 @@ static int getstapos(const char *file, const char *name, double *r)
     trace(1,"no station position: %s %s\n",name,file);
     return 0;
 }
-/* antenna phase center position ---------------------------------------------*/
-static int antpos(prcopt_t *opt, int rcvno, const obs_t *obs, const nav_t *nav,
+// Antenna marker position --------------------------------------------------
+// The delta from the marker to the antenna ARP is in opt->antdel[] and this
+// comes from an antdel config option or from RINEX or RTCM station info.
+static int antpos(prcopt_t *opt, int base, const obs_t *obs, const nav_t *nav,
                   const sta_t *sta, const char *posfile)
 {
-    double *rr=rcvno==1?opt->ru:opt->rb,del[3],pos[3],dr[3]={0};
-    int i,postype=rcvno==1?opt->rovpos:opt->refpos;
-    char *name;
+    trace(3,"antpos  : base=%d\n",base);
 
-    trace(3,"antpos  : rcvno=%d\n",rcvno);
-
-    if (postype==POSOPT_SINGLE) { /* average of single position */
-        if (!avepos(rr,rcvno,obs,nav,opt)) {
+    double *rr=base==0?opt->ru:opt->rb;
+    int postype=base==0?opt->rovpos:opt->refpos;
+    if (postype==POSOPT_SINGLE) { // Average of single position.
+        if (!avepos(rr,base,obs,nav,opt)) {
             showmsg("error : station pos computation");
             return 0;
         }
     }
-    else if (postype==POSOPT_FILE) { /* read from position file */
-        name=stas[rcvno==1?0:1].name;
+    else if (postype==POSOPT_FILE) { // Read from position file.
+        char *name=stas[base].name;
         if (!getstapos(posfile,name,rr)) {
             showmsg("error : no position of %s in %s",name,posfile);
             return 0;
         }
     }
-    else if (postype==POSOPT_RINEX) { /* get from rinex header */
-        if (norm(stas[rcvno==1?0:1].pos,3)<=0.0) {
+    else if (postype==POSOPT_RINEX) { // Get from rinex header.
+        if (norm(stas[base].pos,3)<=0.0) {
             showmsg("error : no position in rinex header");
             trace(1,"no position in rinex header\n");
             return 0;
         }
-        /* add antenna delta unless already done in antpcv() */
-        if (!strcmp(opt->anttype[rcvno],"*")) {
-            if (stas[rcvno==1?0:1].deltype==0) { /* enu */
-                for (i=0;i<3;i++) del[i]=stas[rcvno==1?0:1].del[i];
-                del[2]+=stas[rcvno==1?0:1].hgt;
-                ecef2pos(stas[rcvno==1?0:1].pos,pos);
+        // Add antenna delta unless already done in setpcv().
+        double dr[3]={0};
+        if (!strcmp(opt->anttype[base],"*")) {
+            if (stas[base].deltype==0) { // ENU
+                double del[3];
+                for (int i=0;i<3;i++) del[i]=stas[base].del[i];
+                del[2]+=stas[base].hgt;
+                double pos[3];
+                ecef2pos(stas[base].pos,pos);
                 enu2ecef(pos,del,dr);
-            }  else { /* xyz */
-                for (i=0;i<3;i++) dr[i]=stas[rcvno==1?0:1].del[i];
+            }  else { // XYZ
+                for (int i=0;i<3;i++) dr[i]=stas[base].del[i];
             }
         }
-        for (i=0;i<3;i++) rr[i]=stas[rcvno==1?0:1].pos[i]+dr[i];
+        for (int i=0;i<3;i++) rr[i]=stas[base].pos[i]+dr[i];
     }
     return 1;
 }
@@ -963,16 +966,18 @@ static void setpcv(gtime_t time, prcopt_t *popt, nav_t *nav, const pcvs_t *pcvs,
     }
     for (i=0;i<(mode?2:1);i++) {
         popt->pcvr[i]=pcv0;
-        if (!strcmp(popt->anttype[i],"*")) { /* set by station parameters */
+        if (!strcmp(popt->anttype[i],"*")) {
+            // Set by station parameters. This overrides the config antenna
+            // type and antenna delta, which are ignored in this case.
             strcpy(popt->anttype[i],sta[i].antdes);
-            if (sta[i].deltype==1) { /* xyz */
+            if (sta[i].deltype==1) { // XYZ
                 if (norm(sta[i].pos,3)>0.0) {
                     ecef2pos(sta[i].pos,pos);
                     ecef2enu(pos,sta[i].del,del);
                     for (j=0;j<3;j++) popt->antdel[i][j]=del[j];
                 }
             }
-            else { /* enu */
+            else { // ENU
                 for (j=0;j<3;j++) popt->antdel[i][j]=stas[i].del[j];
             }
         }
@@ -1120,19 +1125,19 @@ static int execses(gtime_t ts, gtime_t te, double ti, const prcopt_t *popt,
     }
     /* rover/reference fixed position */
     if (popt_.mode==PMODE_FIXED) {
-        if (!antpos(&popt_,1,&obss,&navs,stas,fopt->stapos)) {
+        if (!antpos(&popt_,0,&obss,&navs,stas,fopt->stapos)) {
             freeobsnav(&obss,&navs);
             free(rtk_ptr);
             return 0;
         }
-        if (!antpos(&popt_,2,&obss,&navs,stas,fopt->stapos)) {
+        if (!antpos(&popt_,1,&obss,&navs,stas,fopt->stapos)) {
             freeobsnav(&obss,&navs);
             free(rtk_ptr);
             return 0;
         }
     }
     else if (PMODE_DGPS<=popt_.mode&&popt_.mode<=PMODE_STATIC_START) {
-        if (!antpos(&popt_,2,&obss,&navs,stas,fopt->stapos)) {
+        if (!antpos(&popt_,1,&obss,&navs,stas,fopt->stapos)) {
             freeobsnav(&obss,&navs);
             free(rtk_ptr);
             return 0;

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1817,7 +1817,7 @@ EXPORT int lambda_search(int n, int m, const double *a, const double *Q,
 
 /* standard positioning ------------------------------------------------------*/
 EXPORT int pntpos(const obsd_t *obs, int n, const nav_t *nav,
-                  const prcopt_t *opt, sol_t *sol, double *azel,
+                  const prcopt_t *opt, int base, sol_t *sol, double *azel,
                   ssat_t *ssat, char *msg);
 
 /* precise positioning -------------------------------------------------------*/

--- a/src/rtkpos.c
+++ b/src/rtkpos.c
@@ -2321,7 +2321,7 @@ extern int rtkpos(rtk_t *rtk, const obsd_t *obs, int n, const nav_t *nav)
     /* rover position and time by single point positioning, skip if
      position variance smaller than threshold */
     if (rtk->P[0]==0||rtk->P[0]>STD_PREC_VAR_THRESH) {
-        if (!pntpos(obs,nu,nav,&rtk->opt,&rtk->sol,NULL,rtk->ssat,msg)) {
+        if (!pntpos(obs,nu,nav,&rtk->opt,0,&rtk->sol,NULL,rtk->ssat,msg)) {
             errmsg(rtk,"point pos error (%s)\n",msg);
 
             if (!rtk->opt.dynamics) {
@@ -2368,7 +2368,7 @@ extern int rtkpos(rtk_t *rtk, const obsd_t *obs, int n, const nav_t *nav)
         /* estimate position/velocity of base station,
            skip if position variance below threshold*/
         if (rtk->P[0]==0||rtk->P[0]>STD_PREC_VAR_THRESH) {
-            if (!pntpos(obs+nu,nr,nav,&rtk->opt,&solb,NULL,NULL,msg)) {
+            if (!pntpos(obs+nu,nr,nav,&rtk->opt,1,&solb,NULL,NULL,msg)) {
                 errmsg(rtk,"base station position error (%s)\n",msg);
                 return 0;
             }

--- a/src/rtksvr.c
+++ b/src/rtksvr.c
@@ -617,7 +617,7 @@ static void *rtksvrthread(void *arg)
         if (fobs[1]>0&&svr->rtk.opt.refpos==POSOPT_SINGLE) {
             if ((svr->rtk.opt.maxaveep<=0||svr->nave<svr->rtk.opt.maxaveep)&&
                 pntpos(svr->obs[1][0].data,svr->obs[1][0].n,&svr->nav,
-                       &svr->rtk.opt,&sol,NULL,NULL,msg)) {
+                       &svr->rtk.opt,1,&sol,NULL,NULL,msg)) {
                 svr->nave++;
                 for (i=0;i<3;i++) {
                     svr->rb_ave[i]+=(sol.rr[i]-svr->rb_ave[i])/svr->nave;


### PR DESCRIPTION
This is a prerequisite to applying the antenna delta for the pntpos solutions - need to know if the base or rover delta is to be applied. Also fixes an OOB in rtkpos.c.

Pass in the receiver index, as a 'base' argument, which is 0 for the rover and 1 for the base, to allow the respective options to be selected rather than just using the rover options even for the base. Start making use of this: in rescode() this is now used to select the respective SNR and SNR mask.

For postpos.c where a one based receiver number and zero base index were both be used, fix an instance in antpos() of indexing into option anttype[] with an one base index which would be OOB for a value of
2. Try to clean up this code in this regard.