### PR TITLE
winapp rtkconv codeopt: update codes

### DIFF
--- a/app/winapp/rtkconv/codeopt.cpp
+++ b/app/winapp/rtkconv/codeopt.cpp
@@ -28,6 +28,7 @@ void __fastcall TCodeOptDialog::FormShow(TObject *Sender)
 	G06->Checked=mask[0][ 5]=='1';
 	G07->Checked=mask[0][ 6]=='1';
 	G08->Checked=mask[0][ 7]=='1';
+	G12->Checked=mask[0][11]=='1';
 	G14->Checked=mask[0][13]=='1';
 	G15->Checked=mask[0][14]=='1';
 	G16->Checked=mask[0][15]=='1';
@@ -76,8 +77,10 @@ void __fastcall TCodeOptDialog::FormShow(TObject *Sender)
 	J01->Checked=mask[3][ 0]=='1';
 	J07->Checked=mask[3][ 6]=='1';
 	J08->Checked=mask[3][ 7]=='1';
-	J13->Checked=mask[3][12]=='1';
+	J09->Checked=mask[3][ 8]=='1';
+	J11->Checked=mask[3][10]=='1';
 	J12->Checked=mask[3][11]=='1';
+	J13->Checked=mask[3][12]=='1';
 	J16->Checked=mask[3][15]=='1';
 	J17->Checked=mask[3][16]=='1';
 	J18->Checked=mask[3][17]=='1';
@@ -104,8 +107,9 @@ void __fastcall TCodeOptDialog::FormShow(TObject *Sender)
 	C56->Checked=mask[5][55]=='1'; //
 	C02->Checked=mask[5][ 1]=='1'; //
 	C12->Checked=mask[5][11]=='1'; //
-	C10->Checked=mask[5][ 9]=='1'; //
-	C06->Checked=mask[5][ 5]=='1'; //
+	C07->Checked=mask[5][ 6]=='1'; //
+	C08->Checked=mask[5][ 7]=='1'; //
+	C13->Checked=mask[5][12]=='1'; //
 	C57->Checked=mask[5][56]=='1'; //
 	C58->Checked=mask[5][57]=='1'; //
 	C26->Checked=mask[5][25]=='1'; //
@@ -115,7 +119,9 @@ void __fastcall TCodeOptDialog::FormShow(TObject *Sender)
 	C64->Checked=mask[5][63]=='1'; //
 	C65->Checked=mask[5][64]=='1'; //
 	C39->Checked=mask[5][38]=='1'; //
-	C30->Checked=mask[5][29]=='1'; //
+	C69->Checked=mask[5][68]=='1'; //
+	C70->Checked=mask[5][69]=='1'; //
+	C34->Checked=mask[5][33]=='1'; //
 	I49->Checked=mask[6][48]=='1';
 	I50->Checked=mask[6][49]=='1';
 	I51->Checked=mask[6][50]=='1';
@@ -124,6 +130,9 @@ void __fastcall TCodeOptDialog::FormShow(TObject *Sender)
 	I53->Checked=mask[6][52]=='1';
 	I54->Checked=mask[6][53]=='1';
 	I55->Checked=mask[6][54]=='1';
+	I56->Checked=mask[6][55]=='1';
+	I02->Checked=mask[6][1]=='1';
+	I12->Checked=mask[6][11]=='1';
 	S01->Checked=mask[4][ 0]=='1';
 	S24->Checked=mask[4][23]=='1';
 	S25->Checked=mask[4][24]=='1';
@@ -145,6 +154,7 @@ void __fastcall TCodeOptDialog::BtnOkClick(TObject *Sender)
 	if (G06->Checked) mask[0][ 5]='1';
 	if (G07->Checked) mask[0][ 6]='1';
 	if (G08->Checked) mask[0][ 7]='1';
+	if (G12->Checked) mask[0][11]='1';
 	if (G14->Checked) mask[0][13]='1';
 	if (G15->Checked) mask[0][14]='1';
 	if (G16->Checked) mask[0][15]='1';
@@ -193,8 +203,10 @@ void __fastcall TCodeOptDialog::BtnOkClick(TObject *Sender)
 	if (J01->Checked) mask[3][ 0]='1';
 	if (J07->Checked) mask[3][ 6]='1';
 	if (J08->Checked) mask[3][ 7]='1';
-	if (J13->Checked) mask[3][12]='1';
+	if (J09->Checked) mask[3][ 8]='1';
+	if (J11->Checked) mask[3][10]='1';
 	if (J12->Checked) mask[3][11]='1';
+	if (J13->Checked) mask[3][12]='1';
 	if (J16->Checked) mask[3][15]='1';
 	if (J17->Checked) mask[3][16]='1';
 	if (J18->Checked) mask[3][17]='1';
