### PR TITLE
Convert some larger stack allocations to heap allocations

### DIFF
--- a/app/qtapp/rtknavi_qt/mondlg.cpp
+++ b/app/qtapp/rtknavi_qt/mondlg.cpp
@@ -401,7 +401,6 @@ void MonitorDialog::setRtk()
 //--------------------------------------------------------)-------------------
 void MonitorDialog::showRtk()
 {
-	rtk_t rtk;
     QString exsats, navsys = "";
     const QString svrstate[] = {tr("Stop"), tr("Run")};
     const QString sol[] = {tr("-"), tr("Fix"), tr("Float"), tr("SBAS"), tr("DGPS"), tr("Single"), tr("PPP"), tr("Dead Reckoning")};
@@ -419,9 +418,12 @@ void MonitorDialog::showRtk()
     const QString tropopt[] = {tr("OFF"), tr("Saastamoinen"), tr("SBAS"), tr("Estimate ZTD"), tr("Estimate ZTD+Grad")};
     const QString ephopt [] = {tr("Broadcast"), tr("Precise"), tr("Broadcast+SBAS"), tr("Broadcast+SSR APC"), tr("Broadcast+SSR CoM"), tr("QZSS LEX")};
 
+    rtk_t *rtk = static_cast<rtk_t *>(malloc(sizeof(rtk_t)));
+    if (rtk == NULL) return;
+
     rtksvrlock(rtksvr); // lock
 
-    rtk = rtksvr->rtk;
+    *rtk = rtksvr->rtk;
     cycle = rtksvr->cycle;
     state = rtksvr->state < 0 || rtksvr->state > 1 ? 0 : rtksvr->state;
     rtkstat = rtksvr->rtk.sol.stat > MAXSOLQ ? 0 : rtksvr->rtk.sol.stat;
@@ -455,23 +457,26 @@ void MonitorDialog::showRtk()
     rtksvrunlock(rtksvr); // unlock
 
     for (j = k = 0; j < MAXSAT; j++) {
-        if (rtk.opt.mode == PMODE_SINGLE && !rtk.ssat[j].vs) continue;
-        if (rtk.opt.mode != PMODE_SINGLE && !rtk.ssat[j].vsat[0]) continue;
-        azel[k * 2] = rtk.ssat[j].azel[0];
-        azel[k * 2 + 1] = rtk.ssat[j].azel[1];
+        if (rtk->opt.mode == PMODE_SINGLE && !rtk->ssat[j].vs) continue;
+        if (rtk->opt.mode != PMODE_SINGLE && !rtk->ssat[j].vsat[0]) continue;
+        azel[k * 2] = rtk->ssat[j].azel[0];
+        azel[k * 2 + 1] = rtk->ssat[j].azel[1];
 		k++;
 	}
     dops(k, azel, 0.0, dop);
 
-    if (rtk.opt.navsys & SYS_GPS) navsys = navsys + tr("GPS ");
-    if (rtk.opt.navsys & SYS_GLO) navsys = navsys + tr("GLONASS ");
-    if (rtk.opt.navsys & SYS_GAL) navsys = navsys + tr("Galileo ");
-    if (rtk.opt.navsys & SYS_QZS) navsys = navsys + tr("QZSS ");
-    if (rtk.opt.navsys & SYS_CMP) navsys = navsys + tr("BDS ");
-    if (rtk.opt.navsys & SYS_IRN) navsys = navsys + tr("NavIC ");
-    if (rtk.opt.navsys & SYS_SBS) navsys = navsys + tr("SBAS ");
+    if (rtk->opt.navsys & SYS_GPS) navsys = navsys + tr("GPS ");
+    if (rtk->opt.navsys & SYS_GLO) navsys = navsys + tr("GLONASS ");
+    if (rtk->opt.navsys & SYS_GAL) navsys = navsys + tr("Galileo ");
+    if (rtk->opt.navsys & SYS_QZS) navsys = navsys + tr("QZSS ");
+    if (rtk->opt.navsys & SYS_CMP) navsys = navsys + tr("BDS ");
+    if (rtk->opt.navsys & SYS_IRN) navsys = navsys + tr("NavIC ");
+    if (rtk->opt.navsys & SYS_SBS) navsys = navsys + tr("SBAS ");
 
-    if (ui->tWConsole->rowCount() < 55) return;
+    if (ui->tWConsole->rowCount() < 55) {
+      free(rtk);
+      return;
+    }
 
     row = 0;
 
@@ -485,49 +490,49 @@ void MonitorDialog::showRtk()
     ui->tWConsole->item(row++, 1)->setText(QString::number(cycle));
 
     ui->tWConsole->item(row,   0)->setText(tr("Positioning Mode"));
-    ui->tWConsole->item(row++, 1)->setText(mode[rtk.opt.mode < 0 || rtk.opt.mode > 9 ? 0 : rtk.opt.mode ]);
+    ui->tWConsole->item(row++, 1)->setText(mode[rtk->opt.mode < 0 || rtk->opt.mode > 9 ? 0 : rtk->opt.mode ]);
 
     ui->tWConsole->item(row,   0)->setText(tr("Frequencies"));
-    ui->tWConsole->item(row++, 1)->setText(freq[rtk.opt.nf > 5 ? 0 : rtk.opt.nf]);
+    ui->tWConsole->item(row++, 1)->setText(freq[rtk->opt.nf > 5 ? 0 : rtk->opt.nf]);
 
     ui->tWConsole->item(row,   0)->setText(tr("Elevation Mask"));
-    ui->tWConsole->item(row++, 1)->setText(QString::number(rtk.opt.elmin * R2D, 'f', 0) + " deg");
+    ui->tWConsole->item(row++, 1)->setText(QString::number(rtk->opt.elmin * R2D, 'f', 0) + " deg");
 
     ui->tWConsole->item(row,   0)->setText(tr("SNR Mask L1 (dBHz)"));
-    ui->tWConsole->item(row++, 1)->setText(!rtk.opt.snrmask.ena[0] ? "" :
+    ui->tWConsole->item(row++, 1)->setText(!rtk->opt.snrmask.ena[0] ? "" :
                               QStringLiteral("%1, %2, %3, %4, %5, %6, %7, %8, %9")
-                              .arg(rtk.opt.snrmask.mask[0][0], 0).arg(rtk.opt.snrmask.mask[0][1], 0).arg(rtk.opt.snrmask.mask[0][2], 0)
-                              .arg(rtk.opt.snrmask.mask[0][3], 0).arg(rtk.opt.snrmask.mask[0][4], 0).arg(rtk.opt.snrmask.mask[0][5], 0)
-                              .arg(rtk.opt.snrmask.mask[0][6], 0).arg(rtk.opt.snrmask.mask[0][7], 0).arg(rtk.opt.snrmask.mask[0][8], 0));
+                              .arg(rtk->opt.snrmask.mask[0][0], 0).arg(rtk->opt.snrmask.mask[0][1], 0).arg(rtk->opt.snrmask.mask[0][2], 0)
+                              .arg(rtk->opt.snrmask.mask[0][3], 0).arg(rtk->opt.snrmask.mask[0][4], 0).arg(rtk->opt.snrmask.mask[0][5], 0)
+                              .arg(rtk->opt.snrmask.mask[0][6], 0).arg(rtk->opt.snrmask.mask[0][7], 0).arg(rtk->opt.snrmask.mask[0][8], 0));
 
     ui->tWConsole->item(row,   0)->setText(tr("SNR Mask L2 (dBHz)"));
-    ui->tWConsole->item(row++, 1)->setText(!rtk.opt.snrmask.ena[0] ? "" :
+    ui->tWConsole->item(row++, 1)->setText(!rtk->opt.snrmask.ena[0] ? "" :
                               QStringLiteral("%1, %2, %3, %4, %5, %6, %7, %8, %9")
-                              .arg(rtk.opt.snrmask.mask[1][0], 0).arg(rtk.opt.snrmask.mask[1][1], 0).arg(rtk.opt.snrmask.mask[1][2], 0)
-                              .arg(rtk.opt.snrmask.mask[1][3], 0).arg(rtk.opt.snrmask.mask[1][4], 0).arg(rtk.opt.snrmask.mask[1][5], 0)
-                              .arg(rtk.opt.snrmask.mask[1][6], 0).arg(rtk.opt.snrmask.mask[1][7], 0).arg(rtk.opt.snrmask.mask[1][8], 0));
+                              .arg(rtk->opt.snrmask.mask[1][0], 0).arg(rtk->opt.snrmask.mask[1][1], 0).arg(rtk->opt.snrmask.mask[1][2], 0)
+                              .arg(rtk->opt.snrmask.mask[1][3], 0).arg(rtk->opt.snrmask.mask[1][4], 0).arg(rtk->opt.snrmask.mask[1][5], 0)
+                              .arg(rtk->opt.snrmask.mask[1][6], 0).arg(rtk->opt.snrmask.mask[1][7], 0).arg(rtk->opt.snrmask.mask[1][8], 0));
 
     ui->tWConsole->item(row,   0)->setText(tr("SNR Mask L5 (dBHz)"));
-    ui->tWConsole->item(row++, 1)->setText(!rtk.opt.snrmask.ena[0] ? "" :
+    ui->tWConsole->item(row++, 1)->setText(!rtk->opt.snrmask.ena[0] ? "" :
                               QStringLiteral("%1, %2, %3, %4, %5, %6, %7, %8, %9")
-                              .arg(rtk.opt.snrmask.mask[2][0], 0).arg(rtk.opt.snrmask.mask[2][1], 0).arg(rtk.opt.snrmask.mask[2][2], 0)
-                              .arg(rtk.opt.snrmask.mask[2][3], 0).arg(rtk.opt.snrmask.mask[2][4], 0).arg(rtk.opt.snrmask.mask[2][5], 0)
-                              .arg(rtk.opt.snrmask.mask[2][6], 0).arg(rtk.opt.snrmask.mask[2][7], 0).arg(rtk.opt.snrmask.mask[2][8], 0));
+                              .arg(rtk->opt.snrmask.mask[2][0], 0).arg(rtk->opt.snrmask.mask[2][1], 0).arg(rtk->opt.snrmask.mask[2][2], 0)
+                              .arg(rtk->opt.snrmask.mask[2][3], 0).arg(rtk->opt.snrmask.mask[2][4], 0).arg(rtk->opt.snrmask.mask[2][5], 0)
+                              .arg(rtk->opt.snrmask.mask[2][6], 0).arg(rtk->opt.snrmask.mask[2][7], 0).arg(rtk->opt.snrmask.mask[2][8], 0));
 
     ui->tWConsole->item(row,   0)->setText(tr("Rec Dynamic/Earth Tides Correction"));
-    ui->tWConsole->item(row++, 1)->setText(QStringLiteral("%1, %2").arg(rtk.opt.dynamics ? tr("ON") : tr("OFF"), rtk.opt.tidecorr ? tr("ON") : tr("OFF")));
+    ui->tWConsole->item(row++, 1)->setText(QStringLiteral("%1, %2").arg(rtk->opt.dynamics ? tr("ON") : tr("OFF"), rtk->opt.tidecorr ? tr("ON") : tr("OFF")));
 
     ui->tWConsole->item(row,   0)->setText(tr("Ionosphere/Troposphere Model"));
-    ui->tWConsole->item(row++, 1)->setText(QStringLiteral("%1, %2").arg(ionoopt[rtk.opt.ionoopt < 0 || rtk.opt.ionoopt > 6 ? 0 : rtk.opt.ionoopt],
-                                                                        tropopt[rtk.opt.tropopt < 0 || rtk.opt.tropopt > 4 ? 0 : rtk.opt.tropopt]));
+    ui->tWConsole->item(row++, 1)->setText(QStringLiteral("%1, %2").arg(ionoopt[rtk->opt.ionoopt < 0 || rtk->opt.ionoopt > 6 ? 0 : rtk->opt.ionoopt],
+                                                                        tropopt[rtk->opt.tropopt < 0 || rtk->opt.tropopt > 4 ? 0 : rtk->opt.tropopt]));
 
     ui->tWConsole->item(row,   0)->setText(tr("Satellite Ephemeris"));
-    ui->tWConsole->item(row++, 1)->setText(ephopt[rtk.opt.sateph < 0 || rtk.opt.sateph > 5 ? 0 : rtk.opt.sateph]);
+    ui->tWConsole->item(row++, 1)->setText(ephopt[rtk->opt.sateph < 0 || rtk->opt.sateph > 5 ? 0 : rtk->opt.sateph]);
 
     for (j = 1; j <= MAXSAT; j++) {
-        if (!rtk.opt.exsats[j - 1]) continue;
+        if (!rtk->opt.exsats[j - 1]) continue;
         satno2id(j, id);
-        if (rtk.opt.exsats[j - 1] == 2) exsats = exsats + "+";
+        if (rtk->opt.exsats[j - 1] == 2) exsats = exsats + "+";
         exsats = exsats + id + " ";
 	}
     ui->tWConsole->item(row,   0)->setText(tr("Excluded Satellites"));
@@ -566,22 +571,22 @@ void MonitorDialog::showRtk()
     ui->tWConsole->item(row,   0)->setText(tr("Solution Status"));
     ui->tWConsole->item(row++, 1)->setText(sol[rtkstat]);
 
-    time2str(rtk.sol.time, tstr, 9);
+    time2str(rtk->sol.time, tstr, 9);
     ui->tWConsole->item(row,   0)->setText(tr("Time of Receiver Clock Rover"));
-    ui->tWConsole->item(row++, 1)->setText(rtk.sol.time.time ? tstr : "-");
+    ui->tWConsole->item(row++, 1)->setText(rtk->sol.time.time ? tstr : "-");
 
     ui->tWConsole->item(row,   0)->setText(tr("Time System Offset/Receiver Bias\n (GLO-GPS, GAL-GPS, BDS-GPS, IRN-GPS, QZS-GPS) (ns)"));
-    ui->tWConsole->item(row++, 1)->setText(QStringLiteral("%1, %2, %3, %4, %5").arg(rtk.sol.dtr[1] * 1E9, 0, 'f', 3).arg(rtk.sol.dtr[2] * 1E9, 0, 'f', 3)
-                                            .arg(rtk.sol.dtr[3] * 1E9, 0, 'f', 3).arg(rtk.sol.dtr[4] * 1E9, 0, 'f', 3).arg(rtk.sol.dtr[5] * 1E9, 0, 'f', 3));
+    ui->tWConsole->item(row++, 1)->setText(QStringLiteral("%1, %2, %3, %4, %5").arg(rtk->sol.dtr[1] * 1E9, 0, 'f', 3).arg(rtk->sol.dtr[2] * 1E9, 0, 'f', 3)
+                                            .arg(rtk->sol.dtr[3] * 1E9, 0, 'f', 3).arg(rtk->sol.dtr[4] * 1E9, 0, 'f', 3).arg(rtk->sol.dtr[5] * 1E9, 0, 'f', 3));
 
     ui->tWConsole->item(row,   0)->setText(tr("Solution Interval"));
-    ui->tWConsole->item(row++, 1)->setText(QString::number(rtk.tt, 'f', 3) + " s");
+    ui->tWConsole->item(row++, 1)->setText(QString::number(rtk->tt, 'f', 3) + " s");
 
     ui->tWConsole->item(row,   0)->setText(tr("Age of Differential"));
-    ui->tWConsole->item(row++, 1)->setText(QString::number(rtk.sol.age, 'f', 3) + " s");
+    ui->tWConsole->item(row++, 1)->setText(QString::number(rtk->sol.age, 'f', 3) + " s");
 
     ui->tWConsole->item(row,   0)->setText(tr("Ratio for AR Validation"));
-    ui->tWConsole->item(row++, 1)->setText(QString::number(rtk.sol.ratio, 'f', 3));
+    ui->tWConsole->item(row++, 1)->setText(QString::number(rtk->sol.ratio, 'f', 3));
 
     ui->tWConsole->item(row,   0)->setText(tr("# of Satellites Rover"));
     ui->tWConsole->item(row++, 1)->setText(QString::number(nsat0));
@@ -590,65 +595,65 @@ void MonitorDialog::showRtk()
     ui->tWConsole->item(row++, 1)->setText(QString::number(nsat1));
 
     ui->tWConsole->item(row,   0)->setText(tr("# of Valid Satellites"));
-    ui->tWConsole->item(row++, 1)->setText(QString::number(rtk.sol.ns));
+    ui->tWConsole->item(row++, 1)->setText(QString::number(rtk->sol.ns));
 
     ui->tWConsole->item(row,   0)->setText(tr("GDOP/PDOP/HDOP/VDOP"));
     ui->tWConsole->item(row++, 1)->setText(QString("%1, %2, %3, %4").arg(dop[0], 0, 'f', 1).arg(dop[1], 0, 'f', 1)
                                             .arg(dop[2], 0, 'f', 1).arg(dop[3], 0, 'f', 1));
 
     ui->tWConsole->item(row,   0)->setText(tr("# of Real Estimated States"));
-    ui->tWConsole->item(row++, 1)->setText(QString::number(rtk.na));
+    ui->tWConsole->item(row++, 1)->setText(QString::number(rtk->na));
 
     ui->tWConsole->item(row,   0)->setText(tr("# of All Estimated States"));
-    ui->tWConsole->item(row++, 1)->setText(QString::number(rtk.nx));
+    ui->tWConsole->item(row++, 1)->setText(QString::number(rtk->nx));
 
     ui->tWConsole->item(row,   0)->setText(tr("Pos X/Y/Z Single (m) Rover"));
-    ui->tWConsole->item(row++, 1)->setText(QStringLiteral("%1, %2, %3").arg(rtk.sol.rr[0], 0, 'f', 3).arg(rtk.sol.rr[1], 0, 'f', 3).arg(rtk.sol.rr[2], 0, 'f', 3));
+    ui->tWConsole->item(row++, 1)->setText(QStringLiteral("%1, %2, %3").arg(rtk->sol.rr[0], 0, 'f', 3).arg(rtk->sol.rr[1], 0, 'f', 3).arg(rtk->sol.rr[2], 0, 'f', 3));
 
-    if (norm(rtk.sol.rr, 3) > 0.0)
-        ecef2pos(rtk.sol.rr, pos);
+    if (norm(rtk->sol.rr, 3) > 0.0)
+        ecef2pos(rtk->sol.rr, pos);
     else
         pos[0] = pos[1] = pos[2] = 0.0;
     ui->tWConsole->item(row,   0)->setText(tr("Lat/Lon/Height Single Rover"));
     ui->tWConsole->item(row++, 1)->setText(QStringLiteral("%1 deg, %2 deg, %3 m").arg(pos[0] * R2D, 0, 'f', 8).arg(pos[1] * R2D, 0, 'f', 8).arg(pos[2], 0, 'f', 3));
 
-    ecef2enu(pos, rtk.sol.rr + 3, vel);
+    ecef2enu(pos, rtk->sol.rr + 3, vel);
     ui->tWConsole->item(row,   0)->setText(tr("Vel E/N/U (m/s) Rover"));
     ui->tWConsole->item(row++, 1)->setText(QStringLiteral("%1 m/s, %2 m/s, %3 m/s").arg(vel[0], 0, 'f', 3).arg(vel[1], 0, 'f', 3).arg(vel[2], 0, 'f', 3));
 
     ui->tWConsole->item(row,   0)->setText(tr("Pos X/Y/Z Float Rover"));
     ui->tWConsole->item(row++, 1)->setText(QStringLiteral("%1 m, %2 m, %3 m")
-                              .arg(rtk.x ? rtk.x[0] : 0, 0, 'f', 3).arg(rtk.x ? rtk.x[1] : 0, 0, 'f', 3).arg(rtk.x ? rtk.x[2] : 0, 0, 'f', 3));
+                              .arg(rtk->x ? rtk->x[0] : 0, 0, 'f', 3).arg(rtk->x ? rtk->x[1] : 0, 0, 'f', 3).arg(rtk->x ? rtk->x[2] : 0, 0, 'f', 3));
 
     ui->tWConsole->item(row,   0)->setText(tr("Pos X/Y/Z Float Std Rover"));
     ui->tWConsole->item(row++, 1)->setText(QString("%1 m, %2 m, %3 m")
-                              .arg(rtk.P ? SQRT(rtk.P[0]) : 0, 0, 'f', 3).arg(rtk.P ? SQRT(rtk.P[1 + 1 * rtk.nx]) : 0, 0, 'f', 3).arg(rtk.P ? SQRT(rtk.P[2 + 2 * rtk.nx]) : 0, 0, 'f', 3));
+                              .arg(rtk->P ? SQRT(rtk->P[0]) : 0, 0, 'f', 3).arg(rtk->P ? SQRT(rtk->P[1 + 1 * rtk->nx]) : 0, 0, 'f', 3).arg(rtk->P ? SQRT(rtk->P[2 + 2 * rtk->nx]) : 0, 0, 'f', 3));
 
     ui->tWConsole->item(row,   0)->setText(tr("Pos X/Y/Z Fixed Rover"));
     ui->tWConsole->item(row++, 1)->setText(QStringLiteral("%1 m, %2 m, %3 m")
-                              .arg(rtk.xa ? rtk.xa[0] : 0, 0, 'f', 3).arg(rtk.xa ? rtk.xa[1] : 0, 0, 'f', 3).arg(rtk.xa ? rtk.xa[2] : 0, 0, 'f', 3));
+                              .arg(rtk->xa ? rtk->xa[0] : 0, 0, 'f', 3).arg(rtk->xa ? rtk->xa[1] : 0, 0, 'f', 3).arg(rtk->xa ? rtk->xa[2] : 0, 0, 'f', 3));
 
     ui->tWConsole->item(row,   0)->setText(tr("Pos X/Y/Z Fixed Std Rover"));
     ui->tWConsole->item(row++, 1)->setText(QStringLiteral("%1 m, %2 m, %3 m")
-                              .arg(rtk.Pa ? SQRT(rtk.Pa[0]) : 0, 0, 'f', 3).arg(rtk.Pa ? SQRT(rtk.Pa[1 + 1 * rtk.na]) : 0, 0, 'f', 3).arg(rtk.Pa ? SQRT(rtk.Pa[2 + 2 * rtk.na]) : 0, 0, 'f', 3));
+                              .arg(rtk->Pa ? SQRT(rtk->Pa[0]) : 0, 0, 'f', 3).arg(rtk->Pa ? SQRT(rtk->Pa[1 + 1 * rtk->na]) : 0, 0, 'f', 3).arg(rtk->Pa ? SQRT(rtk->Pa[2 + 2 * rtk->na]) : 0, 0, 'f', 3));
 
     ui->tWConsole->item(row,   0)->setText(tr("Pos X/Y/Z Base Station"));
