### PR TITLE
eci2ecef: thread safety, add THREADLOCAL

### DIFF
--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -2379,8 +2379,8 @@ static void nut_iau1980(double t, const double *f, double *dpsi, double *deps)
 extern void eci2ecef(gtime_t tutc, const double *erpv, double *U, double *gmst)
 {
     const double ep2000[]={2000,1,1,12,0,0};
-    static gtime_t tutc_;
-    static double U_[9],gmst_;
+    static THREADLOCAL gtime_t tutc_ = {0, 0};
+    static THREADLOCAL double U_[9], gmst_;
     gtime_t tgps;
     double eps,ze,th,z,t,t2,t3,dpsi,deps,gast,f[5];
     double R1[9],R2[9],R3[9],R[9],W[9],N[9],P[9],NP[9];

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -59,6 +59,16 @@ extern "C" {
 #define EXPORT
 #endif
 
+#if (__STDC_VERSION__ >= 201710L)
+#define THREADLOCAL _Thread_local
+#elif defined(__GNUC__)
+#define THREADLOCAL __thread
+#elif defined(_MSC_VER)
+#define THREADLOCAL __declspec(__thread)
+#else
+#define THREADLOCAL
+#endif
+
 /* constants -----------------------------------------------------------------*/
 
 #define VER_RTKLIB  "demo5"             /* library version */


### PR DESCRIPTION
Add a THREADLOCAL definition that maps to _Thread_local for C11, __thread for gcc, and __declspec(__thread) for MSC.

Use this to make the eci2ecef() cache thread safe.

Testing on linux. If people could test this on other platforms, and if there is a workable thread local declaration, then this could be useful in a few other places. Worst case the definition could be empty for platforms without thread local storage declarations and then these uses would remain not thread safe for now on these platforms. The MSC declaration is based on https://learn.microsoft.com/en-us/cpp/cpp/thread?view=msvc-170 For C11 _Thread_local appears to be usable, but RTKLIB currently targets C99 so this also maps to GCC amd MSC extensions.