### PR TITLE
SNR, P and L std, float storage

### DIFF
--- a/app/consapp/rtkrcv/rtkrcv.c
+++ b/app/consapp/rtkrcv/rtkrcv.c
@@ -879,7 +879,7 @@ static void probserv(vt_t *vt, int nf)
         for (j=0;j<nf;j++) vt_printf(vt,"%13.3f",obs[i].P[j]);
         for (j=0;j<nf;j++) vt_printf(vt,"%14.3f",obs[i].L[j]);
         for (j=0;j<nf;j++) vt_printf(vt,"%8.1f" ,obs[i].D[j]);
-        for (j=0;j<nf;j++) vt_printf(vt,"%3.0f" ,obs[i].SNR[j]*SNR_UNIT);
+        for (j=0;j<nf;j++) vt_printf(vt,"%3.0f" ,obs[i].SNR[j]);
         for (j=0;j<nf;j++) vt_printf(vt,"%2d"   ,obs[i].LLI[j]);
         vt_printf(vt,"\n");
     }

--- a/app/qtapp/rtknavi_qt/mondlg.cpp
+++ b/app/qtapp/rtknavi_qt/mondlg.cpp
@@ -1014,8 +1014,11 @@ void MonitorDialog::setObservations()
     const QString label[] = {tr("Trcv (GPST)"), tr("SAT"), tr("STR")};
     int i, j = 0, width[] = {230, 46, 40};
     int nex = ui->cBSelectObservation->currentIndex() ? NEXOBS : 0;
+    // Show standard deviations when the extended observations are
+    // also selected, but this could be a separate option.
+    int std = ui->cBSelectObservation->currentIndex();
 
-    ui->tWConsole->setColumnCount(3 + (NFREQ + nex) * 6);
+    ui->tWConsole->setColumnCount(3 + (NFREQ + nex) * (6 + std * 2));
     ui->tWConsole->setRowCount(0);
     header.clear();
 
@@ -1034,11 +1037,19 @@ void MonitorDialog::setObservations()
     for (i = 0; i < NFREQ + nex; i++) {
         ui->tWConsole->setColumnWidth(j++, 135 * fontScale / 96);
         header << (i < NFREQ ? tr("P%1 (m)").arg(i+1) : tr("PX%1 (m)").arg(i - NFREQ + 1));
+        if (std) {
+          ui->tWConsole->setColumnWidth(j++, 65 * fontScale / 96);
+          header << tr("Std");
+        }
     }
     for (i = 0; i < NFREQ + nex; i++) {
         ui->tWConsole->setColumnWidth(j++, 160 * fontScale / 96);
         header << (i < NFREQ ? tr("L%1 (cycle)").arg(i+1) : tr("LX%1 (cycle)").arg(i - NFREQ + 1));
-	}
+        if (std) {
+          ui->tWConsole->setColumnWidth(j++, 75 * fontScale / 96);
+          header << tr("Std");
+        }
+    }
     for (i = 0; i < NFREQ + nex; i++) {
         ui->tWConsole->setColumnWidth(j++, 120 * fontScale / 96);
         header << (i < NFREQ ? tr("D%1 (Hz)").arg(i+1) : tr("DX%1 (Hz)").arg(i - NFREQ + 1));
@@ -1057,6 +1068,7 @@ void MonitorDialog::showObservations()
     char tstr[40], id[8], *code;
     int i, k, n = 0, nex = ui->cBSelectObservation->currentIndex() ? NEXOBS : 0;
     int sys = sys_tbl[ui->cBSelectNavigationSystems->currentIndex()];
+    int std = ui->cBSelectObservation->currentIndex();
 
     obsd_t *obs = static_cast<obsd_t *>(calloc(MAXOBS * 2, sizeof(obsd_t)));
     if (obs == NULL) {
@@ -1103,10 +1115,20 @@ void MonitorDialog::showObservations()
             if (obs[i].SNR[k]) ui->tWConsole->item(i, j++)->setText(QString::number(obs[i].SNR[k], 'f', 1));
             else ui->tWConsole->item(i, j++)->setText("-");
         }
-        for (k = 0; k < NFREQ + nex; k++)
+        for (k = 0; k < NFREQ + nex; k++) {
             ui->tWConsole->item(i, j++)->setText(QString::number(obs[i].P[k], 'f', 3));
-        for (k = 0; k < NFREQ + nex; k++)
+            if (std) {
+              if (obs[i].Pstd[k]) ui->tWConsole->item(i, j++)->setText(QString::number(obs[i].Pstd[k], 'f', 3));
+              else ui->tWConsole->item(i, j++)->setText("-");
+            }
+        }
+        for (k = 0; k < NFREQ + nex; k++) {
             ui->tWConsole->item(i, j++)->setText(QString::number(obs[i].L[k], 'f', 3));
+            if (std) {
+              if (obs[i].Lstd[k]) ui->tWConsole->item(i, j++)->setText(QString::number(obs[i].Lstd[k], 'f', 4));
+              else ui->tWConsole->item(i, j++)->setText("-");
+            }
+        }
         for (k = 0; k < NFREQ + nex; k++)
             ui->tWConsole->item(i, j++)->setText(QString::number(obs[i].D[k], 'f', 3));
         for (k = 0; k < NFREQ + nex; k++)

--- a/app/qtapp/rtknavi_qt/mondlg.cpp
+++ b/app/qtapp/rtknavi_qt/mondlg.cpp
@@ -1100,7 +1100,7 @@ void MonitorDialog::showObservations()
             else ui->tWConsole->item(i, j++)->setText("-");
         }
         for (k = 0; k < NFREQ + nex; k++) {
-            if (obs[i].SNR[k]) ui->tWConsole->item(i, j++)->setText(QString::number(obs[i].SNR[k] * SNR_UNIT, 'f', 1));
+            if (obs[i].SNR[k]) ui->tWConsole->item(i, j++)->setText(QString::number(obs[i].SNR[k], 'f', 1));
             else ui->tWConsole->item(i, j++)->setText("-");
         }
         for (k = 0; k < NFREQ + nex; k++)

--- a/app/qtapp/rtkplot_qt/plotcmn.cpp
+++ b/app/qtapp/rtkplot_qt/plotcmn.cpp
@@ -356,7 +356,7 @@ QColor Plot::observationColor(const obsd_t *obs, double az, double el, QVariant 
         if (obs->L[freq-1] == 0.0 && obs->P[freq-1] == 0.0) {
             return Qt::black;
         }
-        color = snrColor(obs->SNR[freq-1] * SNR_UNIT);
+        color = snrColor(obs->SNR[freq-1]);
     } else {  // code
         for (i = 0; i < NFREQ + NEXOBS; i++) {
             if (!strcmp(code2obs(obs->code[i]), qPrintable(obstype.toString()))) break;
@@ -367,7 +367,7 @@ QColor Plot::observationColor(const obsd_t *obs, double az, double el, QVariant 
         if (obs->L[i] == 0.0 && obs->P[i] == 0.0) {
             return Qt::black;
         }
-        color = snrColor(obs->SNR[i] * SNR_UNIT);
+        color = snrColor(obs->SNR[i]);
     }
 
     // check against elevation mask

--- a/app/qtapp/rtkplot_qt/plotdata.cpp
+++ b/app/qtapp/rtkplot_qt/plotdata.cpp
@@ -1039,7 +1039,7 @@ void Plot::saveSnrMp(const QString &file)
                 time2str(timeadd(gpst2utc(time), 9 * 3600.0), tstr, 1);
             }
             data = QString("%1 %2 %3 %4 %5 %6f\n").arg(tstr).arg(sat, 6).arg(azimuth[j] * R2D, 8, 'f', 1)
-                       .arg(elevation[j] * R2D, 8, 'f', 1).arg(observation.data[j].SNR[k] * SNR_UNIT, 9, 'f', 2).arg(!multipath[k] ? 0.0 : multipath[k][j], 10, 'f', 4);
+                       .arg(elevation[j] * R2D, 8, 'f', 1).arg(observation.data[j].SNR[k], 9, 'f', 2).arg(!multipath[k] ? 0.0 : multipath[k][j], 10, 'f', 4);
             fp.write(data.toLatin1());
         }
     }