-    ui->tWConsole->item(row++, 1)->setText(QStringLiteral("%1 m, %2 m, %3 m").arg(rtk.rb[0], 0, 'f', 3).arg(rtk.rb[1], 0, 'f', 3).arg(rtk.rb[2], 0, 'f', 3));
+    ui->tWConsole->item(row++, 1)->setText(QStringLiteral("%1 m, %2 m, %3 m").arg(rtk->rb[0], 0, 'f', 3).arg(rtk->rb[1], 0, 'f', 3).arg(rtk->rb[2], 0, 'f', 3));
 
-    if (norm(rtk.rb, 3) > 0.0)
-        ecef2pos(rtk.rb, pos);
+    if (norm(rtk->rb, 3) > 0.0)
+        ecef2pos(rtk->rb, pos);
     else
         pos[0] = pos[1] = pos[2] = 0.0;
     ui->tWConsole->item(row,   0)->setText(tr("Lat/Lon/Height Base Station"));
     ui->tWConsole->item(row++, 1)->setText(QStringLiteral("%1 deg, %2 deg, %3 m").arg(pos[0] * R2D, 0, 'f', 8).arg(pos[1] * R2D, 0, 'f', 8).arg(pos[2], 0, 'f', 3));
 
-    ecef2enu(pos, rtk.rb + 3, vel);
+    ecef2enu(pos, rtk->rb + 3, vel);
     ui->tWConsole->item(row,   0)->setText(tr("Vel E/N/U Base Station"));
     ui->tWConsole->item(row++, 1)->setText(QStringLiteral("%1 m/s, %2 m/s, %3 m/s").arg(vel[0], 0, 'f', 3).arg(vel[1], 0, 'f', 3).arg(vel[2], 0, 'f', 3));
 