@@ -221,8 +233,9 @@ void __fastcall TCodeOptDialog::BtnOkClick(TObject *Sender)
 	if (C56->Checked) mask[5][55]='1'; //
 	if (C02->Checked) mask[5][ 1]='1'; //
 	if (C12->Checked) mask[5][11]='1'; //
-	if (C10->Checked) mask[5][ 9]='1'; //
-	if (C06->Checked) mask[5][ 5]='1'; //
+	if (C07->Checked) mask[5][ 6]='1'; //
+	if (C08->Checked) mask[5][ 7]='1'; //
+	if (C13->Checked) mask[5][12]='1'; //
 	if (C57->Checked) mask[5][56]='1'; //
 	if (C58->Checked) mask[5][57]='1'; //
 	if (C26->Checked) mask[5][25]='1'; //
@@ -232,7 +245,9 @@ void __fastcall TCodeOptDialog::BtnOkClick(TObject *Sender)
 	if (C64->Checked) mask[5][63]='1'; //
 	if (C65->Checked) mask[5][64]='1'; //
 	if (C39->Checked) mask[5][38]='1'; //
-	if (C30->Checked) mask[5][29]='1'; //
+	if (C69->Checked) mask[5][68]='1'; //
+	if (C70->Checked) mask[5][69]='1'; //
+	if (C34->Checked) mask[5][33]='1'; //
 	if (I49->Checked) mask[6][48]='1';
 	if (I50->Checked) mask[6][49]='1';
 	if (I51->Checked) mask[6][50]='1';
@@ -241,6 +256,9 @@ void __fastcall TCodeOptDialog::BtnOkClick(TObject *Sender)
 	if (I53->Checked) mask[6][52]='1';
 	if (I54->Checked) mask[6][53]='1';
 	if (I55->Checked) mask[6][54]='1';
+	if (I56->Checked) mask[6][55]='1';
+	if (I02->Checked) mask[6][ 1]='1';
+	if (I12->Checked) mask[6][11]='1';
 	if (S01->Checked) mask[4][ 0]='1';
 	if (S24->Checked) mask[4][23]='1';
 	if (S25->Checked) mask[4][24]='1';
@@ -260,6 +278,7 @@ void __fastcall TCodeOptDialog::BtnSetAllClick(TObject *Sender)
 	G06->Checked=set;
 	G07->Checked=set;
 	G08->Checked=set;
+	G12->Checked=set;
 	G14->Checked=set;
 	G15->Checked=set;
 	G16->Checked=set;
@@ -308,8 +327,10 @@ void __fastcall TCodeOptDialog::BtnSetAllClick(TObject *Sender)
 	J01->Checked=set;
 	J07->Checked=set;
 	J08->Checked=set;
-	J13->Checked=set;
+	J09->Checked=set;
+	J11->Checked=set;
 	J12->Checked=set;
+	J13->Checked=set;
 	J16->Checked=set;
 	J17->Checked=set;
 	J18->Checked=set;
@@ -336,8 +357,9 @@ void __fastcall TCodeOptDialog::BtnSetAllClick(TObject *Sender)
 	C56->Checked=set; //
 	C02->Checked=set; //
 	C12->Checked=set; //
-	C10->Checked=set; //
-	C06->Checked=set; //
+	C07->Checked=set; //
+	C08->Checked=set; //
+	C13->Checked=set; //
 	C57->Checked=set; //
 	C58->Checked=set; //
 	C26->Checked=set; //
@@ -347,7 +369,9 @@ void __fastcall TCodeOptDialog::BtnSetAllClick(TObject *Sender)
 	C64->Checked=set; //
 	C65->Checked=set; //
 	C39->Checked=set; //
-	C30->Checked=set; //
+	C69->Checked=set; //
+	C70->Checked=set; //
+	C34->Checked=set; //
 	I49->Checked=set;
 	I50->Checked=set;
 	I51->Checked=set;
@@ -356,6 +380,9 @@ void __fastcall TCodeOptDialog::BtnSetAllClick(TObject *Sender)
 	I53->Checked=set;
 	I54->Checked=set;
 	I55->Checked=set;
+	I56->Checked=set;
+	I02->Checked=set;
+	I12->Checked=set;
 	S01->Checked=set;
 	S24->Checked=set;
 	S25->Checked=set;
@@ -373,6 +400,7 @@ void __fastcall TCodeOptDialog::UpdateEnable(void)
 	G06->Enabled=(NavSys&SYS_GPS)&&(FreqType&FREQTYPE_L1);
 	G07->Enabled=(NavSys&SYS_GPS)&&(FreqType&FREQTYPE_L1);
 	G08->Enabled=(NavSys&SYS_GPS)&&(FreqType&FREQTYPE_L1);
