### PR TITLE
postpos: when processing unit periods alloc for all infiles

### DIFF
--- a/src/postpos.c
+++ b/src/postpos.c
@@ -1417,7 +1417,7 @@ extern int postpos(gtime_t ts, gtime_t te, double ti, double tu,
             closeses(&navs,&pcvss,&pcvsr);
             return 0;
         }
-        for (i=0;i<n&&i<MAXINFILE;i++) {
+        for (i=0;i<MAXINFILE;i++) {
             if (!(ifile[i]=(char *)malloc(1024))) {
                 for (;i>=0;i--) free(ifile[i]);
                 closeses(&navs,&pcvss,&pcvsr);
@@ -1477,7 +1477,7 @@ extern int postpos(gtime_t ts, gtime_t te, double ti, double tu,
 
             if (stat==1) break;
         }
-        for (i=0;i<n&&i<MAXINFILE;i++) free(ifile[i]);
+        for (i=0;i<MAXINFILE;i++) free(ifile[i]);
     }
     else if (ts.time!=0) {
         for (i=0;i<n&&i<MAXINFILE;i++) {


### PR DESCRIPTION
For the case in which there is a start and end time and a unit period, the number of input files can grow in` reppaths()` and this function was being allowed to use up to `MAXINFILE `files so these all need to be allocated and freed in this code path.

Building on https://github.com/rtklibexplorer/RTKLIB/pull/609 but allocate all `MAXINFILE `elements to `infile[]` in this code path which is around 1M of memory usage.