-    if (norm(rtk.rb,3)>0.0) {
+    if (norm(rtk->rb,3)>0.0) {
         for (k = 0; k < 3; k++)
-            rr[k] = rtk.sol.rr[k] - rtk.rb[k];
+            rr[k] = rtk->sol.rr[k] - rtk->rb[k];
         ecef2enu(pos,rr,enu);
     }
     ui->tWConsole->item(row,   0)->setText(tr("Baseline Length/E/N/U Rover-Base Station"));
@@ -658,28 +663,28 @@ void MonitorDialog::showRtk()
     ui->tWConsole->item(row++, 1)->setText(QString::number(nave));
 
     ui->tWConsole->item(row,   0)->setText(tr("Antenna Type Rover"));
-    ui->tWConsole->item(row++, 1)->setText(rtk.opt.pcvr[0].type);
+    ui->tWConsole->item(row++, 1)->setText(rtk->opt.pcvr[0].type);
 
     for (j = 0; j < NFREQ; j++) {
-        off = rtk.opt.pcvr[0].off[j];
+        off = rtk->opt.pcvr[0].off[j];
         ui->tWConsole->item(row,   0)->setText(tr("Antenna Phase Center L%1 E/N/U Rover").arg(j+1));
         ui->tWConsole->item(row++, 1)->setText(QStringLiteral("%1 m, %2 m, %3 m").arg(off[0], 0, 'f', 3).arg(off[1], 0, 'f', 3).arg(off[2], 0, 'f', 3));
     }
 
-    del = rtk.opt.antdel[0];
+    del = rtk->opt.antdel[0];
     ui->tWConsole->item(row,   0)->setText(tr("Antenna Delta E/N/U Rover"));
     ui->tWConsole->item(row++, 1)->setText(QStringLiteral("%1 m, %2 m, %3 m").arg(del[0], 0, 'f', 3).arg(del[1], 0, 'f', 3).arg(del[2], 0, 'f', 3));
 
     ui->tWConsole->item(row,   0)->setText(tr("Antenna Type Base Station"));
-    ui->tWConsole->item(row++, 1)->setText(rtk.opt.pcvr[1].type);
+    ui->tWConsole->item(row++, 1)->setText(rtk->opt.pcvr[1].type);
 
     for (j = 0; j < NFREQ; j++) {
-        off = rtk.opt.pcvr[1].off[0];
+        off = rtk->opt.pcvr[1].off[0];
         ui->tWConsole->item(row,   0)->setText(tr("Antenna Phase Center L%1 E/N/U Base Station").arg(j+1));
         ui->tWConsole->item(row++, 1)->setText(QStringLiteral("%1 m, %2 m, %3 m").arg(off[0], 0, 'f', 3).arg(off[1], 0, 'f', 3).arg(off[2], 0, 'f', 3));
     }
 
-    del = rtk.opt.antdel[1];
+    del = rtk->opt.antdel[1];
     ui->tWConsole->item(row,   0)->setText(tr("Antenna Delta E/N/U Base Station"));
     ui->tWConsole->item(row++, 1)->setText(QStringLiteral("%1 m, %2 m, %3 m").arg(del[0], 0, 'f', 3).arg(del[1], 0, 'f', 3).arg(del[2], 0, 'f', 3));
 
@@ -691,6 +696,7 @@ void MonitorDialog::showRtk()
 
     ui->tWConsole->item(row,   0)->setText(tr("Precise Ephemeris Download File"));
     ui->tWConsole->item(row++, 1)->setText(file);
+    free(rtk);
 }
 //---------------------------------------------------------------------------
 void MonitorDialog::setSat()
