### PR TITLE
rtcm3 decode_ssr3: quieten compiler warning, loss of precision

### DIFF
--- a/src/rtcm3.c
+++ b/src/rtcm3.c
@@ -1673,7 +1673,7 @@ static int decode_ssr3(rtcm_t *rtcm, int sys, int subtype)
             mode=getbitu(rtcm->buff,i, 5);      i+= 5;
             bias=getbits(rtcm->buff,i,14)*0.01; i+=14;
             if (sigs[mode]) {
-                cbias[sigs[mode]-1]=(float)bias;
+                cbias[sigs[mode]-1]=bias;
             }
             else {
                 trace(2,"rtcm3 %d not supported mode: mode=%d\n",type,mode);


### PR DESCRIPTION
just to quieten a compiler warning of a loss of precision.