### PR TITLE
do not close stderr by accident

### DIFF
--- a/src/trace.c
+++ b/src/trace.c
@@ -27,7 +27,7 @@ static void traceswap(void)
         rtklib_unlock(&lock_trace);
         return;
     }
-    if (fp_trace) fclose(fp_trace);
+    if (fp_trace && fp_trace != stderr) fclose(fp_trace);
 
     if (!(fp_trace = fopen(path, "w"))) {
         fp_trace = stderr;


### PR DESCRIPTION
This minor fix prevents accidentally closing stderr, see also the traceclose function in line 49.