--- a/app/qtapp/rtkplot_qt/plotdraw.cpp
+++ b/app/qtapp/rtkplot_qt/plotdraw.cpp
@@ -1389,7 +1389,7 @@ void Plot::drawSky(QPainter &c, int level)
                     if (obs->P[j] == 0.0 && obs->L[j] == 0.0)
                         s += "-- ";
                     else
-                        s += QStringLiteral("%1 ").arg(obs->SNR[j] * SNR_UNIT, 2, 'f', 0, QChar('0'));
+                        s += QStringLiteral("%1 ").arg(obs->SNR[j], 2, 'f', 0, QChar('0'));
                 }
 
                 // LLI
@@ -1412,7 +1412,7 @@ void Plot::drawSky(QPainter &c, int level)
                 if (obs->P[freq - 1] == 0.0 && obs->L[freq - 1] == 0.0)
                     s += "---- ";
                 else
-                    s += QStringLiteral("%1 ").arg(obs->SNR[freq - 1] * SNR_UNIT, 4, 'f', 1);
+                    s += QStringLiteral("%1 ").arg(obs->SNR[freq - 1], 4, 'f', 1);
 
                 // LLI
                 if (obs->L[freq-1] == 0.0)
@@ -1434,7 +1434,7 @@ void Plot::drawSky(QPainter &c, int level)
                 if (obs->P[j] == 0.0 && obs->L[j] == 0.0)
                     s += "---- ";
                 else
-                    s += QStringLiteral("%1 ").arg(obs->SNR[j] * SNR_UNIT, 4, 'f', 1);
+                    s += QStringLiteral("%1 ").arg(obs->SNR[j], 4, 'f', 1);
 
                 // LLI
                 if (obs->L[j] == 0.0)
@@ -1630,7 +1630,7 @@ void Plot::drawSky(QPainter &c, int level)
                     if (obs->P[j] == 0.0 && obs->L[j] == 0.0)
                         s += "-- ";
                     else
-                        s += QStringLiteral("%1 ").arg(obs->SNR[j] * SNR_UNIT, 2, 'f', 0, QChar('0'));
+                        s += QStringLiteral("%1 ").arg(obs->SNR[j], 2, 'f', 0, QChar('0'));
                 }
 
                 // LLI
@@ -1653,7 +1653,7 @@ void Plot::drawSky(QPainter &c, int level)
                 if (obs->P[freq - 1] == 0.0 && obs->L[freq - 1] == 0.0)
                     s += "---- ";
                 else
-                    s += QStringLiteral("%1 ").arg(obs->SNR[freq - 1] * SNR_UNIT, 4, 'f', 1);
+                    s += QStringLiteral("%1 ").arg(obs->SNR[freq - 1], 4, 'f', 1);
 
                 // LLI
                 if (obs->L[freq-1] == 0.0)
@@ -1675,7 +1675,7 @@ void Plot::drawSky(QPainter &c, int level)
                 if (obs->P[j] == 0.0 && obs->L[j] == 0.0)
                     s += "---- ";
                 else
-                    s += QStringLiteral("%1 ").arg(obs->SNR[j] * SNR_UNIT, 4, 'f', 1);
+                    s += QStringLiteral("%1 ").arg(obs->SNR[j], 4, 'f', 1);
 
                 // LLI
                 if (obs->L[j] == 0.0)
@@ -1734,7 +1734,7 @@ void Plot::drawSolSky(QPainter &c, int level) {
       if (satelliteMask[solstat->sat - 1] || !satelliteSelection[solstat->sat - 1]) continue;
       if (solstat->frq != frq || solstat->el <= 0) continue;
 
-      QColor col = snrColor(solstat->snr * SNR_UNIT);
+      QColor col = snrColor(solstat->snr);
       // Include satellites with invalid data but note this in the color.
       if ((solstat->flag & 0x20) == 0) col = plotOptDialog->getMarkerColor(0, 7);
       // Check against elevation mask.
@@ -1845,7 +1845,7 @@ void Plot::drawSolSky(QPainter &c, int level) {
       if (satelliteMask[solstat->sat - 1] || !satelliteSelection[solstat->sat - 1]) continue;
       if (solstat->frq != frq || solstat->el <= 0) continue;
 
-      QColor col = snrColor(solstat->snr * SNR_UNIT);
+      QColor col = snrColor(solstat->snr);
       // Include satellites with invalid data but note this in the color.
       if ((solstat->flag & 0x20) == 0) col = plotOptDialog->getMarkerColor(0, 7);
       // Check against elevation mask.
@@ -2348,12 +2348,12 @@ void Plot::drawSnr(QPainter &c, int level)
                         }
                         if (idx >= NFREQ + NEXOBS) continue;
                     }
-                    if (obs->SNR[idx] * SNR_UNIT <= 0.0) continue;  // skip negative SNR
+                    if (obs->SNR[idx] <= 0.0) continue;  // skip negative SNR
 
                     // calculate position
                     x[n] = timePosition(obs->time);
                     if (panel == 0) {  // SNR
-                        y[n] = obs->SNR[idx] * SNR_UNIT;
+                        y[n] = obs->SNR[idx];
                         col[n] = plotOptDialog->getMarkerColor(0, 4);
                     } else if (panel == 1) {  // multipath
                         if (!multipath[idx] || multipath[idx][j] == 0.0) continue;
@@ -2365,7 +2365,7 @@ void Plot::drawSnr(QPainter &c, int level)
                         if (simulatedObservation)
                             col[n] = sysColor(obs->sat);
                         else
-                            col[n] = snrColor(obs->SNR[idx] * SNR_UNIT);
+                            col[n] = snrColor(obs->SNR[idx]);
 
                         if (elevation[j] > 0.0 && elevation[j] < plotOptDialog->getElevationMask() * D2R) col[n] = plotOptDialog->getMarkerColor(0, 0);
                     }
@@ -2546,10 +2546,10 @@ void Plot::drawSnrE(QPainter &c, int level)
                     }
                     if (idx >= NFREQ + NEXOBS) continue;
                 }
-                if (obs->SNR[idx] * SNR_UNIT <= 0.0) continue;
+                if (obs->SNR[idx] <= 0.0) continue;
 
                 x[0][n[0]] = x[1][n[1]] = elevation[j] * R2D;
-                y[0][n[0]] = obs->SNR[idx] * SNR_UNIT;
+                y[0][n[0]] = obs->SNR[idx];
                 y[1][n[1]] = !multipath[idx] ? 0.0 : multipath[idx][j];
 
                 col[0][n[0]] = col[1][n[1]] = (elevation[j] > 0.0 && elevation[j] < plotOptDialog->getElevationMask() * D2R) ?\
@@ -2945,7 +2945,7 @@ void Plot::drawResidual(QPainter &c, int level)
                 y[0][m[0]] = solstat->resp;
                 y[1][m[1]] = solstat->resc;
                 y[2][m[2]] = solstat->el * R2D;
-                y[3][m[3]] = solstat->snr * SNR_UNIT;
+                y[3][m[3]] = solstat->snr;
 
                 if (!(solstat->flag >> 5)) q = 0;          // invalid
                 else if ((solstat->flag & 7) <= 1) q = 2;  // float