+	G12->Enabled=(NavSys&SYS_GPS)&&(FreqType&FREQTYPE_L1);
 	G14->Enabled=(NavSys&SYS_GPS)&&(FreqType&FREQTYPE_L2);
 	G15->Enabled=(NavSys&SYS_GPS)&&(FreqType&FREQTYPE_L2);
 	G16->Enabled=(NavSys&SYS_GPS)&&(FreqType&FREQTYPE_L2);
@@ -421,8 +449,10 @@ void __fastcall TCodeOptDialog::UpdateEnable(void)
 	J01->Enabled=(NavSys&SYS_QZS)&&(FreqType&FREQTYPE_L1);
 	J07->Enabled=(NavSys&SYS_QZS)&&(FreqType&FREQTYPE_L1);
 	J08->Enabled=(NavSys&SYS_QZS)&&(FreqType&FREQTYPE_L1);
-	J13->Enabled=(NavSys&SYS_QZS)&&(FreqType&FREQTYPE_L1);
+	J09->Enabled=(NavSys&SYS_QZS)&&(FreqType&FREQTYPE_L1);
+	J11->Enabled=(NavSys&SYS_QZS)&&(FreqType&FREQTYPE_L1);
 	J12->Enabled=(NavSys&SYS_QZS)&&(FreqType&FREQTYPE_L1);
+	J13->Enabled=(NavSys&SYS_QZS)&&(FreqType&FREQTYPE_L1);
 	J16->Enabled=(NavSys&SYS_QZS)&&(FreqType&FREQTYPE_L2);
 	J17->Enabled=(NavSys&SYS_QZS)&&(FreqType&FREQTYPE_L2);
 	J18->Enabled=(NavSys&SYS_QZS)&&(FreqType&FREQTYPE_L2);
@@ -449,8 +479,9 @@ void __fastcall TCodeOptDialog::UpdateEnable(void)
 	C56->Enabled=(NavSys&SYS_CMP)&&(FreqType&FREQTYPE_L5); //
 	C02->Enabled=(NavSys&SYS_CMP)&&(FreqType&FREQTYPE_L5); //
 	C12->Enabled=(NavSys&SYS_CMP)&&(FreqType&FREQTYPE_L5); //
-	C10->Enabled=(NavSys&SYS_CMP)&&(FreqType&FREQTYPE_L5); //
-	C06->Enabled=(NavSys&SYS_CMP)&&(FreqType&FREQTYPE_L5); //
+	C07->Enabled=(NavSys&SYS_CMP)&&(FreqType&FREQTYPE_L5); //
+	C08->Enabled=(NavSys&SYS_CMP)&&(FreqType&FREQTYPE_L5); //
+	C13->Enabled=(NavSys&SYS_CMP)&&(FreqType&FREQTYPE_L5); //
 	C57->Enabled=(NavSys&SYS_CMP)&&(FreqType&FREQTYPE_L3); //
 	C58->Enabled=(NavSys&SYS_CMP)&&(FreqType&FREQTYPE_L3); //
 	C26->Enabled=(NavSys&SYS_CMP)&&(FreqType&FREQTYPE_L3); //
@@ -460,7 +491,9 @@ void __fastcall TCodeOptDialog::UpdateEnable(void)
 	C64->Enabled=(NavSys&SYS_CMP)&&(FreqType&FREQTYPE_L6); //
 	C65->Enabled=(NavSys&SYS_CMP)&&(FreqType&FREQTYPE_L6); //
 	C39->Enabled=(NavSys&SYS_CMP)&&(FreqType&FREQTYPE_L6); //
-	C30->Enabled=(NavSys&SYS_CMP)&&(FreqType&FREQTYPE_L4); //
+	C69->Enabled=(NavSys&SYS_CMP)&&(FreqType&FREQTYPE_L4); //
+	C70->Enabled=(NavSys&SYS_CMP)&&(FreqType&FREQTYPE_L4); //
+	C34->Enabled=(NavSys&SYS_CMP)&&(FreqType&FREQTYPE_L4); //
 	I49->Enabled=(NavSys&SYS_IRN)&&(FreqType&FREQTYPE_L1);
 	I50->Enabled=(NavSys&SYS_IRN)&&(FreqType&FREQTYPE_L1);
 	I51->Enabled=(NavSys&SYS_IRN)&&(FreqType&FREQTYPE_L1);
@@ -469,6 +502,9 @@ void __fastcall TCodeOptDialog::UpdateEnable(void)
 	I53->Enabled=(NavSys&SYS_IRN)&&(FreqType&FREQTYPE_L2);
 	I54->Enabled=(NavSys&SYS_IRN)&&(FreqType&FREQTYPE_L2);
 	I55->Enabled=(NavSys&SYS_IRN)&&(FreqType&FREQTYPE_L2);