@@ -758,15 +764,17 @@ void MonitorDialog::setSat()
 //---------------------------------------------------------------------------
 void MonitorDialog::showSat()
 {
-	rtk_t rtk;
 	ssat_t *ssat;
     int i, j, k, n, nsat, fix, nfreq, sys = sys_tbl[ui->cBSelectNavigationSystems->currentIndex()];
     int vsat[MAXSAT] = {0};
 	char id[8];
     double az, el, cbias[MAXSAT][2];
 
+    rtk_t *rtk = static_cast<rtk_t *>(malloc(sizeof(rtk_t)));
+    if (rtk == NULL) return;
+
     rtksvrlock(rtksvr);
-    rtk = rtksvr->rtk;
+    *rtk = rtksvr->rtk;
 
     for (i = 0; i < MAXSAT; i++)
     {
@@ -777,7 +785,7 @@ void MonitorDialog::showSat()
     rtksvrunlock(rtksvr);
 
     for (i = 0; i < MAXSAT; i++) {
-        ssat = rtk.ssat + i;
+        ssat = rtk->ssat + i;
         vsat[i] = ssat->vs;
     }
 
@@ -789,6 +797,7 @@ void MonitorDialog::showSat()
 
     if (nsat < 1) {
         ui->tWConsole->setRowCount(0);
+        free(rtk);
 		return;
 	}
     if (ui->tWConsole->rowCount() != nsat) {
@@ -801,7 +810,7 @@ void MonitorDialog::showSat()
     for (i = 0, n = 0; i < MAXSAT; i++) {
         if (!(satsys(i + 1, NULL) & sys)) continue;
         j = 0;
-        ssat = rtk.ssat + i;
+        ssat = rtk->ssat + i;
         if (ui->cBSelectSatellites->currentIndex() == 1 && !vsat[i]) continue;
         satno2id(i + 1, id);
         ui->tWConsole->item(n, j++)->setText(id);
@@ -835,6 +844,7 @@ void MonitorDialog::showSat()
         ui->tWConsole->item(n, j++)->setText(QString::number(0, 'f', 2));
 		n++;
 	}
+    free(rtk);
 }
 //---------------------------------------------------------------------------
 void MonitorDialog::setEstimates()
@@ -1037,10 +1047,15 @@ void MonitorDialog::setObservations()
 //---------------------------------------------------------------------------
 void MonitorDialog::showObservations()
 {
-    obsd_t obs[MAXOBS * 2];
     char tstr[40], id[8], *code;
     int i, k, n = 0, nex = ui->cBSelectObservation->currentIndex() ? NEXOBS : 0;
     int sys = sys_tbl[ui->cBSelectNavigationSystems->currentIndex()];
+
+    obsd_t *obs = static_cast<obsd_t *>(calloc(MAXOBS * 2, sizeof(obsd_t)));
+    if (obs == NULL) {
+      trace(1, "MonitorDialog::showObservations obsd_t alloc failed\n");
+      return;
+    }
 
     rtksvrlock(rtksvr);
     for (i = 0; i < rtksvr->obs[0][0].n && n < MAXOBS * 2; i++) {
@@ -1055,6 +1070,7 @@ void MonitorDialog::showObservations()
 
     if (n < 1) {
         ui->tWConsole->setRowCount(0);
+        free(obs);
         return;
     }
     if (ui->tWConsole->rowCount() != n) {
@@ -1089,6 +1105,7 @@ void MonitorDialog::showObservations()
         for (k = 0; k < NFREQ + nex; k++)
             ui->tWConsole->item(i, j++)->setText(QString::number(obs[i].LLI[k]));
 	}
+        free(obs);
 }
 //---------------------------------------------------------------------------
 void MonitorDialog::setNavigationGPS()

--- a/app/qtapp/rtkplot_qt/plotdata.cpp
+++ b/app/qtapp/rtkplot_qt/plotdata.cpp
@@ -153,7 +153,6 @@ void Plot::readSolutionStat(const QStringList &files, int sel)
 void Plot::readObservation(const QStringList &files)
 {
     obs_t obs = {};
-    nav_t nav = {};
     sta_t sta = {};
     int nobs;
 
@@ -166,14 +165,22 @@ void Plot::readObservation(const QStringList &files)
     readWaitStart();
     showLegend(QStringList());
 
-    if ((nobs = readObservationRinex(files, &obs, &nav, &sta)) <= 0) {
+    nav_t *nav = static_cast<nav_t *>(calloc(1, sizeof(nav_t)));
+    if (nav == NULL) {
+      trace(1, "Plot::readObservation nav alloc failed\n");
+      return;
+    }
+
+    if ((nobs = readObservationRinex(files, &obs, nav, &sta)) <= 0) {
         readWaitEnd();
+        free(nav);
         return;
     }
     clearObservation();
 
     observation = obs;
-    navigation = nav;
+    navigation = *nav;
+    free(nav);
     station = sta;
     simulatedObservation = 0;
 

--- a/app/qtapp/rtkplot_qt/plotmain.cpp
+++ b/app/qtapp/rtkplot_qt/plotmain.cpp
@@ -106,7 +106,6 @@ Plot::Plot(QWidget *parent) : QMainWindow(parent), ui(new Ui::Plot)
     setlocale(LC_NUMERIC, "C"); // use point as decimal separator in formatted output
 
     gtime_t t0 = {0, 0};
-    nav_t nav0 = {};
     obs_t obs0 = {};
     sta_t sta0 = {};
     gis_t gis0 = {};
@@ -134,13 +133,10 @@ Plot::Plot(QWidget *parent) : QMainWindow(parent), ui(new Ui::Plot)
     }
 
     obs0.data = NULL; obs0.n = obs0.nmax = 0;
-    nav0.eph = NULL; nav0.n = nav0.nmax = 0;
-    nav0.geph = NULL; nav0.ng = nav0.ngmax = 0;
-    nav0.seph = NULL; nav0.ns = nav0.nsmax = 0;
 
     observationIndex = 0;
     observation = obs0;
-    navigation = nav0;
+    memset(&navigation, 0, sizeof(navigation));
     station = sta0;
     gis = gis0;
     simulatedObservation = 0;

--- a/app/winapp/appcmn/glofcndlg.cpp
+++ b/app/winapp/appcmn/glofcndlg.cpp
@@ -51,21 +51,29 @@ void __fastcall TGloFcnDialog::BtnOkClick(TObject *Sender)
 //---------------------------------------------------------------------------
 void __fastcall TGloFcnDialog::BtnReadClick(TObject *Sender)
 {
-	AnsiString file,text;
-	nav_t nav={0};
-	int prn;
+        if (!OpenDialog->Execute()) return;
+	
+        nav_t *nav = static_cast<nav_t *>(calloc(1, sizeof(nav_t)));
+        if (nav == NULL) {
+          trace(1, "TGloFcnDialog::BtnReadClick nav alloc failed\n");
+          return;
+        }
 
-    if (!OpenDialog->Execute()) return;
-	
-	file=OpenDialog->FileName;
+        AnsiString file=OpenDialog->FileName;
     
-	if (!readrnx(file.c_str(),0,"",NULL,&nav,NULL)) return;
+	if (!readrnx(file.c_str(),0,"",NULL,nav,NULL)) {
+          free(nav);
+          return;
+        }
 	
-	for (int i=0;i<nav.ng;i++) {
-		if (satsys(nav.geph[i].sat,&prn)!=SYS_GLO) continue;
-        GetFcn(prn)->Text=text.sprintf("%d",nav.geph[i].frq);
+	for (int i=0;i<nav->ng;i++) {
+          int prn;
+          if (satsys(nav->geph[i].sat,&prn)!=SYS_GLO) continue;
+          AnsiString text;
+          GetFcn(prn)->Text=text.sprintf("%d",nav->geph[i].frq);
 	}
-	freenav(&nav,0xFF);
+	freenav(nav,0xFF);
+        free(nav);
 }
 //---------------------------------------------------------------------------
 void __fastcall TGloFcnDialog::BtnClearClick(TObject *Sender)

--- a/app/winapp/rtknavi/mondlg.cpp
+++ b/app/winapp/rtknavi/mondlg.cpp
@@ -354,7 +354,6 @@ void __fastcall TMonitorDialog::SetRtk(void)
 //---------------------------------------------------------------------------
 void __fastcall TMonitorDialog::ShowRtk(void)
 {
-	rtk_t rtk;
 	AnsiString s,exsats,navsys="";
 	AnsiString svrstate[]={"Stop","Run"};
 	AnsiString sol[]={"-","Fix","Float","SBAS","DGPS","Single","PPP",""};
@@ -371,9 +370,12 @@ void __fastcall TMonitorDialog::ShowRtk(void)
 	const char *tropopt[]={"OFF","Saastamoinen","SBAS","Estimate ZTD","Estimate ZTD+Grad",""};
 	const char *ephopt []={"Broadcast","Precise","Broadcast+SBAS","Broadcat+SSR APC","Broadcast+SSR CoM","QZSS LEX",""};
 	
+        rtk_t *rtk = static_cast<rtk_t *>(malloc(sizeof(rtk_t)));
+        if (rtk == NULL) return;
+
 	rtksvrlock(&rtksvr); // lock
 	
-	rtk=rtksvr.rtk;
+	*rtk=rtksvr.rtk;
 	thread=(int)rtksvr.thread;
 	cycle=rtksvr.cycle;
 	state=rtksvr.state;
@@ -402,21 +404,21 @@ void __fastcall TMonitorDialog::ShowRtk(void)
 	rtksvrunlock(&rtksvr); // unlock
 	
 	for (j=k=0;j<MAXSAT;j++) {
-		if (rtk.opt.mode==PMODE_SINGLE&&!rtk.ssat[j].vs) continue;
-		if (rtk.opt.mode!=PMODE_SINGLE&&!rtk.ssat[j].vsat[0]) continue;
-		azel[  k*2]=rtk.ssat[j].azel[0];
-		azel[1+k*2]=rtk.ssat[j].azel[1];
+		if (rtk->opt.mode==PMODE_SINGLE&&!rtk->ssat[j].vs) continue;
+		if (rtk->opt.mode!=PMODE_SINGLE&&!rtk->ssat[j].vsat[0]) continue;
+		azel[  k*2]=rtk->ssat[j].azel[0];
+		azel[1+k*2]=rtk->ssat[j].azel[1];
 		k++;
 	}
 	dops(k,azel,0.0,dop);
 	
-	if (rtk.opt.navsys&SYS_GPS) navsys=navsys+"GPS ";
-	if (rtk.opt.navsys&SYS_GLO) navsys=navsys+"GLONASS ";
-	if (rtk.opt.navsys&SYS_GAL) navsys=navsys+"Galileo ";
-	if (rtk.opt.navsys&SYS_QZS) navsys=navsys+"QZSS ";
-	if (rtk.opt.navsys&SYS_CMP) navsys=navsys+"BDS ";
-	if (rtk.opt.navsys&SYS_IRN) navsys=navsys+"NavIC ";
-	if (rtk.opt.navsys&SYS_SBS) navsys=navsys+"SBAS ";
+	if (rtk->opt.navsys&SYS_GPS) navsys=navsys+"GPS ";
+	if (rtk->opt.navsys&SYS_GLO) navsys=navsys+"GLONASS ";
+	if (rtk->opt.navsys&SYS_GAL) navsys=navsys+"Galileo ";
+	if (rtk->opt.navsys&SYS_QZS) navsys=navsys+"QZSS ";
+	if (rtk->opt.navsys&SYS_CMP) navsys=navsys+"BDS ";
+	if (rtk->opt.navsys&SYS_IRN) navsys=navsys+"NavIC ";
+	if (rtk->opt.navsys&SYS_SBS) navsys=navsys+"SBAS ";
 	
 	Label->Caption="";
 	Tbl->RowCount=54+NFREQ*2;
@@ -435,54 +437,54 @@ void __fastcall TMonitorDialog::ShowRtk(void)
 	Tbl->Cells[1][i++]=s.sprintf("%d",cycle);
 	
 	Tbl->Cells[0][i  ]="Positioning Mode";
-	Tbl->Cells[1][i++]=mode[rtk.opt.mode];
+	Tbl->Cells[1][i++]=mode[rtk->opt.mode];
 	
 	Tbl->Cells[0][i  ]="Frequencies";
-	Tbl->Cells[1][i++]=freq[rtk.opt.nf];
+	Tbl->Cells[1][i++]=freq[rtk->opt.nf];
 	
 	Tbl->Cells[0][i  ]="Elevation Mask (deg)";
-	Tbl->Cells[1][i++]=s.sprintf("%.0f",rtk.opt.elmin*R2D);
+	Tbl->Cells[1][i++]=s.sprintf("%.0f",rtk->opt.elmin*R2D);
 	
 	Tbl->Cells[0][i  ]="SNR Mask L1 (dBHz)";
-	Tbl->Cells[1][i++]=!rtk.opt.snrmask.ena[0]?s.sprintf(""):
+	Tbl->Cells[1][i++]=!rtk->opt.snrmask.ena[0]?s.sprintf(""):
 		s.sprintf("%.0f, %.0f, %.0f, %.0f, %.0f, %.0f, %.0f, %.0f, %.0f",
-				  rtk.opt.snrmask.mask[0][0],rtk.opt.snrmask.mask[0][1],rtk.opt.snrmask.mask[0][2],
-				  rtk.opt.snrmask.mask[0][3],rtk.opt.snrmask.mask[0][4],rtk.opt.snrmask.mask[0][5],
-				  rtk.opt.snrmask.mask[0][6],rtk.opt.snrmask.mask[0][7],rtk.opt.snrmask.mask[0][8]);
+				  rtk->opt.snrmask.mask[0][0],rtk->opt.snrmask.mask[0][1],rtk->opt.snrmask.mask[0][2],
+				  rtk->opt.snrmask.mask[0][3],rtk->opt.snrmask.mask[0][4],rtk->opt.snrmask.mask[0][5],
+				  rtk->opt.snrmask.mask[0][6],rtk->opt.snrmask.mask[0][7],rtk->opt.snrmask.mask[0][8]);
 	
 	Tbl->Cells[0][i  ]="SNR Mask L2 (dBHz)";
-	Tbl->Cells[1][i++]=!rtk.opt.snrmask.ena[0]?s.sprintf(""):
+	Tbl->Cells[1][i++]=!rtk->opt.snrmask.ena[0]?s.sprintf(""):
 		s.sprintf("%.0f, %.0f, %.0f, %.0f, %.0f, %.0f, %.0f, %.0f, %.0f",
-				  rtk.opt.snrmask.mask[1][0],rtk.opt.snrmask.mask[1][1],rtk.opt.snrmask.mask[1][2],
-				  rtk.opt.snrmask.mask[1][3],rtk.opt.snrmask.mask[1][4],rtk.opt.snrmask.mask[1][5],
-				  rtk.opt.snrmask.mask[1][6],rtk.opt.snrmask.mask[1][7],rtk.opt.snrmask.mask[1][8]);
+				  rtk->opt.snrmask.mask[1][0],rtk->opt.snrmask.mask[1][1],rtk->opt.snrmask.mask[1][2],
+				  rtk->opt.snrmask.mask[1][3],rtk->opt.snrmask.mask[1][4],rtk->opt.snrmask.mask[1][5],
+				  rtk->opt.snrmask.mask[1][6],rtk->opt.snrmask.mask[1][7],rtk->opt.snrmask.mask[1][8]);
 
 	Tbl->Cells[0][i  ]="SNR Mask L5 (dBHz)";
-	Tbl->Cells[1][i++]=!rtk.opt.snrmask.ena[0]?s.sprintf(""):
+	Tbl->Cells[1][i++]=!rtk->opt.snrmask.ena[0]?s.sprintf(""):
 		s.sprintf("%.0f, %.0f, %.0f, %.0f, %.0f, %.0f, %.0f, %.0f, %.0f",
-				  rtk.opt.snrmask.mask[2][0],rtk.opt.snrmask.mask[2][1],rtk.opt.snrmask.mask[2][2],
-				  rtk.opt.snrmask.mask[2][3],rtk.opt.snrmask.mask[2][4],rtk.opt.snrmask.mask[2][5],
-				  rtk.opt.snrmask.mask[2][6],rtk.opt.snrmask.mask[2][7],rtk.opt.snrmask.mask[2][8]);
+				  rtk->opt.snrmask.mask[2][0],rtk->opt.snrmask.mask[2][1],rtk->opt.snrmask.mask[2][2],
+				  rtk->opt.snrmask.mask[2][3],rtk->opt.snrmask.mask[2][4],rtk->opt.snrmask.mask[2][5],
+				  rtk->opt.snrmask.mask[2][6],rtk->opt.snrmask.mask[2][7],rtk->opt.snrmask.mask[2][8]);
 
 	Tbl->Cells[0][i  ]="SNR Mask L6 (dBHz)";
-	Tbl->Cells[1][i++]=!rtk.opt.snrmask.ena[0]?s.sprintf(""):
+	Tbl->Cells[1][i++]=!rtk->opt.snrmask.ena[0]?s.sprintf(""):
 		s.sprintf("%.0f, %.0f, %.0f, %.0f, %.0f, %.0f, %.0f, %.0f, %.0f",
-				  rtk.opt.snrmask.mask[3][0],rtk.opt.snrmask.mask[3][1],rtk.opt.snrmask.mask[3][2],
-				  rtk.opt.snrmask.mask[3][3],rtk.opt.snrmask.mask[3][4],rtk.opt.snrmask.mask[3][5],
-				  rtk.opt.snrmask.mask[3][6],rtk.opt.snrmask.mask[3][7],rtk.opt.snrmask.mask[3][8]);
+				  rtk->opt.snrmask.mask[3][0],rtk->opt.snrmask.mask[3][1],rtk->opt.snrmask.mask[3][2],
+				  rtk->opt.snrmask.mask[3][3],rtk->opt.snrmask.mask[3][4],rtk->opt.snrmask.mask[3][5],
+				  rtk->opt.snrmask.mask[3][6],rtk->opt.snrmask.mask[3][7],rtk->opt.snrmask.mask[3][8]);
 	Tbl->Cells[0][i  ]="Rec Dynamic/Earth Tides Correction";
-	Tbl->Cells[1][i++]=s.sprintf("%s, %s",rtk.opt.dynamics?"ON":"OFF",rtk.opt.tidecorr?"ON":"OFF");
+	Tbl->Cells[1][i++]=s.sprintf("%s, %s",rtk->opt.dynamics?"ON":"OFF",rtk->opt.tidecorr?"ON":"OFF");
 	
 	Tbl->Cells[0][i  ]="Ionosphere/Troposphere Model";
-	Tbl->Cells[1][i++]=s.sprintf("%s, %s",ionoopt[rtk.opt.ionoopt],tropopt[rtk.opt.tropopt]);
+	Tbl->Cells[1][i++]=s.sprintf("%s, %s",ionoopt[rtk->opt.ionoopt],tropopt[rtk->opt.tropopt]);
 	
 	Tbl->Cells[0][i  ]="Satellite Ephemeris";
-	Tbl->Cells[1][i++]=ephopt[rtk.opt.sateph];
+	Tbl->Cells[1][i++]=ephopt[rtk->opt.sateph];
 	
 	for (j=1;j<=MAXSAT;j++) {
-		if (!rtk.opt.exsats[j-1]) continue;
+		if (!rtk->opt.exsats[j-1]) continue;
 		satno2id(j,id);
-		if (rtk.opt.exsats[j-1]==2) exsats=exsats+"+";
+		if (rtk->opt.exsats[j-1]==2) exsats=exsats+"+";
 		exsats=exsats+id+" ";
 	}
 	Tbl->Cells[0][i  ]="Excluded Satellites";
@@ -521,22 +523,22 @@ void __fastcall TMonitorDialog::ShowRtk(void)
 	Tbl->Cells[0][i  ]="Solution Status";
 	Tbl->Cells[1][i++]=sol[rtkstat];
 	
-	time2str(rtk.sol.time,tstr,9);
+	time2str(rtk->sol.time,tstr,9);
 	Tbl->Cells[0][i  ] ="Time of Receiver Clock Rover";
-	Tbl->Cells[1][i++]=rtk.sol.time.time?tstr:"-";
+	Tbl->Cells[1][i++]=rtk->sol.time.time?tstr:"-";
 	
 	Tbl->Cells[0][i  ] ="Time Sytem Offset/Receiver Bias (GLO-GPS,GAL-GPS,BDS-GPS,IRN-GPS) (ns)";
-	Tbl->Cells[1][i++]=s.sprintf("%.3f, %.3f, %.3f, %.3f",rtk.sol.dtr[1]*1E9,rtk.sol.dtr[2]*1E9,
-                                 rtk.sol.dtr[3]*1E9,rtk.sol.dtr[4]*1E9);
+	Tbl->Cells[1][i++]=s.sprintf("%.3f, %.3f, %.3f, %.3f",rtk->sol.dtr[1]*1E9,rtk->sol.dtr[2]*1E9,
+                                 rtk->sol.dtr[3]*1E9,rtk->sol.dtr[4]*1E9);
 	
 	Tbl->Cells[0][i  ]="Solution Interval (s)";
-	Tbl->Cells[1][i++]=s.sprintf("%.3f",rtk.tt);
+	Tbl->Cells[1][i++]=s.sprintf("%.3f",rtk->tt);
 	
 	Tbl->Cells[0][i  ]="Age of Differential (s)";
-	Tbl->Cells[1][i++] =s.sprintf("%.3f",rtk.sol.age);
+	Tbl->Cells[1][i++] =s.sprintf("%.3f",rtk->sol.age);
 	
 	Tbl->Cells[0][i  ]="Ratio for AR Validation";
-	Tbl->Cells[1][i++]=s.sprintf("%.3f",rtk.sol.ratio);
+	Tbl->Cells[1][i++]=s.sprintf("%.3f",rtk->sol.ratio);
 	
 	Tbl->Cells[0][i  ]="# of Satellites Rover";
 	Tbl->Cells[1][i++]=s.sprintf("%d",nsat0);
@@ -545,57 +547,57 @@ void __fastcall TMonitorDialog::ShowRtk(void)
 	Tbl->Cells[1][i++]=s.sprintf("%d",nsat1);
 	
 	Tbl->Cells[0][i  ]="# of Valid Satellites";
-	Tbl->Cells[1][i++]=s.sprintf("%d",rtk.sol.ns);
+	Tbl->Cells[1][i++]=s.sprintf("%d",rtk->sol.ns);
 	
 	Tbl->Cells[0][i  ]="GDOP/PDOP/HDOP/VDOP";
 	Tbl->Cells[1][i++]=s.sprintf("%.1f, %.1f, %.1f, %.1f",dop[0],dop[1],dop[2],dop[3]);
 	
 	Tbl->Cells[0][i  ]="# of Real Estimated States";
-	Tbl->Cells[1][i++]=s.sprintf("%d",rtk.na);
+	Tbl->Cells[1][i++]=s.sprintf("%d",rtk->na);
 	
 	Tbl->Cells[0][i  ]="# of All Estimated States";
-	Tbl->Cells[1][i++]=s.sprintf("%d",rtk.nx);
+	Tbl->Cells[1][i++]=s.sprintf("%d",rtk->nx);
 	
 	Tbl->Cells[0][i  ]="Pos X/Y/Z Single (m) Rover";
-	Tbl->Cells[1][i++]=s.sprintf("%.3f, %.3f, %.3f",rtk.sol.rr[0],rtk.sol.rr[1],rtk.sol.rr[2]);
+	Tbl->Cells[1][i++]=s.sprintf("%.3f, %.3f, %.3f",rtk->sol.rr[0],rtk->sol.rr[1],rtk->sol.rr[2]);
 	
-	if (norm(rtk.sol.rr,3)>0.0) ecef2pos(rtk.sol.rr,pos); else pos[0]=pos[1]=pos[2]=0.0;
+	if (norm(rtk->sol.rr,3)>0.0) ecef2pos(rtk->sol.rr,pos); else pos[0]=pos[1]=pos[2]=0.0;
 	Tbl->Cells[0][i  ]="Lat/Lon/Height Single (deg,m) Rover";
 	Tbl->Cells[1][i++]=s.sprintf("%.8f, %.8f, %.3f",pos[0]*R2D,pos[1]*R2D,pos[2]);
 	
-	ecef2enu(pos,rtk.sol.rr+3,vel);
+	ecef2enu(pos,rtk->sol.rr+3,vel);
 	Tbl->Cells[0][i  ]="Vel E/N/U (m/s) Rover";
 	Tbl->Cells[1][i++]=s.sprintf("%.3f, %.3f, %.3f",vel[0],vel[1],vel[2]);
 	
 	Tbl->Cells[0][i  ]="Pos X/Y/Z Float (m) Rover";
 	Tbl->Cells[1][i++]=s.sprintf("%.3f, %.3f, %.3f",
-		rtk.x?rtk.x[0]:0,rtk.x?rtk.x[1]:0,rtk.x?rtk.x[2]:0);
+		rtk->x?rtk->x[0]:0,rtk->x?rtk->x[1]:0,rtk->x?rtk->x[2]:0);
 	
 	Tbl->Cells[0][i  ]="Pos X/Y/Z Float Std (m) Rover";
 	Tbl->Cells[1][i++]=s.sprintf("%.3f, %.3f, %.3f",
-		rtk.P?SQRT(rtk.P[0]):0,rtk.P?SQRT(rtk.P[1+1*rtk.nx]):0,rtk.P?SQRT(rtk.P[2+2*rtk.nx]):0);
+		rtk->P?SQRT(rtk->P[0]):0,rtk->P?SQRT(rtk->P[1+1*rtk->nx]):0,rtk->P?SQRT(rtk->P[2+2*rtk->nx]):0);
 	
 	Tbl->Cells[0][i  ]="Pos X/Y/Z Fixed (m) Rover";
 	Tbl->Cells[1][i++]=s.sprintf("%.3f, %.3f, %.3f",
-		rtk.xa?rtk.xa[0]:0,rtk.xa?rtk.xa[1]:0,rtk.xa?rtk.xa[2]:0);
+		rtk->xa?rtk->xa[0]:0,rtk->xa?rtk->xa[1]:0,rtk->xa?rtk->xa[2]:0);
 	
 	Tbl->Cells[0][i  ]="Pos X/Y/Z Fixed Std (m) Rover";
 	Tbl->Cells[1][i++]=s.sprintf("%.3f, %.3f, %.3f",
-		rtk.Pa?SQRT(rtk.Pa[0]):0,rtk.Pa?SQRT(rtk.Pa[1+1*rtk.na]):0,rtk.Pa?SQRT(rtk.Pa[2+2*rtk.na]):0);
+		rtk->Pa?SQRT(rtk->Pa[0]):0,rtk->Pa?SQRT(rtk->Pa[1+1*rtk->na]):0,rtk->Pa?SQRT(rtk->Pa[2+2*rtk->na]):0);
 	
 	Tbl->Cells[0][i  ]="Pos X/Y/Z (m) Base Station";
