### PR TITLE
MAXSOLMSG: increase to 32768, to correct an overflow

### DIFF
--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -281,7 +281,8 @@ extern "C" {
 #define MAXSTRMSG   1024                /* max length of stream message */
 #define MAXSTRRTK   8                   /* max number of stream in RTK server */
 #define MAXSBSMSG   32                  /* max number of SBAS msg in RTK server */
-#define MAXSOLMSG   8191                /* max length of solution message */
+#define MAXSOLLEN   512                 /* max line length of solution message */
+#define MAXSOLMSG   32768               /* max length of solution messages */
 #define MAXRAWLEN   16384               /* max length of receiver raw message */
 #define MAXERRMSG   4096                /* max length of error/warning message */
 #define MAXANT      64                  /* max length of station name/antenna type */
@@ -926,7 +927,7 @@ typedef struct {        /* solution buffer type */
     gtime_t time;       /* current solution time */
     sol_t *data;        /* solution data */
     double rb[3];       /* reference position {x,y,z} (ecef) (m) */
-    uint8_t buff[MAXSOLMSG+1]; /* message buffer */
+    uint8_t buff[MAXSOLLEN+1]; /* message line buffer */
     int nb;             /* number of byte in message buffer */
 } solbuf_t;
 
@@ -1321,7 +1322,7 @@ typedef struct {        /* RTK server type */
     uint8_t *buff[3];   /* input buffers {rov,base,corr} */
     uint8_t *sbuf[2];   /* output buffers {sol1,sol2} */
     uint8_t *pbuf[3];   /* peek buffers {rov,base,corr} */
-    sol_t solbuf[MAXSOLBUF]; /* solution buffer */
+    sol_t solbuf[MAXSOLBUF]; /* solution line buffer */
     uint32_t nmsg[3][10]; /* input message counts */
     raw_t  raw [3];     /* receiver raw control {rov,base,corr} */
     rtcm_t rtcm[3];     /* RTCM control {rov,base,corr} */

--- a/src/rtkpos.c
+++ b/src/rtkpos.c
@@ -356,7 +356,7 @@ static void outsolstat(rtk_t *rtk,const nav_t *nav)
     swapsolstat();
 
     /* write solution status */
-    char buff[3*MAXSOLMSG+1];
+    char buff[MAXSOLMSG+1];
     int n=rtkoutstat(rtk,statlevel,buff);
     buff[n]='\0';
     

--- a/src/rtksvr.c
+++ b/src/rtksvr.c
@@ -71,7 +71,7 @@ static void saveoutbuf(rtksvr_t *svr, uint8_t *buff, int n, int index)
 static void writesol(rtksvr_t *svr, int index)
 {
     solopt_t solopt=solopt_default;
-    uint8_t buff[3*MAXSOLMSG+1];
+    uint8_t buff[MAXSOLMSG+1];
     int i,n;
     
     tracet(4,"writesol: index=%d\n",index);

--- a/src/solution.c
+++ b/src/solution.c
@@ -763,13 +763,12 @@ static void decode_solopt(char *buff, solopt_t *opt)
 /* read solution option ------------------------------------------------------*/
 static void readsolopt(FILE *fp, solopt_t *opt)
 {
-    char buff[MAXSOLMSG+1];
+    char buff[MAXSOLLEN+1];
     int i;
     
     trace(3,"readsolopt:\n");
     
-    for (i=0;fgets(buff,sizeof(buff),fp)&&i<100;i++) { /* only 100 lines */
-        
+    for (i=0;fgets(buff,sizeof(buff),fp)&&i<100;i++) { /* Only 100 lines */
         /* decode solution options */
         decode_solopt(buff,opt);
     }
@@ -798,7 +797,7 @@ extern int inputsol(uint8_t data, gtime_t ts, gtime_t te, double tint,
     if (data!='\r'&&data!='\n') {
     solbuf->buff[solbuf->nb++]=data;
     }
-    if (data!='\n'&&solbuf->nb<MAXSOLMSG) return 0; /* sync trailer */
+    if (data!='\n'&&solbuf->nb<MAXSOLLEN) return 0; /* sync trailer */
     
     solbuf->buff[solbuf->nb]='\0';
     solbuf->nb=0;
@@ -1113,7 +1112,7 @@ static int readsolstatdata(FILE *fp, gtime_t ts, gtime_t te, double tint,
                            solstatbuf_t *statbuf)
 {
     solstat_t stat={{0}};
-    char buff[MAXSOLMSG+1];
+    char buff[MAXSOLLEN+1];
     
     trace(3,"readsolstatdata:\n");
     


### PR DESCRIPTION
Correct a further noted overflow in this buffer increasing it from 24576 to 32768, and clean up the usage of the buffer size.

A further overflow was noted, but with over 40 satellites and with support for 5+ frequencies enabled.

This definition is used for a buffer size for solution status messages and as the number of satellites and frequencies has increased this buffer has needed to grow. There is a $SAT solution status line for each satellite frequency.

In places this buffer size had been increased as overflows were noted, but not consistently, so update the definition and correct the references.

MAXSOLLEN - add a new definition for the solution status line buffer length. There were cases in which the MAXSOLMSG buffer size was being used for a single line buffer which was excessive, particularly with the now increased size

The MAXSOLMSG definition of 32768 bytes would support 256 solution status lines of length 128 bytes. There is an existing definition of MAXSOLBUF as 256 which is roughly the number of solution status lines buffered.