+	I56->Enabled=(NavSys&SYS_IRN)&&(FreqType&FREQTYPE_L2);
+	I02->Enabled=(NavSys&SYS_IRN)&&(FreqType&FREQTYPE_L3);
+	I12->Enabled=(NavSys&SYS_IRN)&&(FreqType&FREQTYPE_L3);
 	S01->Enabled=(NavSys&SYS_SBS)&&(FreqType&FREQTYPE_L1);
 	S24->Enabled=(NavSys&SYS_SBS)&&(FreqType&FREQTYPE_L3);
 	S25->Enabled=(NavSys&SYS_SBS)&&(FreqType&FREQTYPE_L3);

--- a/app/winapp/rtkconv/codeopt.dfm
+++ b/app/winapp/rtkconv/codeopt.dfm
@@ -4,7 +4,7 @@ object CodeOptDialog: TCodeOptDialog
   BorderStyle = bsDialog
   Caption = 'Signal Mask'
   ClientHeight = 402
-  ClientWidth = 400
+  ClientWidth = 440
   Color = clWhite
   Font.Charset = DEFAULT_CHARSET
   Font.Color = clWindowText
@@ -123,78 +123,6 @@ object CodeOptDialog: TCodeOptDialog
       Caption = '1M'
       TabOrder = 4
     end
-    object G14: TCheckBox
-      Left = 10
-      Top = 33
-      Width = 44
-      Height = 16
-      Caption = '2C'
-      TabOrder = 8
-    end
-    object G15: TCheckBox
-      Left = 48
-      Top = 33
-      Width = 44
-      Height = 16
-      Caption = '2D'
-      TabOrder = 9
-    end
-    object G16: TCheckBox
-      Left = 86
-      Top = 33
-      Width = 44
-      Height = 16
-      Caption = '2S'
-      TabOrder = 10
-    end
-    object G17: TCheckBox
-      Left = 124
-      Top = 33
-      Width = 44
-      Height = 16
-      Caption = '2L'
-      TabOrder = 11
-    end
-    object G18: TCheckBox
-      Left = 162
-      Top = 33
-      Width = 44
-      Height = 16
-      Caption = '2X'
-      TabOrder = 12
-    end
-    object G24: TCheckBox
-      Left = 10
-      Top = 52
-      Width = 44
-      Height = 16
-      Caption = '5I'
-      TabOrder = 18
-    end
-    object G25: TCheckBox
-      Left = 48
-      Top = 52
-      Width = 44
-      Height = 16
-      Caption = '5Q'
-      TabOrder = 19
-    end
-    object G26: TCheckBox
-      Left = 86
-      Top = 52
-      Width = 44
-      Height = 16
-      Caption = '5X'
-      TabOrder = 20
-    end
-    object G19: TCheckBox
-      Left = 200
-      Top = 33
-      Width = 44
-      Height = 16
-      Caption = '2P'
-      TabOrder = 13
-    end
     object G06: TCheckBox
       Left = 200
       Top = 14
@@ -202,14 +130,6 @@ object CodeOptDialog: TCodeOptDialog
       Height = 16
       Caption = '1N'
       TabOrder = 5
-    end
-    object G20: TCheckBox
-      Left = 238
-      Top = 33
-      Width = 44
-      Height = 16
-      Caption = '2W'
-      TabOrder = 14
     end
     object G07: TCheckBox
       Left = 238
@@ -219,22 +139,6 @@ object CodeOptDialog: TCodeOptDialog
       Caption = '1S'
       TabOrder = 6
     end
-    object G21: TCheckBox
-      Left = 276
-      Top = 33
-      Width = 44
-      Height = 16
-      Caption = '2Y'
-      TabOrder = 15
-    end
-    object G22: TCheckBox
-      Left = 314
-      Top = 33
-      Width = 40
-      Height = 16
-      Caption = '2M'
-      TabOrder = 16
-    end
     object G08: TCheckBox
       Left = 276
       Top = 14
@@ -243,13 +147,117 @@ object CodeOptDialog: TCodeOptDialog
       Caption = '1L'
       TabOrder = 7
     end
