### PR TITLE
rtkplot-qt: initialize ionosphere

### DIFF
--- a/app/qtapp/rtkplot_qt/plotmain.cpp
+++ b/app/qtapp/rtkplot_qt/plotmain.cpp
@@ -158,6 +158,8 @@ Plot::Plot(QWidget *parent) : QMainWindow(parent), ui(new Ui::Plot)
     for (int i = 0; i < NFREQ + NEXOBS; i++)
         multipath[i] = NULL;
 
+    ionosphere = NULL;
+
     graphTrack = new Graph(ui->lblDisplay);
     graphTrack->fit = 0;
 


### PR DESCRIPTION
to avoid a crash when trying to free garbage