--- a/app/winapp/rtknavi/mondlg.cpp
+++ b/app/winapp/rtknavi/mondlg.cpp
@@ -1027,7 +1027,7 @@ void __fastcall TMonitorDialog::ShowObs(void)
 			else       Tbl->Cells[j++][i+1]="-";
 		}
 		for (k=0;k<NFREQ+nex;k++) {
-			if (obs[i].SNR[k]) Tbl->Cells[j++][i+1]=s.sprintf("%.1f",obs[i].SNR[k]*SNR_UNIT);
+			if (obs[i].SNR[k]) Tbl->Cells[j++][i+1]=s.sprintf("%.1f",obs[i].SNR[k]);
 			else               Tbl->Cells[j++][i+1]=s.sprintf("-");
 		}
 		for (k=0;k<NFREQ+nex;k++) {

--- a/app/winapp/rtkplot/plotcmn.cpp
+++ b/app/winapp/rtkplot/plotcmn.cpp
@@ -343,7 +343,7 @@ TColor __fastcall TPlot::ObsColor(const obsd_t *obs, double az, double el)
         if (obs->L[freq-1]==0.0&&obs->P[freq-1]==0.0) {
             return clBlack;
         }
-        color=SnrColor(obs->SNR[freq-1]*SNR_UNIT);
+        color=SnrColor(obs->SNR[freq-1]);
     }
     else {
         for (i=0;i<NFREQ+NEXOBS;i++) {
@@ -355,7 +355,7 @@ TColor __fastcall TPlot::ObsColor(const obsd_t *obs, double az, double el)
         if (obs->L[i]==0.0&&obs->P[i]==0.0) {
             return clBlack;
         }
-        color=SnrColor(obs->SNR[i]*SNR_UNIT);
+        color=SnrColor(obs->SNR[i]);
     }
     if (el<ElMask*D2R||(ElMaskP&&el<ElMaskData[(int)(az*R2D+0.5)])) {
         return HideLowSat?clBlack:MColor[0][0];

--- a/app/winapp/rtkplot/plotdata.cpp
+++ b/app/winapp/rtkplot/plotdata.cpp
@@ -1054,7 +1054,7 @@ void __fastcall TPlot::SaveSnrMp(AnsiString file)
                 time2str(timeadd(gpst2utc(time),9*3600.0),tstr,1);
             }
             fprintf(fp,"%s %6s %8.1f %8.1f %9.2f %10.4f\n",tstr,sat,Az[j]*R2D,
-                    El[j]*R2D,Obs.data[j].SNR[k]*SNR_UNIT,!Mp[k]?0.0:Mp[k][j]);
+                    El[j]*R2D,Obs.data[j].SNR[k],!Mp[k]?0.0:Mp[k][j]);
         }
     }
     fclose(fp);

--- a/app/winapp/rtkplot/plotdraw.cpp
+++ b/app/winapp/rtkplot/plotdraw.cpp
@@ -1351,7 +1351,7 @@ void __fastcall TPlot::DrawSky(int level)
                 ustr+=" ";
                 for (j=0;j<NFREQ;j++) {
                     if (obs->P[j]==0.0&&obs->L[j]==0.0) ustr+="-- ";
-                    else ustr+=ss.sprintf("%02.0f ",obs->SNR[j]*SNR_UNIT);
+                    else ustr+=ss.sprintf("%02.0f ",obs->SNR[j]);
                 }
                 for (j=0;j<NFREQ;j++) {
                     if (obs->L[j]==0.0) ustr+="-";
@@ -1365,7 +1365,7 @@ void __fastcall TPlot::DrawSky(int level)
                               obs->P[freq-1]==0.0?"-":"C",obs->L[freq-1]==0.0?"-":"L",
                               obs->D[freq-1]==0.0?"-":"D");
                 if (obs->P[freq-1]==0.0&&obs->L[freq-1]==0.0) ustr+="---- ";
-                else ustr+=ss.sprintf("%4.1f ",obs->SNR[freq-1]*SNR_UNIT);
+                else ustr+=ss.sprintf("%4.1f ",obs->SNR[freq-1]);
                 if (obs->L[freq-1]==0.0) ustr+=" -";
                 else ustr+=ss.sprintf("%2d",obs->LLI[freq-1]);
             }
@@ -1378,7 +1378,7 @@ void __fastcall TPlot::DrawSky(int level)
                                  obs->P[j]==0.0?"-":"C",obs->L[j]==0.0?"-":"L",
                                  obs->D[j]==0.0?"-":"D");
                 if (obs->P[j]==0.0&&obs->L[j]==0.0) ustr+="---- ";
-                else ustr+=ss.sprintf("%4.1f ",obs->SNR[j]*SNR_UNIT);
+                else ustr+=ss.sprintf("%4.1f ",obs->SNR[j]);
                 if (obs->L[j]==0.0) ustr+=" -";
                 else ustr+=ss.sprintf("%2d",obs->LLI[j]);
             }
@@ -1422,7 +1422,7 @@ void __fastcall TPlot::DrawSolSky(int level) {
       if (SatMask[solstat->sat - 1] || !SatSel[solstat->sat - 1]) continue;
       if (solstat->frq != frq || solstat->el <= 0.0) continue;
 
-      TColor col = SnrColor(solstat->snr*SNR_UNIT);
+      TColor col = SnrColor(solstat->snr);
       // Include satellites with invalid data but note this in the color.
       if ((solstat->flag & 0x20) == 0) col = MColor[0][7];
       double azel[2];
@@ -1518,7 +1518,7 @@ void __fastcall TPlot::DrawSolSky(int level) {
       if (SatMask[solstat->sat - 1] || !SatSel[solstat->sat - 1]) continue;
       if (solstat->frq != frq || solstat->el <= 0.0) continue;
 
-      TColor col = SnrColor(solstat->snr*SNR_UNIT);
+      TColor col = SnrColor(solstat->snr);
       // Include satellites with invalid data but note this in the color.
       if ((solstat->flag & 0x20) == 0) col = MColor[0][7];
       double azel[2];
@@ -1955,11 +1955,11 @@ void __fastcall TPlot::DrawSnr(int level)
                         }
                         if (k>=NFREQ+NEXOBS) continue;
                     }
-                    if (obs->SNR[k]*SNR_UNIT<=0.0) continue;
+                    if (obs->SNR[k]<=0.0) continue;
                     
                     x[n]=TimePos(obs->time);
                     if (i==0) {
-                        y[n]=obs->SNR[k]*SNR_UNIT;
+                        y[n]=obs->SNR[k];
                         col[n]=MColor[0][4];
                     }
                     else if (i==1) {
@@ -1970,7 +1970,7 @@ void __fastcall TPlot::DrawSnr(int level)
                     else {
                         y[n]=El[j]*R2D;
                         if (SimObs) col[n]=SysColor(obs->sat);
-                        else col[n]=SnrColor(obs->SNR[k]*SNR_UNIT);
+                        else col[n]=SnrColor(obs->SNR[k]);
                         if (El[j]>0.0&&El[j]<ElMask*D2R) col[n]=MColor[0][0];
                     }
                     if (timediff(time,obs->time)==0.0&&np<MAXSAT) {
@@ -2112,10 +2112,10 @@ void __fastcall TPlot::DrawSnrE(int level)
                     }
                     if (k>=NFREQ+NEXOBS) continue;
                 }
-                if (obs->SNR[k]*SNR_UNIT<=0.0) continue;
+                if (obs->SNR[k]<=0.0) continue;
 
                 x[0][n[0]]=x[1][n[1]]=El[j]*R2D;
-                y[0][n[0]]=obs->SNR[k]*SNR_UNIT;
+                y[0][n[0]]=obs->SNR[k];
                 y[1][n[1]]=!Mp[k]?0.0:Mp[k][j];
                 
                 col[0][n[0]]=col[1][n[1]]=
@@ -2353,7 +2353,7 @@ void __fastcall TPlot::DrawRes(int level)
                 y[0][m[0]]=p->resp;
                 y[1][m[1]]=p->resc;
                 y[2][m[2]]=p->el*R2D;
-                y[3][m[3]]=p->snr*SNR_UNIT;
+                y[3][m[3]]=p->snr;
                 if      (!(p->flag>>5))  q=0; // invalid
                 else if ((p->flag&7)<=1) q=2; // float
                 else if ((p->flag&7)<=3) q=1; // fixed

