### PR TITLE
rtkrcv: remove an apparent SP3 stream format hack

### DIFF
--- a/app/consapp/rtkrcv/rtkrcv.c
+++ b/app/consapp/rtkrcv/rtkrcv.c
@@ -465,8 +465,6 @@ static int startsvr(vt_t *vt)
     stropt[4]=fswapmargin;
     strsetopt(stropt);
     
-    if (strfmt[2]==8) strfmt[2]=STRFMT_SP3;
-    
     /* set ftp/http directory and proxy */
     strsetdir(filopt.tempdir);
     strsetproxy(proxyaddr);


### PR DESCRIPTION
Not sure the intention of this line of code, but a STRFMT of 8 is now for the JAVAD format and surely that should not be replaced with SP3 file loading.