### PR TITLE
winapp rtknavi: enable solution processing options

### DIFF
--- a/app/winapp/rtknavi/naviopt.cpp
+++ b/app/winapp/rtknavi/naviopt.cpp
@@ -1145,12 +1145,12 @@ void __fastcall TOptDialog::UpdateEnable(void)
 	BaselineLen    ->Enabled=BaselineConst->Checked&&PosMode->ItemIndex==PMODE_MOVEB;
 	BaselineSig    ->Enabled=BaselineConst->Checked&&PosMode->ItemIndex==PMODE_MOVEB;
 	
-	OutputHead     ->Enabled=SolFormat->ItemIndex!=3;
-	OutputOpt      ->Enabled=false;
-	TimeFormat     ->Enabled=SolFormat->ItemIndex!=3;
-	TimeDecimal    ->Enabled=SolFormat->ItemIndex!=3;
+	OutputHead     ->Enabled=SolFormat->ItemIndex<3;
+	OutputOpt      ->Enabled=SolFormat->ItemIndex<3;
+	TimeFormat     ->Enabled=SolFormat->ItemIndex<3;
+	TimeDecimal    ->Enabled=SolFormat->ItemIndex<3;
 	LatLonFormat   ->Enabled=SolFormat->ItemIndex==0;
-	FieldSep       ->Enabled=SolFormat->ItemIndex!=3;
+	FieldSep       ->Enabled=SolFormat->ItemIndex<3;
 	OutputSingle   ->Enabled=PosMode->ItemIndex!=0;
 	OutputDatum    ->Enabled=SolFormat->ItemIndex==0;
 	OutputHeight   ->Enabled=SolFormat->ItemIndex==0;

--- a/app/winapp/rtknavi/naviopt.dfm
+++ b/app/winapp/rtknavi/naviopt.dfm
@@ -840,7 +840,6 @@ object OptDialog: TOptDialog
         Width = 152
         Height = 21
         Style = csDropDownList
-        Enabled = False
         ItemIndex = 0
         TabOrder = 0
         Text = 'Lat/Lon/Height'
@@ -947,7 +946,6 @@ object OptDialog: TOptDialog
         Width = 75
         Height = 21
         Style = csDropDownList
-        Enabled = False
         ItemIndex = 0
         TabOrder = 2
         Text = 'OFF'


### PR DESCRIPTION
The rtksvr can now output the processing options in the header. Sync with the qt app which recently enabled this.

Also enable the solution format in the options tab, as even though it is not used by rtksvr it is used to gate the other options enabled and those options may be used. The solution format rather comes from the output streams, specific to each output stream. The user it left to sync these options. This also syncs with the qt app.

This might not be the best approach, it might be best to expand the output streams options to have the solution options for each output stream, but this syncs with the qt app and might be an incremental improvement. Alternatively would the qt app also disable this solution format selection, and all solution format options be always enabled. Or should it be smarter and check if any output stream is using an option. 