+    object G12: TCheckBox
+      Left = 314
+      Top = 14
+      Width = 44
+      Height = 16
+      Caption = '1X'
+      TabOrder = 8
+    end
+    object G14: TCheckBox
+      Left = 10
+      Top = 33
+      Width = 44
+      Height = 16
+      Caption = '2C'
+      TabOrder = 9
+    end
+    object G15: TCheckBox
+      Left = 48
+      Top = 33
+      Width = 44
+      Height = 16
+      Caption = '2D'
+      TabOrder = 10
+    end
+    object G16: TCheckBox
+      Left = 86
+      Top = 33
+      Width = 44
+      Height = 16
+      Caption = '2S'
+      TabOrder = 11
+    end
+    object G17: TCheckBox
+      Left = 124
+      Top = 33
+      Width = 44
+      Height = 16
+      Caption = '2L'
+      TabOrder = 12
+    end
+    object G18: TCheckBox
+      Left = 162
+      Top = 33
+      Width = 44
+      Height = 16
+      Caption = '2X'
+      TabOrder = 13
+    end
+    object G19: TCheckBox
+      Left = 200
+      Top = 33
+      Width = 44
+      Height = 16
+      Caption = '2P'
+      TabOrder = 14
+    end
+    object G20: TCheckBox
+      Left = 238
+      Top = 33
+      Width = 44
+      Height = 16
+      Caption = '2W'
+      TabOrder = 15
+    end
+    object G21: TCheckBox
+      Left = 276
+      Top = 33
+      Width = 44
+      Height = 16
+      Caption = '2Y'
+      TabOrder = 16
+    end
+    object G22: TCheckBox
+      Left = 314
+      Top = 33
+      Width = 40
+      Height = 16
+      Caption = '2M'
+      TabOrder = 17
+    end
     object G23: TCheckBox
       Left = 352
       Top = 33
       Width = 35
       Height = 16
       Caption = '2N'
-      TabOrder = 17
+      TabOrder = 18
+    end
+    object G24: TCheckBox
+      Left = 10
+      Top = 52
+      Width = 44
+      Height = 16
+      Caption = '5I'
+      TabOrder = 19
+    end
+    object G25: TCheckBox
+      Left = 48
+      Top = 52
+      Width = 44
+      Height = 16
+      Caption = '5Q'
+      TabOrder = 20
+    end
+    object G26: TCheckBox
+      Left = 86
+      Top = 52
+      Width = 44
+      Height = 16
+      Caption = '5X'
+      TabOrder = 21
     end
   end
   object GroupBox2: TGroupBox
@@ -435,6 +443,46 @@ object CodeOptDialog: TCodeOptDialog
       Caption = '5X'
       TabOrder = 7
     end
+    object E30: TCheckBox
+      Left = 124
+      Top = 33
+      Width = 44
+      Height = 16
+      Caption = '6A'
+      TabOrder = 8
+    end
+    object E31: TCheckBox
+      Left = 162
+      Top = 33
+      Width = 35
+      Height = 16
+      Caption = '6B'
+      TabOrder = 9
+    end
+    object E32: TCheckBox
+      Left = 200
+      Top = 33
+      Width = 44
+      Height = 16
+      Caption = '6C'
+      TabOrder = 10
+    end
+    object E33: TCheckBox
+      Left = 237
+      Top = 33
+      Width = 44
+      Height = 16
+      Caption = '6X'
+      TabOrder = 11
+    end
+    object E34: TCheckBox
+      Left = 276
+      Top = 33
+      Width = 44
+      Height = 16
+      Caption = '6Z'
+      TabOrder = 12
+    end
     object E27: TCheckBox
       Left = 10
       Top = 52
@@ -459,22 +507,6 @@ object CodeOptDialog: TCodeOptDialog
       Caption = '7X'
       TabOrder = 15
     end
-    object E30: TCheckBox
-      Left = 124
-      Top = 33
-      Width = 44
-      Height = 16
-      Caption = '6A'
-      TabOrder = 8
-    end
-    object E31: TCheckBox
-      Left = 162
-      Top = 33
-      Width = 35
-      Height = 16
-      Caption = '6B'
-      TabOrder = 9
-    end
     object E37: TCheckBox
       Left = 124
       Top = 52
@@ -491,14 +523,6 @@ object CodeOptDialog: TCodeOptDialog
       Caption = '8Q'
       TabOrder = 17
     end
-    object E32: TCheckBox
-      Left = 200
-      Top = 33
-      Width = 44
-      Height = 16
-      Caption = '6C'
-      TabOrder = 10
-    end
     object E39: TCheckBox
       Left = 200
       Top = 52
@@ -507,27 +531,11 @@ object CodeOptDialog: TCodeOptDialog
       Caption = '8X'
       TabOrder = 18
     end
-    object E33: TCheckBox
-      Left = 237
-      Top = 33
-      Width = 44
-      Height = 16
-      Caption = '6X'
-      TabOrder = 11
-    end
-    object E34: TCheckBox
-      Left = 276
-      Top = 33
-      Width = 44
-      Height = 16
-      Caption = '6Z'
-      TabOrder = 12
-    end
   end
   object GroupBox4: TGroupBox
     Left = 4
     Top = 199
-    Width = 390
+    Width = 425
     Height = 55
     Caption = 'QZSS'
     TabOrder = 5
@@ -555,14 +563,6 @@ object CodeOptDialog: TCodeOptDialog
       Caption = '1L'
       TabOrder = 2
     end