--- a/src/pntpos.c
+++ b/src/pntpos.c
@@ -65,12 +65,12 @@ static double varerr(const prcopt_t *opt, const ssat_t *ssat, const obsd_t *obs,
     /* var = R^2*(a^2 + (b^2/sin(el) + c^2*(10^(0.1*(snr_max-snr_rover)))) + (d*rcv_std)^2) */
     varr=SQR(opt->err[1])+SQR(opt->err[2])/sin(el);
     if (opt->err[6]>0.0) {  /* if snr term not zero */
-        snr_rover=(ssat)?SNR_UNIT*ssat->snr_rover[0]:opt->err[5];
+        snr_rover=(ssat)?ssat->snr_rover[0]:opt->err[5];
         varr+=SQR(opt->err[6])*pow(10,0.1*MAX(opt->err[5]-snr_rover,0));
     }
     varr*=SQR(opt->eratio[0]);
     if (opt->err[7]>0.0) {
-        varr+=SQR(opt->err[7]*0.01*(1<<(obs->Pstd[0]+5)));  /* 0.01*2^(n+5) m */
+        varr+=SQR(opt->err[7]*obs->Pstd[0]);
     }
     if (opt->ionoopt==IONOOPT_IFLC) varr*=SQR(3.0); /* iono-free */
     return SQR(fact)*varr;
@@ -98,12 +98,12 @@ static int snrmask(const obsd_t *obs, const double *azel, const prcopt_t *opt)
 {
     int f2;
 
-    if (testsnr(0,0,azel[1],obs->SNR[0]*SNR_UNIT,&opt->snrmask)) {
+    if (testsnr(0,0,azel[1],obs->SNR[0],&opt->snrmask)) {
         return 0;
     }
     if (opt->ionoopt==IONOOPT_IFLC) {
         f2=seliflc(opt->nf,satsys(obs->sat,NULL));
-        if (testsnr(0,f2,azel[1],obs->SNR[f2]*SNR_UNIT,&opt->snrmask)) return 0;
+        if (testsnr(0,f2,azel[1],obs->SNR[f2],&opt->snrmask)) return 0;
     }
     return 1;
 }

--- a/src/ppp.c
+++ b/src/ppp.c
@@ -361,8 +361,8 @@ static double varerr(int sat, int sys, double el, double snr_rover,
         var+=e*e*(pow(10,0.1*MAX(snr_max-snr_rover,0)));
     }
     if (opt->err[7]>0.0) {   /* add rcvr stdevs term */
-        if (code) var+=SQR(opt->err[7]*0.01*(1<<(obs->Pstd[frq]+5))); /* 0.01*2^(n+5) */
-        else var+=SQR(opt->err[7]*obs->Lstd[frq]*0.004*0.2); /* 0.004 cycles -> m) */
+        if (code) var+=SQR(opt->err[7]*obs->Pstd[frq]);
+        else var+=SQR(opt->err[7]*obs->Lstd[frq]*0.2);
     }
     /* FIXME: the scaling factor is not 3 for other signals/constellations than GPS L1/L2 */
     var*=(opt->ionoopt==IONOOPT_IFLC)?SQR(3.0):1.0;
@@ -415,7 +415,7 @@ static void corr_meas(const obsd_t *obs, const nav_t *nav, const double *azel,
         /* skip if low SNR or missing observations */
         freq[i]=sat2freq(obs->sat,obs->code[i],nav);
         if (freq[i]==0.0||obs->L[i]==0.0||obs->P[i]==0.0) continue;
-        if (testsnr(0,0,azel[1],obs->SNR[i]*SNR_UNIT,&opt->snrmask)) continue;
+        if (testsnr(0,0,azel[1],obs->SNR[i],&opt->snrmask)) continue;
 
         /* antenna phase center and phase windup correction */
         L[i]=obs->L[i]*CLIGHT/freq[i]-dants[i]-dantr[i]-phw*CLIGHT/freq[i];
@@ -1045,7 +1045,7 @@ static int ppp_res(int post, const obsd_t *obs, int n, const double *rs,
 
             /* variance */
             var[nv]=varerr(sat,sys,azel[1+i*2],
-                    SNR_UNIT*rtk->ssat[sat-1].snr_rover[frq],
+                    rtk->ssat[sat-1].snr_rover[frq],
                     j,opt,obs+i);
             var[nv] +=vart+SQR(C)*vari+var_rs[i];
             if (sys==SYS_GLO&&code==1) var[nv]+=VAR_GLO_IFB;

--- a/src/rcv/binex.c
+++ b/src/rcv/binex.c
@@ -977,8 +977,8 @@ static uint8_t *decode_bnx_7f_05_obs(raw_t *raw, uint8_t *buff, int sat,
         }
         if (k<0) {
             data->P[i]=data->L[i]=0.0;
-            data->D[i]=0.0f;
-            data->SNR[i]=data->LLI[i]=0;
+            data->D[i]=data->SNR[i]=0.0;
+            data->LLI[i]=0;
             data->code[i]=CODE_NONE;
         }
         else {
@@ -986,7 +986,7 @@ static uint8_t *decode_bnx_7f_05_obs(raw_t *raw, uint8_t *buff, int sat,
             data->P[i]=range[k];
             data->L[i]=phase[k]*freq/CLIGHT;
             data->D[i]=dopp[k];
-            data->SNR[i]=(uint16_t)(cnr[k]/SNR_UNIT+0.5);
+            data->SNR[i]=cnr[k];
             data->code[i]=codes[code[k]];
             data->LLI[i]=slip[k]?1:0;
             mask[k]=1;
@@ -998,8 +998,8 @@ static uint8_t *decode_bnx_7f_05_obs(raw_t *raw, uint8_t *buff, int sat,
         }
         if (k>=nobs) {
             data->P[i]=data->L[i]=0.0;
-            data->D[i]=0.0f;
-            data->SNR[i]=data->LLI[i]=0;
+            data->D[i]=data->SNR[i]=0.0;
+            data->LLI[i]=0;
             data->code[i]=CODE_NONE;
         }
         else {
@@ -1007,7 +1007,7 @@ static uint8_t *decode_bnx_7f_05_obs(raw_t *raw, uint8_t *buff, int sat,
             data->P[i]=range[k];
             data->L[i]=phase[k]*freq/CLIGHT;
             data->D[i]=dopp[k];
-            data->SNR[i]=(uint16_t)(cnr[k]/SNR_UNIT+0.5);
+            data->SNR[i]=cnr[k];
             data->code[i]=codes[code[k]];
             data->LLI[i]=slip[k]?1:0;
             mask[k]=1;

--- a/src/rcv/comnav.c
+++ b/src/rcv/comnav.c
@@ -84,8 +84,8 @@ static int obsindex(obs_t *obs, gtime_t time, int sat)
     obs->data[i].sat=sat;
     for (j=0;j<NFREQ+NEXOBS;j++) {
         obs->data[i].L[j]=obs->data[i].P[j]=0.0;
-        obs->data[i].D[j]=0.0;
-        obs->data[i].SNR[j]=obs->data[i].LLI[j]=0;
+        obs->data[i].D[j]=obs->data[i].SNR[j]=0.0;
+        obs->data[i].LLI[j]=0;
         obs->data[i].code[j]=CODE_NONE;
     }
     obs->n++;
@@ -299,8 +299,7 @@ static int decode_rangecmpb(raw_t *raw)
             raw->obs.data[index].L  [pos]=adr;
             raw->obs.data[index].P  [pos]=psr;
             raw->obs.data[index].D  [pos]=(float)dop;
-            raw->obs.data[index].SNR[pos]=
-                0.0<=snr&&snr<255.0?(unsigned char)(snr*4.0+0.5):0;
+            raw->obs.data[index].SNR[pos]=0.0<=snr&&snr<255.0?snr:0;
             raw->obs.data[index].LLI[pos]=(unsigned char)lli;
             raw->obs.data[index].code[pos]=code;
 #if 0
@@ -388,8 +387,7 @@ static int decode_rangeb(raw_t *raw)
             raw->obs.data[index].L  [pos]=-adr;
             raw->obs.data[index].P  [pos]=psr;
             raw->obs.data[index].D  [pos]=(float)dop;
-            raw->obs.data[index].SNR[pos]=
-                0.0<=snr&&snr<255.0?(unsigned char)(snr*4.0+0.5):0;
+            raw->obs.data[index].SNR[pos]=0.0<=snr&&snr<255.0?snr:0;
             raw->obs.data[index].LLI[pos]=(unsigned char)lli;
             raw->obs.data[index].code[pos]=code;
 #if 0

--- a/src/rcv/crescent.c
+++ b/src/rcv/crescent.c
@@ -145,14 +145,14 @@ static int decode_cresraw(raw_t *raw)
         raw->obs.data[n].P[0]=pr;
         raw->obs.data[n].L[0]=cp*freq/CLIGHT;
         raw->obs.data[n].D[0]=-(float)(dop*freq/CLIGHT);
-        raw->obs.data[n].SNR[0]=(uint16_t)(snr/SNR_UNIT+0.5);
+        raw->obs.data[n].SNR[0]=snr;
         raw->obs.data[n].LLI[0]=(uint8_t)lli;
         raw->obs.data[n].code[0]=CODE_L1C;
         
         for (j=1;j<NFREQ;j++) {
             raw->obs.data[n].L[j]=raw->obs.data[n].P[j]=0.0;
-            raw->obs.data[n].D[j]=0.0;
-            raw->obs.data[n].SNR[j]=raw->obs.data[n].LLI[j]=0;
+            raw->obs.data[n].D[j]=raw->obs.data[n].SNR[j]=0.0;
+            raw->obs.data[n].LLI[j]=0;
             raw->obs.data[n].code[j]=CODE_NONE;
         }
         n++;
@@ -256,14 +256,14 @@ static int decode_cresraw2(raw_t *raw)
                 raw->obs.data[n].P[j]=pr[j]==0.0?0.0:pr[j]-toff;
                 raw->obs.data[n].L[j]=cp[j]==0.0?0.0:cp[j]-toff*freq[j]/CLIGHT;
                 raw->obs.data[n].D[j]=-(float)dop[j];
-                raw->obs.data[n].SNR[j]=(uint16_t)(snr[j]/SNR_UNIT+0.5);
+                raw->obs.data[n].SNR[j]=snr[j];
                 raw->obs.data[n].LLI[j]=(uint8_t)lli[j];
                 raw->obs.data[n].code[j]=j==0?CODE_L1C:CODE_L2P;
             }
             else {
                 raw->obs.data[n].L[j]=raw->obs.data[n].P[j]=0.0;
-                raw->obs.data[n].D[j]=0.0;
-                raw->obs.data[n].SNR[j]=raw->obs.data[n].LLI[j]=0;
+                raw->obs.data[n].D[j]=raw->obs.data[n].SNR[j]=0.0;
+                raw->obs.data[n].LLI[j]=0;
                 raw->obs.data[n].code[j]=CODE_NONE;
             }
         }
@@ -461,14 +461,14 @@ static int decode_cresgloraw(raw_t *raw)
                 raw->obs.data[n].P[j]=pr[j]==0.0?0.0:pr[j]-toff;
                 raw->obs.data[n].L[j]=cp[j]==0.0?0.0:cp[j]-toff*freq[j]/CLIGHT;
                 raw->obs.data[n].D[j]=-(float)dop[j];
-                raw->obs.data[n].SNR[j]=(uint16_t)(snr[j]/SNR_UNIT+0.5);
+                raw->obs.data[n].SNR[j]=snr[j];
                 raw->obs.data[n].LLI[j]=(uint8_t)lli[j];
                 raw->obs.data[n].code[j]=j==0?CODE_L1C:CODE_L2P;
             }
             else {
                 raw->obs.data[n].L[j]=raw->obs.data[n].P[j]=0.0;
-                raw->obs.data[n].D[j]=0.0;
-                raw->obs.data[n].SNR[j]=raw->obs.data[n].LLI[j]=0;
+                raw->obs.data[n].D[j]=raw->obs.data[n].SNR[j]=0.0;
+                raw->obs.data[n].LLI[j]=0;
                 raw->obs.data[n].code[j]=CODE_NONE;
             }
         }

--- a/src/rcv/javad.c
+++ b/src/rcv/javad.c
@@ -232,8 +232,8 @@ static int flushobuf(raw_t *raw)
         raw->obuf.data[i].time=time0;
         for (j=0;j<NFREQ+NEXOBS;j++) {
             raw->obuf.data[i].L[j]=raw->obuf.data[i].P[j]=0.0;
-            raw->obuf.data[i].D[j]=0.0;
-            raw->obuf.data[i].SNR[j]=raw->obuf.data[i].LLI[j]=0;
+            raw->obuf.data[i].D[j]=raw->obuf.data[i].SNR[j]=0.0;
+            raw->obuf.data[i].LLI[j]=0;
             raw->obuf.data[i].code[j]=CODE_NONE;
         }
     }
@@ -1562,7 +1562,7 @@ static int decode_Ex(raw_t *raw, char sig)
         
         if ((idx=checkpri(sys,code,raw->opt,idx))>=0) {
             if (!settag(raw->obuf.data+i,raw->time)) continue;
-            raw->obuf.data[i].SNR[idx]=(uint16_t)(cnr/SNR_UNIT+0.5);
+            raw->obuf.data[i].SNR[idx]=cnr;
         }
     }
     return 0;
@@ -1593,7 +1593,7 @@ static int decode_xE(raw_t *raw, char sig)
         
         if ((idx=checkpri(sys,code,raw->opt,idx))>=0) {
             if (!settag(raw->obuf.data+i,raw->time)) continue;
-            raw->obuf.data[i].SNR[idx]=(uint16_t)(cnr*0.25/SNR_UNIT+0.5);
+            raw->obuf.data[i].SNR[idx]=cnr*0.25;
         }
     }
     return 0;

--- a/src/rcv/novatel.c
+++ b/src/rcv/novatel.c
@@ -180,8 +180,8 @@ static int obsindex(obs_t *obs, gtime_t time, int sat)
     obs->data[i].sat=sat;
     for (j=0;j<NFREQ+NEXOBS;j++) {
         obs->data[i].L[j]=obs->data[i].P[j]=0.0;
-        obs->data[i].D[j]=0.0;
-        obs->data[i].SNR[j]=obs->data[i].LLI[j]=0;
+        obs->data[i].D[j]=obs->data[i].SNR[j]=0.0;
+        obs->data[i].LLI[j]=0;
         obs->data[i].code[j]=CODE_NONE;
     }
     obs->n++;
@@ -438,7 +438,7 @@ static int decode_rangecmpb(raw_t *raw)
             raw->obs.data[index].L  [idx]=adr;
             raw->obs.data[index].P  [idx]=psr;
             raw->obs.data[index].D  [idx]=(float)dop;
-            raw->obs.data[index].SNR[idx]=(uint16_t)(snr/SNR_UNIT+0.5);
+            raw->obs.data[index].SNR[idx]=snr;
             raw->obs.data[index].LLI[idx]=(uint8_t)lli;
             raw->obs.data[index].code[idx]=(uint8_t)code;
         }
