### PR TITLE
postpos procpos: catch malloc failure

### DIFF
--- a/src/postpos.c
+++ b/src/postpos.c
@@ -437,6 +437,10 @@ static void procpos(FILE *fp, FILE *fptm, const prcopt_t *popt, const solopt_t *
     gtime_t time={0};
     sol_t sol={{0}},oldsol={{0}},newsol={{0}};
     obsd_t *obs_ptr = (obsd_t *)malloc(sizeof(obsd_t)*MAXOBS*2); /* for rover and base */
+    if (obs_ptr == NULL) {
+      trace(2, "procpos: memory allocation failure\n");
+      return;
+    }
     double rb[3]={0};
     int i,nobs,n,solstatic,num=0,pri[]={6,1,2,3,4,5,1,6};
 


### PR DESCRIPTION
just to report a failure and handle it a little more gracefully.