### PR TITLE
support tersus bd2ephemb

### DIFF
--- a/src/rcv/tersus.c
+++ b/src/rcv/tersus.c
@@ -570,7 +570,7 @@ static int decode_bdsephemerisb(raw_t *raw)
 /* decode bd2ephemb ----------------------------------------------------------*/
 static int decode_bd2ephemb(raw_t *raw)
 {
-    unsigned char *p=raw->buff+UNICOREHLEN;
+    unsigned char *p=raw->buff+TERSUSHLEN;
     eph_t eph={0};
     char *msg;
     double tow,toc,n,ura,tt;
@@ -578,7 +578,7 @@ static int decode_bd2ephemb(raw_t *raw)
 
     trace(3,"decode_bd2ephemb: len=%d\n",raw->len);
 
-    if (raw->len<UNICOREHLEN+232) {
+    if (raw->len<TERSUSHLEN+232) {
         trace(2,"tersus bd2ephemb length error: len=%d\n",raw->len);
         return -1;
     }

--- a/src/rcv/tersus.c
+++ b/src/rcv/tersus.c
@@ -570,8 +570,86 @@ static int decode_bdsephemerisb(raw_t *raw)
 /* decode bd2ephemb ----------------------------------------------------------*/
 static int decode_bd2ephemb(raw_t *raw)
 {
-    trace(2,"tersus bd2ephemb not supported\n");
-    return 0;
+    unsigned char *p=raw->buff+UNICOREHLEN;
+    eph_t eph={0};
+    char *msg;
+    double tow,toc,n,ura,tt;
+    int prn,week,zweek,iode2,as;
+
+    trace(3,"decode_bd2ephemb: len=%d\n",raw->len);
+
+    if (raw->len<UNICOREHLEN+232) {
+        trace(2,"tersus bd2ephemb length error: len=%d\n",raw->len);
+        return -1;
+    }
+    prn        =U2(p); p+=4;
+
+    if (raw->outtype) {
+        msg=raw->msgtype+strlen(raw->msgtype);
+        sprintf(msg," prn=%3d",prn);
+    }
+
+    if (!(eph.sat=satno(SYS_CMP,prn))) {
+        trace(2,"tersus bd2ephemb prn error: prn=%d\n",prn);
+        return -1;
+    }
+
+    tow        =R8(p); p+=8;
+    eph.svh    =(int)U4(p); p+=4;
+    eph.iode   =(int)U4(p); p+=4;
+    iode2      =(int)U4(p); p+=4;
+    week       =(int)U4(p); p+=4;
+    zweek      =U4(p); p+=4;
+    eph.toes   =R8(p); p+=8;
+    eph.A      =R8(p); p+=8;
+    eph.deln   =R8(p); p+=8;
+    eph.M0     =R8(p); p+=8;
+    eph.e      =R8(p); p+=8;
+    eph.omg    =R8(p); p+=8;
+    eph.cuc    =R8(p); p+=8;
+    eph.cus    =R8(p); p+=8;
+    eph.crc    =R8(p); p+=8;
+    eph.crs    =R8(p); p+=8;
+    eph.cic    =R8(p); p+=8;
+    eph.cis    =R8(p); p+=8;
+    eph.i0     =R8(p); p+=8;
+    eph.idot   =R8(p); p+=8;
+    eph.OMG0   =R8(p); p+=8;
+    eph.OMGd   =R8(p); p+=8;
+    eph.iodc   =(int)U4(p); p+=4;
+    toc        =R8(p); p+=8;
+    eph.tgd[0] =R8(p); p+=8;
+    eph.tgd[1] =R8(p); p+=8;
+    eph.f0     =R8(p); p+=8;
+    eph.f1     =R8(p); p+=8;
+    eph.f2     =R8(p); p+=8;
+    as         =(int)U4(p); p+=4; /* AS-ON */
+    n          =R8(p); p+=8;
+    ura        =R8(p); p+=8;
+
+
+    if (eph.iode!=iode2) {
+        trace(2,"tersus bd2ephemb iode error: iode=%d %d\n",eph.iode,iode2);
+        return -1;
+    }
+    eph.week=adjgpsweek(week);
+    eph.toe=gpst2time(eph.week,eph.toes);
+    tt=timediff(eph.toe,raw->time);
+    if      (tt<-302400.0) eph.week++;
+    else if (tt> 302400.0) eph.week--;
+    eph.toe=gpst2time(eph.week,eph.toes);
+    eph.toc=gpst2time(eph.week,toc);
+    eph.ttr=adjweek(eph.toe,tow);
+    eph.sva=uraindex(ura);
+
+    if (!strstr(raw->opt,"-EPHALL")) {
+        if (timediff(raw->nav.eph[eph.sat-1].toe,eph.toe)==0.0&&
+            raw->nav.eph[eph.sat-1].iode==eph.iode&&
+            raw->nav.eph[eph.sat-1].iodc==eph.iodc) return 0; /* unchanged */
+    }
+    raw->nav.eph[eph.sat-1]=eph;
+    raw->ephsat=eph.sat;
+    return 2;
 }
 /* decode ionutcb ------------------------------------------------------------*/
 static int decode_ionutcb(raw_t *raw)


### PR DESCRIPTION
This PR implements the `decode_bd2ephemb` function in the tersus.c file. The function is designed to decode BD2 ephemeris messages, as specified in Chapter 9.16.3 BD2EPHEM of following handbook (in Chinese)

https://mdmobs.cpuniverse.cn/gitbook/02-%E5%BC%80%E5%8F%91%E8%80%85%E6%8C%87%E5%8D%97/Misc/gnss/unicorecomm/Unicore%20Reference%20Commands%20Manual%20For%20N2%20High%20Precison%20Products_V1_CH_R3.5.pdf