-	Tbl->Cells[1][i++]=s.sprintf("%.3f, %.3f, %.3f",rtk.rb[0],rtk.rb[1],rtk.rb[2]);
+	Tbl->Cells[1][i++]=s.sprintf("%.3f, %.3f, %.3f",rtk->rb[0],rtk->rb[1],rtk->rb[2]);
 	
-	if (norm(rtk.rb,3)>0.0) ecef2pos(rtk.rb,pos); else pos[0]=pos[1]=pos[2]=0.0;
+	if (norm(rtk->rb,3)>0.0) ecef2pos(rtk->rb,pos); else pos[0]=pos[1]=pos[2]=0.0;
 	Tbl->Cells[0][i  ]="Lat/Lon/Height (deg,m) Base Station";
 	Tbl->Cells[1][i++]=s.sprintf("%.8f, %.8f, %.3f",pos[0]*R2D,pos[1]*R2D,pos[2]);
 	
-	ecef2enu(pos,rtk.rb+3,vel);
+	ecef2enu(pos,rtk->rb+3,vel);
 	Tbl->Cells[0][i  ]="Vel E/N/U (m/s) Base Station";
 	Tbl->Cells[1][i++]=s.sprintf("%.3f, %.3f, %.3f",vel[0],vel[1],vel[2]);
 	