-    object J13: TCheckBox
-      Left = 162
-      Top = 14
-      Width = 34
-      Height = 16
-      Caption = '1Z'
-      TabOrder = 4
-    end
     object J12: TCheckBox
       Left = 124
       Top = 14
@@ -571,117 +571,141 @@ object CodeOptDialog: TCodeOptDialog
       Caption = '1X'
       TabOrder = 3
     end
-    object J24: TCheckBox
-      Left = 314
+    object J13: TCheckBox
+      Left = 162
       Top = 14
       Width = 34
       Height = 16
-      Caption = '5I'
-      TabOrder = 8
+      Caption = '1Z'
+      TabOrder = 4
     end
-    object J25: TCheckBox
-      Left = 352
-      Top = 14
-      Width = 34
-      Height = 16
-      Caption = '5Q'
-      TabOrder = 9
-    end
-    object J26: TCheckBox
-      Left = 10
-      Top = 33
-      Width = 34
-      Height = 16
-      Caption = '5X'
-      TabOrder = 10
-    end
-    object J35: TCheckBox
-      Left = 161
-      Top = 33
-      Width = 34
-      Height = 16
-      Caption = '6S'
-      TabOrder = 14
-    end
-    object J36: TCheckBox
+    object J09: TCheckBox
       Left = 200
-      Top = 33
+      Top = 14
       Width = 34
       Height = 16
-      Caption = '6L'
-      TabOrder = 15
+      Caption = '1E'
+      TabOrder = 5
+    end
+    object J11: TCheckBox
+      Left = 238
+      Top = 14
+      Width = 34
+      Height = 16
+      Caption = '1B'
+      TabOrder = 6
     end
     object J16: TCheckBox
-      Left = 200
+      Left = 276
       Top = 14
       Width = 34
       Height = 16
       Caption = '2S'
-      TabOrder = 5
+      TabOrder = 7
     end
     object J17: TCheckBox
-      Left = 237
+      Left = 314
       Top = 14
       Width = 34
       Height = 16
       Caption = '2L'
-      TabOrder = 6
+      TabOrder = 8
     end
     object J18: TCheckBox
-      Left = 276
+      Left = 352
       Top = 14
       Width = 34
       Height = 16
       Caption = '2X'
-      TabOrder = 7
+      TabOrder = 9
     end
-    object J33: TCheckBox
-      Left = 237
+    object J24: TCheckBox
+      Left = 10
       Top = 33
       Width = 34
       Height = 16
-      Caption = '6X'
-      TabOrder = 16
+      Caption = '5I'
+      TabOrder = 10
     end
-    object J57: TCheckBox
-      Left = 47
+    object J25: TCheckBox
+      Left = 48
       Top = 33
       Width = 34
       Height = 16
-      Caption = '5D'
+      Caption = '5Q'
       TabOrder = 11
     end
-    object J58: TCheckBox
+    object J26: TCheckBox
       Left = 86
       Top = 33
       Width = 34
       Height = 16
-      Caption = '5P'
+      Caption = '5X'
       TabOrder = 12
     end
-    object J59: TCheckBox
+    object J57: TCheckBox
       Left = 124
       Top = 33
       Width = 34
       Height = 16
-      Caption = '5Z'
+      Caption = '5D'
       TabOrder = 13
     end
-    object J60: TCheckBox
+    object J58: TCheckBox
+      Left = 162
+      Top = 33
+      Width = 34
+      Height = 16
+      Caption = '5P'
+      TabOrder = 14
+    end
+    object J59: TCheckBox
+      Left = 200
+      Top = 33
+      Width = 34
+      Height = 16
+      Caption = '5Z'
+      TabOrder = 15
+    end
+    object J35: TCheckBox
+      Left = 238
+      Top = 33
+      Width = 34
+      Height = 16
+      Caption = '6S'
+      TabOrder = 16
+    end
+    object J36: TCheckBox
       Left = 276
       Top = 33
       Width = 34
       Height = 16
-      Caption = '6E'
+      Caption = '6L'
       TabOrder = 17
     end
-    object J34: TCheckBox
+    object J33: TCheckBox
       Left = 314
       Top = 33
       Width = 34
       Height = 16
-      Caption = '6Z'
+      Caption = '6X'
       TabOrder = 18
+    end
+    object J60: TCheckBox
+      Left = 352
+      Top = 33
+      Width = 34
+      Height = 16
+      Caption = '6E'
+      TabOrder = 19
+    end
+    object J34: TCheckBox
+      Left = 390
+      Top = 33
+      Width = 34
+      Height = 16
+      Caption = '6Z'
+      TabOrder = 20
     end
   end
   object BtnSetAll: TButton
@@ -709,14 +733,23 @@ object CodeOptDialog: TCodeOptDialog
       Enabled = False
       TabOrder = 0
     end
-    object C42: TCheckBox
-      Left = 238
+    object C41: TCheckBox
+      Left = 48
       Top = 15
