### PR TITLE
sunmoonpos_eci: declare epv00 and moon98 prototypes

### DIFF
--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -3910,8 +3910,8 @@ extern void antmodel_s(const pcv_t *pcv, double nadir, double *dant)
 }
 
 /* Sun and moon position in ECI (ref [4] 5.1.1, 5.2.1) -----------------------*/
-void epv00(double date1, double date2, double pvh[2][3], double pvb[2][3]) {}
-void moon98(double date1, double date2, double pv[2][3]) {}
+int epv00(double date1, double date2, double pvh[2][3], double pvb[2][3]);
+void moon98(double date1, double date2, double pv[2][3]);
 static void sunmoonpos_eci(gtime_t tutc, double *rsun, double *rmoon) {
   char tstr[40];
   trace(4, "sunmoonpos_eci: tutc=%s\n", time2str(tutc, tstr, 3));


### PR DESCRIPTION
Fix a merge issue with the sofa changes. The functions epv00 and moon98 are defined in `src/sofa.c` and need only be declared in rtkcm.c. If there is a compilation issue with these not being defined then the build definitions need to be updated to also include src/sofa.c, and hopefully someone can address that for the windows builds if that was the issue.