@@ -521,7 +521,7 @@ static int decode_rangeb(raw_t *raw)
             raw->obs.data[index].L  [idx]=-adr;
             raw->obs.data[index].P  [idx]=psr;
             raw->obs.data[index].D  [idx]=(float)dop;
-            raw->obs.data[index].SNR[idx]=(uint16_t)(snr/SNR_UNIT+0.5);
+            raw->obs.data[index].SNR[idx]=snr;
             raw->obs.data[index].LLI[idx]=(uint8_t)lli;
             raw->obs.data[index].code[idx]=(uint8_t)code;
         }
@@ -1113,8 +1113,7 @@ static int decode_rgeb(raw_t *raw)
             raw->obs.data[index].L  [freq]=-adr; /* flip sign */
             raw->obs.data[index].P  [freq]=psr;
             raw->obs.data[index].D  [freq]=(float)dop;
-            raw->obs.data[index].SNR[freq]=
-                0.0<=snr&&snr<255.0?(uint16_t)(snr/SNR_UNIT+0.5):0;
+            raw->obs.data[index].SNR[freq]=0.0<=snr&&snr<255.0?snr:0;
             raw->obs.data[index].LLI[freq]=(uint8_t)lli;
             raw->obs.data[index].code[freq]=freq==0?CODE_L1C:CODE_L2P;
         }
@@ -1179,7 +1178,7 @@ static int decode_rged(raw_t *raw)
             raw->obs.data[index].L  [freq]=adr;
             raw->obs.data[index].P  [freq]=psr;
             raw->obs.data[index].D  [freq]=(float)dop;
-            raw->obs.data[index].SNR[freq]=(uint16_t)(snr/SNR_UNIT+0.5);
+            raw->obs.data[index].SNR[freq]=snr;
             raw->obs.data[index].LLI[freq]=(uint8_t)lli;
             raw->obs.data[index].code[freq]=freq==0?CODE_L1C:CODE_L2P;
         }