-      Width = 32
+      Width = 34
       Height = 16
-      Caption = '6I'
+      Caption = '2Q'
       Enabled = False
-      TabOrder = 6
+      TabOrder = 1
+    end
+    object C18: TCheckBox
+      Left = 85
+      Top = 15
+      Width = 34
+      Height = 16
+      Caption = '2X'
+      Enabled = False
+      TabOrder = 2
     end
     object C27: TCheckBox
       Left = 124
@@ -745,23 +778,14 @@ object CodeOptDialog: TCodeOptDialog
       Enabled = False
       TabOrder = 5
     end
-    object C41: TCheckBox
-      Left = 48
+    object C42: TCheckBox
+      Left = 238
       Top = 15
-      Width = 34
+      Width = 32
       Height = 16
-      Caption = '2Q'
+      Caption = '6I'
       Enabled = False
-      TabOrder = 1
-    end
-    object C18: TCheckBox
-      Left = 85
-      Top = 15
-      Width = 34
-      Height = 16
-      Caption = '2X'
-      Enabled = False
-      TabOrder = 2
+      TabOrder = 6
     end
     object C43: TCheckBox
       Left = 276
@@ -808,50 +832,59 @@ object CodeOptDialog: TCodeOptDialog
       Enabled = False
       TabOrder = 11
     end
-    object C10: TCheckBox
+    object C07: TCheckBox
       Left = 124
       Top = 33
       Width = 34
       Height = 16
-      Caption = '1A'
+      Caption = '1S'
       Enabled = False
       TabOrder = 12
     end
-    object C06: TCheckBox
+    object C08: TCheckBox
       Left = 162
       Top = 33
       Width = 44
       Height = 16
-      Caption = '1N'
+      Caption = '1L'
       Enabled = False
       TabOrder = 13
     end
-    object C57: TCheckBox
+    object C13: TCheckBox
       Left = 201
+      Top = 33
+      Width = 34
+      Height = 16
+      Caption = '1Z'
+      Enabled = False
+      TabOrder = 14
+    end
+    object C57: TCheckBox
+      Left = 238
       Top = 33
       Width = 34
       Height = 16
       Caption = '5D'
       Enabled = False
-      TabOrder = 14
+      TabOrder = 15
     end
     object C58: TCheckBox
-      Left = 238
+      Left = 276
       Top = 33
       Width = 32
       Height = 16
       Caption = '5P'
       Enabled = False
-      TabOrder = 15
+      TabOrder = 16
     end
     object C26: TCheckBox
-      Left = 276
+      Left = 314
       Top = 33
       Width = 32
       Height = 16
       Caption = '5X'
       Enabled = False
-      TabOrder = 16
+      TabOrder = 17
     end
     object C61: TCheckBox
       Left = 10
@@ -860,7 +893,7 @@ object CodeOptDialog: TCodeOptDialog
       Height = 16
       Caption = '7D'
       Enabled = False
-      TabOrder = 17
+      TabOrder = 18
     end
     object C62: TCheckBox
       Left = 48
@@ -869,7 +902,7 @@ object CodeOptDialog: TCodeOptDialog
       Height = 16
       Caption = '7P'
       Enabled = False
-      TabOrder = 18
+      TabOrder = 19
     end
     object C63: TCheckBox
       Left = 85
@@ -878,7 +911,7 @@ object CodeOptDialog: TCodeOptDialog
       Height = 16
       Caption = '7Z'
       Enabled = False
-      TabOrder = 19
+      TabOrder = 20
     end
     object C64: TCheckBox
       Left = 124
@@ -887,7 +920,7 @@ object CodeOptDialog: TCodeOptDialog
       Height = 16
       Caption = '8D'
       Enabled = False
-      TabOrder = 20
+      TabOrder = 21
     end
     object C65: TCheckBox
       Left = 162
@@ -896,7 +929,7 @@ object CodeOptDialog: TCodeOptDialog
       Height = 16
       Caption = '8P'
       Enabled = False
-      TabOrder = 21
+      TabOrder = 22
     end
     object C39: TCheckBox
       Left = 201
@@ -905,16 +938,34 @@ object CodeOptDialog: TCodeOptDialog
       Height = 16
       Caption = '8X'
       Enabled = False
-      TabOrder = 22
+      TabOrder = 23
     end
-    object C30: TCheckBox
+    object C69: TCheckBox
       Left = 238
       Top = 52
       Width = 32
       Height = 16
-      Caption = '6A'
+      Caption = '6D'
       Enabled = False
-      TabOrder = 23
+      TabOrder = 24
+    end
+    object C70: TCheckBox
+      Left = 276
+      Top = 52
+      Width = 32
+      Height = 16
+      Caption = '6P'
+      Enabled = False
+      TabOrder = 25
+    end
+    object C34: TCheckBox
+      Left = 314
+      Top = 52
+      Width = 32
+      Height = 16
+      Caption = '6Z'
+      Enabled = False
+      TabOrder = 26
     end
   end
   object GroupBox7: TGroupBox