-	if (norm(rtk.rb,3)>0.0) {
-	    for (k=0;k<3;k++) rr[k]=rtk.sol.rr[k]-rtk.rb[k];
+	if (norm(rtk->rb,3)>0.0) {
+	    for (k=0;k<3;k++) rr[k]=rtk->sol.rr[k]-rtk->rb[k];
 	    ecef2enu(pos,rr,enu);
 	}
 	Tbl->Cells[0][i  ]="Baseline Length/E/N/U (m) Rover-Base Station";
@@ -605,26 +607,26 @@ void __fastcall TMonitorDialog::ShowRtk(void)
 	Tbl->Cells[1][i++]=s.sprintf("%d",nave);
 	
 	Tbl->Cells[0][i  ]="Antenna Type Rover";
-	Tbl->Cells[1][i++]=rtk.opt.pcvr[0].type;
+	Tbl->Cells[1][i++]=rtk->opt.pcvr[0].type;
 	
 	for (j=0;j<NFREQ;j++) {
-	    off=rtk.opt.pcvr[0].off[j];
+	    off=rtk->opt.pcvr[0].off[j];
 	    Tbl->Cells[0][i  ]=s.sprintf("Ant Phase Center L%d E/N/U (m) Rover",j+1);
 	    Tbl->Cells[1][i++]=s.sprintf("%.3f, %.3f, %.3f",off[0],off[1],off[2]);
 	}
-	del=rtk.opt.antdel[0];
+	del=rtk->opt.antdel[0];
 	Tbl->Cells[0][i  ]="Ant Delta E/N/U (m) Rover";
 	Tbl->Cells[1][i++]=s.sprintf("%.3f, %.3f, %.3f",del[0],del[1],del[2]);
 	
 	Tbl->Cells[0][i  ]="Antenna Type Base Station";
-	Tbl->Cells[1][i++]=rtk.opt.pcvr[1].type;
+	Tbl->Cells[1][i++]=rtk->opt.pcvr[1].type;
 	
 	for (j=0;j<NFREQ;j++) {
-	    off=rtk.opt.pcvr[1].off[0];
+	    off=rtk->opt.pcvr[1].off[0];
     	Tbl->Cells[0][i  ]=s.sprintf("Ant Phase Center L%d E/N/U (m) Base Station",j+1);
 	    Tbl->Cells[1][i++]=s.sprintf("%.3f, %.3f, %.3f",off[0],off[1],off[2]);
 	}
-	del=rtk.opt.antdel[1];
+	del=rtk->opt.antdel[1];
 	Tbl->Cells[0][i  ]="Ant Delta E/N/U (m) Base Station";
 	Tbl->Cells[1][i++]=s.sprintf("%.3f, %.3f, %.3f",del[0],del[1],del[2]);
 	
@@ -636,6 +638,7 @@ void __fastcall TMonitorDialog::ShowRtk(void)
 	
 	Tbl->Cells[0][i  ]="Precise Ephemeris Download File";
 	Tbl->Cells[1][i++]=file;
+        free(rtk);
 }
 //---------------------------------------------------------------------------
 void __fastcall TMonitorDialog::SetSat(void)