--- a/src/rcv/nvs.c
+++ b/src/rcv/nvs.c
@@ -145,7 +145,7 @@ static int decode_xf5raw(raw_t *raw)
                   sat,L1,P1,D1);
             continue;
         }
-        raw->obs.data[n].SNR[0]=(uint16_t)(I1(p+3)/SNR_UNIT+0.5);
+        raw->obs.data[n].SNR[0]=I1(p+3);
         if (sys==SYS_GLO) {
             raw->obs.data[n].L[0]  =  L1 - toff*(FREQ1_GLO+DFRQ1_GLO*carrNo);
         } else {
@@ -164,8 +164,8 @@ static int decode_xf5raw(raw_t *raw)
         
         for (j=1;j<NFREQ+NEXOBS;j++) {
             raw->obs.data[n].L[j]=raw->obs.data[n].P[j]=0.0;
-            raw->obs.data[n].D[j]=0.0;
-            raw->obs.data[n].SNR[j]=raw->obs.data[n].LLI[j]=0;
+            raw->obs.data[n].D[j]=raw->obs.data[n].SNR[j]=0.0;
+            raw->obs.data[n].LLI[j]=0;
             raw->obs.data[n].code[j]=CODE_NONE;
         }
         n++;

--- a/src/rcv/rt17.c
+++ b/src/rcv/rt17.c
@@ -1701,7 +1701,7 @@ static int DecodeType17(raw_t *Raw, uint32_t rif)
             if (Flags1 & M_BIT6) /* L1 data valid */
             {
                 /* Measure of L1 signal strength (dB * 4) */
-                obs->SNR[0] = (uint16_t)(U1(p)*0.25/SNR_UNIT+0.5);
+                obs->SNR[0] = U1(p)*0.25;
                 p++;
                 
                 /* Full L1 C/A code or P-code pseudorange (meters) */
@@ -1721,7 +1721,7 @@ static int DecodeType17(raw_t *Raw, uint32_t rif)
             if (Flags1 & M_BIT0)  /* L2 data loaded */
             {
                 /* Measure of L2 signal strength (dB * 4) */
-                obs->SNR[1] = (uint16_t)(U1(p)*0.25/SNR_UNIT+0.5);
+                obs->SNR[1] = U1(p)*0.25;
                 p++;
                 
                 /* L2 Continuous Phase (cycles) */
@@ -1780,7 +1780,7 @@ static int DecodeType17(raw_t *Raw, uint32_t rif)
             if (Flags1 & M_BIT6) /* L1 data valid */
             {           
                 /* Measure of satellite signal strength (dB) */
-                obs->SNR[0] = (uint16_t)(R8(p)/SNR_UNIT+0.5);
+                obs->SNR[0] = R8(p);
                 p += 8;
 
                 /* Full L1 C/A code or P-code pseudorange (meters) */
@@ -1803,7 +1803,7 @@ static int DecodeType17(raw_t *Raw, uint32_t rif)
             if (Flags1 & M_BIT0) /* L2 data loaded */
             {
                 /* Measure of L2 signal strength (dB) */
-                obs->SNR[1] = (uint16_t)(R8(p)/SNR_UNIT+0.5);
+                obs->SNR[1] = R8(p);
                 p += 8;
 
                 /* L2 Continuous Phase (cycles) */                

--- a/src/rcv/skytraq.c
+++ b/src/rcv/skytraq.c
@@ -270,7 +270,7 @@ static int decode_stqraw(raw_t *raw)
         raw->obs.data[n].P[0]=pr1;
         raw->obs.data[n].L[0]=cp1;
         raw->obs.data[n].D[0]=!(ind&2)?0.0:R4(p+18);
-        raw->obs.data[n].SNR[0]=(uint16_t)(U1(p+1)/SNR_UNIT+0.5);
+        raw->obs.data[n].SNR[0]=U1(p+1);
         raw->obs.data[n].LLI[0]=0;
         raw->obs.data[n].code[0]=sys==SYS_CMP?CODE_L2I:CODE_L1C;
         
@@ -289,8 +289,8 @@ static int decode_stqraw(raw_t *raw)
         
         for (j=1;j<NFREQ+NEXOBS;j++) {
             raw->obs.data[n].L[j]=raw->obs.data[n].P[j]=0.0;
-            raw->obs.data[n].D[j]=0.0;
-            raw->obs.data[n].SNR[j]=raw->obs.data[n].LLI[j]=0;
+            raw->obs.data[n].D[j]=raw->obs.data[n].SNR[j]=0.0;
+            raw->obs.data[n].LLI[j]=0;
             raw->obs.data[n].code[j]=CODE_NONE;
         }
         n++;
@@ -349,8 +349,8 @@ static int decode_stqrawx(raw_t *raw)
             raw->obs.data[n].rcv=0;
             for (k=0;k<NFREQ+NEXOBS;k++) {
                 raw->obs.data[n].L[k]=raw->obs.data[n].P[k]=0.0;
-                raw->obs.data[n].D[k]=0.0;
-                raw->obs.data[n].SNR[k]=raw->obs.data[n].LLI[k]=0;
+                raw->obs.data[n].D[k]=raw->obs.data[n].SNR[k]=0.0;
+                raw->obs.data[n].LLI[k]=0;
                 raw->obs.data[n].code[k]=CODE_NONE;
             }
             n++;
@@ -358,7 +358,7 @@ static int decode_stqrawx(raw_t *raw)
         raw->obs.data[j].P[idx]=pr1;
         raw->obs.data[j].L[idx]=cp1;
         raw->obs.data[j].D[idx]=!(ind&2)?0.0:R4(p+20);
-        raw->obs.data[j].SNR[idx]=(uint16_t)(U1(p+3)/SNR_UNIT+0.5);
+        raw->obs.data[j].SNR[idx]=U1(p+3);
         raw->obs.data[j].LLI[idx]=0;
         raw->obs.data[j].code[idx]=sig;
 

--- a/src/rcv/swiftnav.c
+++ b/src/rcv/swiftnav.c
@@ -396,8 +396,8 @@ static int flushobuf(raw_t *raw) {
     raw->obuf.data[i].time = time0;
     for (j = 0; j < NFREQ + NEXOBS; j++) {
       raw->obuf.data[i].L[j] = raw->obuf.data[i].P[j] = 0.0;
-      raw->obuf.data[i].D[j] = 0.0;
-      raw->obuf.data[i].SNR[j] = raw->obuf.data[i].LLI[j] = 0;
+      raw->obuf.data[i].D[j] = raw->obuf.data[i].SNR[j] = 0.0;
+      raw->obuf.data[i].LLI[j] = 0;
       raw->obuf.data[i].code[j] = CODE_NONE;
     }
   }
@@ -533,7 +533,7 @@ static int decode_msgobs(raw_t *raw) {
       raw->obuf.data[ii].P[freq] = (flags & 0x1) ? pseudorange : 0.0;
       raw->obuf.data[ii].L[freq] = (flags & 0x2) ? carr_phase : 0.0;
       raw->obuf.data[ii].D[freq] = (flags & 0x8) ? (float)freq_doppler : 0.0f;
-      raw->obuf.data[ii].SNR[freq] = (cn0_int*0.25/SNR_UNIT+0.5);
+      raw->obuf.data[ii].SNR[freq] = cn0_int * 0.25;
       raw->obuf.data[ii].code[freq] = code;
 
       if (flags & 0x2) {

--- a/src/rcv/tersus.c
+++ b/src/rcv/tersus.c
@@ -67,8 +67,8 @@ static int obsindex(obs_t *obs, gtime_t time, int sat)
     obs->data[i].sat=sat;
     for (j=0;j<NFREQ+NEXOBS;j++) {
         obs->data[i].L[j]=obs->data[i].P[j]=0.0;
-        obs->data[i].D[j]=0.0;
-        obs->data[i].SNR[j]=obs->data[i].LLI[j]=0;
+        obs->data[i].D[j]=obs->data[i].SNR[j]=0.0;
+        obs->data[i].LLI[j]=0;
         obs->data[i].code[j]=CODE_NONE;
     }
     obs->n++;
@@ -262,8 +262,7 @@ static int decode_rangeb(raw_t *raw)
             raw->obs.data[index].L  [pos]=-adr;
             raw->obs.data[index].P  [pos]=psr;
             raw->obs.data[index].D  [pos]=(float)dop;
-            raw->obs.data[index].SNR[pos]=
-                0.0<=snr&&snr<255.0?(unsigned char)(snr*4.0+0.5):0;
+            raw->obs.data[index].SNR[pos]=0.0<=snr&&snr<255.0?snr:0;
             raw->obs.data[index].LLI[pos]=(unsigned char)lli;
             raw->obs.data[index].code[pos]=code;
         }
@@ -347,8 +346,7 @@ static int decode_rangecmpb(raw_t *raw)
             raw->obs.data[index].L  [pos]=adr;
             raw->obs.data[index].P  [pos]=psr;
             raw->obs.data[index].D  [pos]=(float)dop;
-            raw->obs.data[index].SNR[pos]=
-                0.0<=snr&&snr<255.0?(unsigned char)(snr*4.0+0.5):0;
+            raw->obs.data[index].SNR[pos]=0.0<=snr&&snr<255.0?snr:0;
             raw->obs.data[index].LLI[pos]=(unsigned char)lli;
             raw->obs.data[index].code[pos]=code;
         }

--- a/src/rcv/unicore.c
+++ b/src/rcv/unicore.c
@@ -77,8 +77,9 @@ static int obsindex(obs_t* obs, gtime_t time, int sat)
     obs->data[i].sat = sat;
     for (j = 0; j < NFREQ + NEXOBS; j++) {
         obs->data[i].L[j] = obs->data[i].P[j] = 0.0;
-        obs->data[i].D[j] = 0.0;
-        obs->data[i].SNR[j] = obs->data[i].LLI[j] = 0;
+        obs->data[i].D[j] = obs->data[i].SNR[j] = 0.0;
+        obs->data[i].Lstd[j] = obs->data[i].Pstd[j] = 0.0;
+        obs->data[i].LLI[j] = 0;
         obs->data[i].code[j] = CODE_NONE;
     }
     obs->n++;
@@ -806,25 +807,14 @@ static int decode_obsvmb(raw_t* raw)
             raw->obs.data[index].L[idx] = -adr;
             raw->obs.data[index].P[idx] = psr;
             raw->obs.data[index].D[idx] = (float)dop;
-            raw->obs.data[index].SNR[idx] = (uint16_t)(snr / SNR_UNIT + 0.5);
+            raw->obs.data[index].SNR[idx] = snr;
             raw->obs.data[index].LLI[idx] = (uint8_t)lli;
             raw->obs.data[index].code[idx] = (uint8_t)code;
             if (rcvstds) {
                 double pstd = U2(p + 20) * 0.01;  // Meters
-                // To RTKlib encoding
-                pstd = log2(pstd / 0.01) - 5;
-                pstd = pstd > 0 ? pstd : 0;
-                // Further limited to 9 in RINEX output
-                pstd = pstd <= 254 ? pstd : 254;
-                raw->obs.data[index].Pstd[idx] = pstd + 0.5;
-
+                raw->obs.data[index].Pstd[idx] = pstd;
                 double lstd = U2(p + 22) * 0.0001; // Cycles
-                // To RTKlib encoding
-                lstd = lstd / 0.004;
-                lstd = lstd > 0 ? lstd : 0;
-                // Further limited to 9 in RINEX output
-                lstd = lstd <= 254 ? lstd : 254;
-                raw->obs.data[index].Lstd[idx] = lstd + 0.5;
+                raw->obs.data[index].Lstd[idx] = lstd;
             }
         }
     }

--- a/src/rtcm2.c
+++ b/src/rtcm2.c
@@ -42,8 +42,8 @@ static int obsindex(obs_t *obs, gtime_t time, int sat)
     obs->data[i].sat=sat;
     for (j=0;j<NFREQ;j++) {
         obs->data[i].L[j]=obs->data[i].P[j]=0.0;
-        obs->data[i].D[j]=0.0;
-        obs->data[i].SNR[j]=obs->data[i].LLI[j]=obs->data[i].code[j]=0;
+        obs->data[i].D[j]=obs->data[i].SNR[j]=0.0;
+        obs->data[i].LLI[j]=obs->data[i].code[j]=0;
     }
     obs->n++;
     return i;

--- a/src/rtcm3.c
+++ b/src/rtcm3.c
@@ -215,9 +215,9 @@ static int lossoflock(rtcm_t *rtcm, int sat, int idx, int lock)
     return lli;
 }
 /* S/N ratio -----------------------------------------------------------------*/
-static uint16_t snratio(double snr)
+static double snratio(double snr)
 {
-    return (uint16_t)(snr<=0.0||100.0<=snr?0.0:snr/SNR_UNIT+0.5);
+    return snr<=0.0||100.0<=snr?0.0:snr;
 }
 /* get observation data index ------------------------------------------------*/
 static int obsindex(obs_t *obs, gtime_t time, int sat)
@@ -2097,7 +2097,7 @@ static void save_msm_obs(rtcm_t *rtcm, int sys, msm_h_t *h, const double *r,
                 }
                 rtcm->obs.data[index].LLI[idx[k]]=
                     lossoflock(rtcm,sat,idx[k],lock[j])+(half[j]?2:0);
-                rtcm->obs.data[index].SNR [idx[k]]=(uint16_t)(cnr[j]/SNR_UNIT+0.5);
+                rtcm->obs.data[index].SNR [idx[k]]=cnr[j];
                 rtcm->obs.data[index].code[idx[k]]=code[k];
             }
             j++;

--- a/src/rtcm3e.c
+++ b/src/rtcm3e.c
@@ -281,8 +281,8 @@ static void gen_obs_gps(rtcm_t *rtcm, const obsd_t *data, int *code1, int *pr1,
     
     if (lock1) *lock1=to_lock(lt1);
     if (lock2) *lock2=to_lock(lt2);
-    if (cnr1 ) *cnr1=ROUND(data->SNR[0]*SNR_UNIT/0.25);
-    if (cnr2 ) *cnr2=ROUND(data->SNR[1]*SNR_UNIT/0.25);
+    if (cnr1 ) *cnr1=ROUND(data->SNR[0]/0.25);
+    if (cnr2 ) *cnr2=ROUND(data->SNR[1]/0.25);
     if (code1) *code1=to_code1_gps(data->code[0]);
     if (code2) *code2=to_code2_gps(data->code[1]);
 }
@@ -330,8 +330,8 @@ static void gen_obs_glo(rtcm_t *rtcm, const obsd_t *data, int fcn, int *code1,
     
     if (lock1) *lock1=to_lock(lt1);
     if (lock2) *lock2=to_lock(lt2);
-    if (cnr1 ) *cnr1=ROUND(data->SNR[0]*SNR_UNIT/0.25);
-    if (cnr2 ) *cnr2=ROUND(data->SNR[1]*SNR_UNIT/0.25);
+    if (cnr1 ) *cnr1=ROUND(data->SNR[0]/0.25);
+    if (cnr2 ) *cnr2=ROUND(data->SNR[1]/0.25);
     if (code1) *code1=to_code1_glo(data->code[0]);
     if (code2) *code2=to_code2_glo(data->code[1]);
 }
@@ -2052,7 +2052,7 @@ static void gen_msm_sig(rtcm_t *rtcm, int sys, int nsat, int nsig, int ncell,
             if (rate &&rate_s !=0.0) rate [cell-1]=rate_s;
             if (lock) lock[cell-1]=lt;
             if (half) half[cell-1]=(data->LLI[j]&2)?1:0;
-            if (cnr ) cnr [cell-1]=(float)(data->SNR[j]*SNR_UNIT);
+            if (cnr ) cnr [cell-1]=data->SNR[j];
         }
     }
 }

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -159,8 +159,6 @@ extern "C" {
 #define NEXOBS      0                   /* number of extended obs codes */
 #endif
 
-#define SNR_UNIT    0.001               /* SNR unit (dBHz) */
-
 #define MINPRNGPS   1                   /* min satellite PRN number of GPS */
 #define MAXPRNGPS   32                  /* max satellite PRN number of GPS */
 #define NSATGPS     (MAXPRNGPS-MINPRNGPS+1) /* number of GPS satellites */
@@ -582,19 +580,18 @@ typedef struct {        /* time struct */
 typedef struct {        /* observation data record */
     gtime_t time;       /* receiver sampling time (GPST) */
     uint8_t sat,rcv;    /* satellite/receiver number */
-    uint16_t SNR[NFREQ+NEXOBS]; /* signal strength (0.001 dBHz) */
-    uint8_t  LLI[NFREQ+NEXOBS]; /* loss of lock indicator */
+    uint8_t freq;       /* GLONASS frequency channel (0-13) */
+    uint8_t LLI[NFREQ+NEXOBS]; /* loss of lock indicator */
     uint8_t code[NFREQ+NEXOBS]; /* code indicator (CODE_???) */
     double L[NFREQ+NEXOBS]; /* observation data carrier-phase (cycle) */
     double P[NFREQ+NEXOBS]; /* observation data pseudorange (m) */
-    float  D[NFREQ+NEXOBS]; /* observation data doppler frequency (Hz) */
+    float D[NFREQ+NEXOBS]; /* observation data doppler frequency (Hz) */
+    float SNR[NFREQ+NEXOBS]; /* signal strength (dBHz) */
+    float Lstd[NFREQ+NEXOBS]; /* stdev of carrier phase (cycles)  */
+    float Pstd[NFREQ+NEXOBS]; /* stdev of pseudorange (meters) */
 
     int timevalid;      /* time is valid (Valid GNSS fix) for time mark */
     gtime_t eventime;   /* time of event (GPST) */
-    uint8_t Lstd[NFREQ+NEXOBS]; /* stdev of carrier phase (0.004 cycles)  */
-    uint8_t Pstd[NFREQ+NEXOBS]; /* stdev of pseudorange (0.01*2^(n+5) meters) */
-    uint8_t freq; /* GLONASS frequency channel (0-13) */
-
 } obsd_t;
 
 typedef struct {        /* observation data */
@@ -942,7 +939,7 @@ typedef struct {        /* solution status type */
     float resp;         /* pseudorange residual (m) */
     float resc;         /* carrier-phase residual (m) */
     uint8_t flag;       /* flags: (vsat<<5)+(slip<<3)+fix */
-    uint16_t snr;       /* signal strength (*SNR_UNIT dBHz) */
+    float snr;          /* signal strength (dBHz) */
     uint16_t lock;      /* lock counter */
     uint16_t outc;      /* outage counter */
     uint16_t slipc;     /* slip counter */
@@ -1177,8 +1174,8 @@ typedef struct {        /* satellite status type */
     double resc[NFREQ]; /* residuals of carrier-phase (m) */
     double icbias[NFREQ];  /* glonass IC bias (cycles) */
     uint8_t vsat[NFREQ]; /* valid satellite flag */
-    uint16_t snr_rover [NFREQ]; /* rover signal strength (0.25 dBHz) */
-    uint16_t snr_base  [NFREQ]; /* base signal strength (0.25 dBHz) */
+    float snr_rover [NFREQ]; /* rover signal strength (dBHz) */
+    float snr_base  [NFREQ]; /* base signal strength (dBHz) */
     uint8_t fix [NFREQ]; /* ambiguity fix flag (1:float,2:fix,3:hold) */
     int code[NFREQ][2];  // Current code per frequency index for the base and rover.
     uint8_t slip[NFREQ]; /* cycle-slip flag */

--- a/src/rtksvr.c
+++ b/src/rtksvr.c
@@ -1130,7 +1130,7 @@ extern int rtksvrostat(rtksvr_t *svr, int rcv, gtime_t *time, int *sat,
         az  [i]=svr->rtk.ssat[sat[i]-1].azel[0];
         el  [i]=svr->rtk.ssat[sat[i]-1].azel[1];
         for (j=0;j<NFREQ;j++) {
-            snr[i][j]=(int)(svr->obs[rcv][0].data[i].SNR[j]*SNR_UNIT+0.5);
+            snr[i][j]=(int)(svr->obs[rcv][0].data[i].SNR[j]);
         }
         if (svr->rtk.sol.stat==SOLQ_NONE||svr->rtk.sol.stat==SOLQ_SINGLE) {
             vsat[i]=svr->rtk.ssat[sat[i]-1].vs;

--- a/src/solution.c
+++ b/src/solution.c
@@ -1087,7 +1087,7 @@ static int decode_solstat(char *buff, solstat_t *stat)
     stat->resp =(float)resp;
     stat->resc =(float)resc;
     stat->flag =(uint8_t)((vsat<<5)+(slip<<3)+fix);
-    stat->snr  =(uint16_t)(snr/SNR_UNIT+0.5);
+    stat->snr  =(float)snr;
     stat->lock =(uint16_t)lock;
     stat->outc =(uint16_t)outc;
     stat->slipc=(uint16_t)slipc;
@@ -1432,7 +1432,7 @@ extern int outnmea_gsv(uint8_t *buff, const sol_t *sol, const ssat_t *ssat)
                     else if (sys==SYS_QZS) prn-=192; /* QZS: 01-10 */
                     az =ssat[sats[n]-1].azel[0]*R2D; if (az<0.0) az+=360.0;
                     el =ssat[sats[n]-1].azel[1]*R2D;
-                    snr=ssat[sats[n]-1].snr_rover[0]*SNR_UNIT;
+                    snr=ssat[sats[n]-1].snr_rover[0];
                 p+=sprintf(p,",%02d,%02.0f,%03.0f,%02.0f",prn,el,az,snr);
             }
             else p+=sprintf(p,",,,,");

--- a/src/trace.c
+++ b/src/trace.c
@@ -102,11 +102,11 @@ extern void traceobs_impl(int level, const obsd_t *obs, int n)
         satno2id(obs[i].sat, id);
         fprintf(fp_trace,
                 " (%2d) %s %-3s rcv%d %13.3f %13.3f %13.3f %13.3f %d %d %d %d "
-                "%x %x %3.1f %3.1f\n",
+                "%3.4f %3.3f %3.1f %3.1f\n",
                 i + 1, str, id, obs[i].rcv, obs[i].L[0], obs[i].L[1],
                 obs[i].P[0], obs[i].P[1], obs[i].LLI[0], obs[i].LLI[1],
                 obs[i].code[0], obs[i].code[1], obs[i].Lstd[0], obs[i].Pstd[0],
-                obs[i].SNR[0] * SNR_UNIT, obs[i].SNR[1] * SNR_UNIT);
+                obs[i].SNR[0], obs[i].SNR[1]);
     }
     fflush(fp_trace);
 }

--- a/util/simobs/simobs.c
+++ b/util/simobs/simobs.c
@@ -281,7 +281,7 @@ static int simobs(simopt_t simopt, rnxopt_t rnxopt, nav_t *nav, obs_t *obs) {
 
         data[j].L[m]   = cp/CLIGHT*fk;
         data[j].P[m]   = pr;
-        data[j].SNR[m] = (uint16_t)(snr/SNR_UNIT + 0.5);
+        data[j].SNR[m] = snr;
         data[j].LLI[m] = 0; /* (data[j].SNR[m]<slipthres? 1 : 0); */
 
         m++;


### PR DESCRIPTION
Submitting this PR again as the queue is relatively clear now, and it touches a lot of places that can cause merge conflicts with other changes in the pipeline. This is largely a proposal to make the code more readable and maintainable, to avoid all the inline encoding and decoding, but it also improves the accuracy a little particularly for the P and L std, but at the expense of a little more memory usage (a 4 byte float vs 2 byte encoding).

Store the SNR as a float, rather than a uint16_t, avoiding the scaling and rounding at each access.

The comnav and tersus decoders were not even using the SNR_UNIT for scaling, perhaps another encoding, but assume scaling is not need when stored as a float.

Store the P and L std in the float format. Makes better use of the input format, without lossy compression. Avoids having to do the encoding and decoding to the compressed format at each use.

Implement the compressed encoding in RINEX input and output. Easier to make changes in one location here, and avoids this lossy compression on other paths.

This uses a little extra storage, but if this is an issue then it might be better to abstract a compressed encoding into accessor functions than to have this distributed to each use. The P and L std might be made a compilation option.

ublox: decode_trkmeas is estimating Lstd so have it respect the -RCVSTDS option.

unicore: was not initialising P and L std.