### PR TITLE
convbin rtcm time: use the start or end time if supplied

### DIFF
--- a/app/consapp/convbin/convbin.c
+++ b/app/consapp/convbin/convbin.c
@@ -605,8 +605,11 @@ static int cmdopts(int argc, char **argv, rnxopt_t *opt, char **ifile,
     if (nf>=6) opt->freqtype|=FREQTYPE_L6;
     if (nf>=7) opt->freqtype|=FREQTYPE_ALL;
     
-    if (!opt->trtcm.time) {
-        get_filetime(*ifile,&opt->trtcm);
+    if (opt->trtcm.time == 0) {
+        // Use the start or end time if supplied. Otherwise use the file time.
+        if (opt->ts.time != 0) opt->trtcm.time = ts;
+        else if (opt->te.time != 0) opt->trtcm.time = te;
+        else get_filetime(*ifile, &opt->trtcm);
     }
     if (*fmt) {
         if      (!strcmp(fmt,"rtcm2")) format=STRFMT_RTCM2;


### PR DESCRIPTION
This RTCM time is a rough time needed to determine the absolute time from the incomplete RTCM encoded time. This can be supplied by the '-tr' argument but this will often be start time. So if not supplied by this argument then use the supplied start or end time before falling back to using the file time because the file time can change if copied or processed.