@@ -707,7 +710,6 @@ void __fastcall TMonitorDialog::SetSat(void)
 //---------------------------------------------------------------------------
 void __fastcall TMonitorDialog::ShowSat(void)
 {
-	rtk_t rtk;
 	ssat_t *ssat;
 	AnsiString s;
 	int i,j,k,n,fix,prn,pmode,nfreq,sys=sys_tbl[SelSys->ItemIndex];
@@ -715,10 +717,13 @@ void __fastcall TMonitorDialog::ShowSat(void)
 	char id[8];
 	double az,el,cbias[MAXSAT][2];
 	
+        rtk_t *rtk = static_cast<rtk_t *>(malloc(sizeof(rtk_t)));
+        if (rtk == NULL) return;
+
 	SetSat();
 
 	rtksvrlock(&rtksvr);
-	rtk=rtksvr.rtk;
+	*rtk=rtksvr.rtk;
 	for (i=0;i<MAXSAT;i++) for (j=0;j<2;j++) {
 		cbias[i][j]=rtksvr.nav.cbias[i][j][0];
 	}
@@ -729,18 +734,19 @@ void __fastcall TMonitorDialog::ShowSat(void)
 	Label->Caption="";
 	
 	for (i=0;i<MAXSAT;i++) {
-		ssat=rtk.ssat+i;
+		ssat=rtk->ssat+i;
 		vsat[i]=ssat->vs;
 	}
 	for (i=0,n=1;i<MAXSAT;i++) {
 		if (!(satsys(i+1,NULL)&sys)) continue;
-		ssat=rtk.ssat+i;
+		ssat=rtk->ssat+i;
 		if (SelSat->ItemIndex==1&&!vsat[i]) continue;
 		n++;
 	}
 	if (n<2) {
 		Tbl->RowCount=2;
 		for (i=0;i<Tbl->ColCount;i++) Tbl->Cells[i][1]="";
+                free(rtk);
 		return;
 	}
 	Tbl->RowCount=n;
@@ -748,7 +754,7 @@ void __fastcall TMonitorDialog::ShowSat(void)
 	for (i=0,n=1;i<MAXSAT;i++) {
 		if (!(satsys(i+1,NULL)&sys)) continue;
 		j=0;
-		ssat=rtk.ssat+i;
+		ssat=rtk->ssat+i;
 		if (SelSat->ItemIndex==1&&!vsat[i]) continue;
 		satno2id(i+1,id);
 		Tbl->Cells[j++][n]=id;
@@ -789,6 +795,7 @@ void __fastcall TMonitorDialog::ShowSat(void)
 		Tbl->Cells[j++][n]=s.sprintf("%.2f",0);
 		n++;
 	}
+        free(rtk);
 }
 //---------------------------------------------------------------------------
 void __fastcall TMonitorDialog::SetEst(void)
