### PR TITLE
rtkpos: tide disp option otl to include solid earth and pole

### DIFF
--- a/src/rtkpos.c
+++ b/src/rtkpos.c
@@ -1035,7 +1035,7 @@ static int zdres(int base, const obsd_t *obs, int n, const double *rs,
 
     /* adjust rcvr pos for earth tide correction */
     if (opt->tidecorr) {
-        tidedisp(gpst2utc(obs[0].time),rr_,opt->tidecorr,&nav->erp,
+        tidedisp(gpst2utc(obs[0].time),rr_,opt->tidecorr==1?1:7,&nav->erp,
                  opt->odisp[base],disp);
         for (i=0;i<3;i++) rr_[i]+=disp[i];
     }


### PR DESCRIPTION
consistent with the usage in the ppp code, for option 2, include the solid earth and pole tide displacements.

Guessing that this was an oversight and that there is no good reason to only apply ocean tide loading for option 2 and that option 2 under rtkpos should be consistent with the ppp code usage.

Alternatively the pos1-tidecorr options could be extended to support all the options of the tidedisp() function.