@@ -933,14 +984,23 @@ object CodeOptDialog: TCodeOptDialog
       Enabled = False
       TabOrder = 0
     end
-    object I54: TCheckBox
-      Left = 238
+    object I50: TCheckBox
+      Left = 48
       Top = 14
-      Width = 32
+      Width = 34
       Height = 16
-      Caption = '9C'
+      Caption = '5B'
       Enabled = False
-      TabOrder = 6
+      TabOrder = 1
+    end
+    object I51: TCheckBox
+      Left = 86
+      Top = 14
+      Width = 34
+      Height = 16
+      Caption = '5C'
+      Enabled = False
+      TabOrder = 2
     end
     object I26: TCheckBox
       Left = 124
@@ -969,23 +1029,14 @@ object CodeOptDialog: TCodeOptDialog
       Enabled = False
       TabOrder = 5
     end
-    object I50: TCheckBox
-      Left = 48
+    object I54: TCheckBox
+      Left = 238
       Top = 14
-      Width = 34
+      Width = 32
       Height = 16
-      Caption = '5B'
+      Caption = '9C'
       Enabled = False
-      TabOrder = 1
-    end
-    object I51: TCheckBox
-      Left = 86
-      Top = 14
-      Width = 34
-      Height = 16
-      Caption = '5C'
-      Enabled = False
-      TabOrder = 2
+      TabOrder = 6
     end
     object I55: TCheckBox
       Left = 276
@@ -995,6 +1046,33 @@ object CodeOptDialog: TCodeOptDialog
       Caption = '9X'
       Enabled = False
       TabOrder = 7
+    end
+    object I56: TCheckBox
+      Left = 314
+      Top = 14
+      Width = 32
+      Height = 16
+      Caption = '1D'
+      Enabled = False
+      TabOrder = 8
+    end
+    object I02: TCheckBox
+      Left = 390
+      Top = 14
+      Width = 32
+      Height = 16
+      Caption = '1P'
+      Enabled = False
+      TabOrder = 9
+    end
+    object I12: TCheckBox
+      Left = 276
+      Top = 14
+      Width = 32
+      Height = 16
+      Caption = '1X'
+      Enabled = False
+      TabOrder = 10
     end
   end
 end

--- a/app/winapp/rtkconv/codeopt.h
+++ b/app/winapp/rtkconv/codeopt.h
@@ -59,8 +59,10 @@ __published:
 	TCheckBox *J01;
 	TCheckBox *J07;
 	TCheckBox *J08;
-	TCheckBox *J13;
+	TCheckBox *J09;
+	TCheckBox *J11;
 	TCheckBox *J12;
+	TCheckBox *J13;
 	TCheckBox *J16;
 	TCheckBox *J17;
 	TCheckBox *J18;
@@ -76,6 +78,7 @@ __published:
 	TCheckBox *J36;
 	TCheckBox *G21;
 	TCheckBox *G08;
+	TCheckBox *G12;
 	TCheckBox *G23;
 	TCheckBox *E34;
 	TButton *BtnSetAll;
@@ -102,6 +105,9 @@ __published:
 	TCheckBox *I50;
 	TCheckBox *I51;
 	TCheckBox *I55;
+	TCheckBox *I56;
+	TCheckBox *I02;
+	TCheckBox *I12;
 	TCheckBox *R66;
 	TCheckBox *R67;
 	TCheckBox *R68;
@@ -116,8 +122,9 @@ __published:
 	TCheckBox *C56;
 	TCheckBox *C02;
 	TCheckBox *C12;
-	TCheckBox *C10;
-	TCheckBox *C06;
+	TCheckBox *C07;
+	TCheckBox *C08;
+	TCheckBox *C13;
 	TCheckBox *C57;
 	TCheckBox *C58;
 	TCheckBox *C26;
@@ -127,7 +134,9 @@ __published:
 	TCheckBox *C64;
 	TCheckBox *C65;
 	TCheckBox *C39;
-	TCheckBox *C30;
+	TCheckBox *C69;
+	TCheckBox *C70;
+	TCheckBox *C34;
 	void __fastcall FormShow(TObject *Sender);
 	void __fastcall BtnOkClick(TObject *Sender);
 	void __fastcall BtnSetAllClick(TObject *Sender);


### PR DESCRIPTION
Updates the codes to parallel the qt app.

GPS was missing code 1X. QZSS was missing codes 1B and 1E. NAVIC was missing codes 1D 1P 1X. BDS had unknown codes 1A 1N 6A, and was missing codes 1S 1L 1Z and 6D 6P 6Z.