@@ -978,10 +985,15 @@ void __fastcall TMonitorDialog::SetObs(void)
 void __fastcall TMonitorDialog::ShowObs(void)
 {
 	AnsiString s;
-	obsd_t obs[MAXOBS*2];
 	char tstr[40],id[8],*code;
 	int i,j,k,n=0,nex=ObsMode?NEXOBS:0,sys=sys_tbl[SelSys->ItemIndex];
 	
+        obsd_t *obs = static_cast<obsd_t *>(calloc(MAXOBS * 2, sizeof(obsd_t)));
+        if (obs == NULL) {
+          trace(1, "TMonitorDialog::ShowObs obsd_t alloc failed\n");
+          return;
+        }
+
 	rtksvrlock(&rtksvr);
 	for (i=0;i<rtksvr.obs[0][0].n&&n<MAXOBS*2;i++) {
         if (!(satsys(rtksvr.obs[0][0].data[i].sat,NULL)&sys)) continue;
@@ -1026,6 +1038,7 @@ void __fastcall TMonitorDialog::ShowObs(void)
 			Tbl->Cells[j++][i+1]=s.sprintf("%d",obs[i].LLI[k]);
 		}
 	}
+        free(obs);
 }
 //---------------------------------------------------------------------------
 void __fastcall TMonitorDialog::SetNav(void)

--- a/app/winapp/rtkplot/plotdata.cpp
+++ b/app/winapp/rtkplot/plotdata.cpp
@@ -145,7 +145,6 @@ void __fastcall TPlot::ReadSolStat(TStrings *files, int sel)
 void __fastcall TPlot::ReadObs(TStrings *files)
 {
     obs_t obs={0};
-    nav_t nav={0};
     sta_t sta={0};
     AnsiString s;
     char file[1024];
@@ -158,13 +157,21 @@ void __fastcall TPlot::ReadObs(TStrings *files)
     ReadWaitStart();
     ShowLegend(NULL);
     
-    if ((nobs=ReadObsRnx(files,&obs,&nav,&sta))<=0) {
+    nav_t *nav = static_cast<nav_t *>(calloc(1, sizeof(nav_t)));
+    if (nav == NULL) {
+      trace(1, "TPlot::ReadObs nav alloc failed\n");
+      return;
+    }
+
+    if ((nobs=ReadObsRnx(files,&obs,nav,&sta))<=0) {
         ReadWaitEnd();
+        free(nav);
         return;
     }
     ClearObs();
     Obs=obs;
-    Nav=nav;
+    Nav=*nav;
+    free(nav);
     Sta=sta;
     SimObs=0;
     UpdateObs(nobs);

--- a/app/winapp/rtkplot/plotmain.cpp
+++ b/app/winapp/rtkplot/plotmain.cpp
@@ -72,7 +72,6 @@ TPlot *Plot;
 __fastcall TPlot::TPlot(TComponent* Owner) : TForm(Owner)
 {
     gtime_t t0={0};
-    nav_t nav0={0};
     obs_t obs0={0};
     sta_t sta0={0};
     gis_t gis0={0};
@@ -99,12 +98,9 @@ __fastcall TPlot::TPlot(TComponent* Owner) : TForm(Owner)
     }
 
     obs0.data=NULL; obs0.n =obs0.nmax =0;
-    nav0.eph =NULL; nav0.n =nav0.nmax =0;
-    nav0.geph=NULL; nav0.ng=nav0.ngmax=0;
-    nav0.seph=NULL; nav0.ns=nav0.nsmax=0;
     ObsIndex=0;
     Obs=obs0;
-    Nav=nav0;
+    memset(&Nav, 0, sizeof(Nav));
     Sta=sta0;
     Gis=gis0;
     SimObs=0;

--- a/src/postpos.c
+++ b/src/postpos.c
@@ -810,13 +810,18 @@ static void freeobsnav(obs_t *obs, nav_t *nav)
 static int avepos(double *ra, int rcv, const obs_t *obs, const nav_t *nav,
                   const prcopt_t *opt)
 {
-    obsd_t data[MAXOBS];
     gtime_t ts={0};
     sol_t sol={{0}};
     int i,j,n=0,m,iobs;
     char msg[128];
 
     trace(3,"avepos: rcv=%d obs.n=%d\n",rcv,obs->n);
+
+    obsd_t *data = (obsd_t *)calloc(MAXOBS, sizeof(obsd_t));
+    if (data == NULL) {
+      trace(1, "avepos: obsd_t alloc failed\n");
+      return 0;
+    }
 
     for (i=0;i<3;i++) ra[i]=0.0;
 
@@ -834,6 +839,7 @@ static int avepos(double *ra, int rcv, const obs_t *obs, const nav_t *nav,
         for (i=0;i<3;i++) ra[i]+=sol.rr[i];
         n++;
     }
+    free(data);
     if (n<=0) {
         trace(1,"no average of base station position\n");
         return 0;


### PR DESCRIPTION
to help avoid stack overflows. In particular the nav_t object and MAXOBJS multiples of the obsd_t objects.

Seeing stack overflows working on the windows rtknavi app, it might be just a 1M stack size, and this resolved it, but that was working with more than the default number of frequency indices and other extended data. Applied the same to the qt app.