### PR TITLE
Refactor .gitignore: Move directory-specific rules to subfolders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,36 +35,6 @@ build/
 
 # Ignore compilation results
 
-bin/*
-lib/libRTKLib.so*
-lib/librtklib.so
-app/consapp/convbin/gcc/convbin
-app/consapp/pos2kml/gcc/pos2kml
-app/consapp/rnx2rtkp/gcc/rnx2rtkp
-app/consapp/rtkrcv/gcc/rtkrcv
-app/consapp/str2str/gcc/str2str
-
-util/gencrc/gencrc
-util/gencrc/genmsk
-util/gencrc/genxor
-util/rnx2rtcm/rnx2rtcm
-util/simobs/gcc/simobs
-
-test/utest/*.out
-test/utest/t_atmos
-test/utest/t_coord
-test/utest/t_geoid
-test/utest/t_gloeph
-test/utest/t_ionex
-test/utest/t_lambda
-test/utest/t_matrix
-test/utest/t_misc
-test/utest/t_ppp
-test/utest/t_preceph
-test/utest/t_rinex
-test/utest/t_time
-test/utest/t_tle
-
 util/gencrc/gencrc
 util/gencrc/genmsk
 util/gencrc/genxor

--- a/app/consapp/.gitignore
+++ b/app/consapp/.gitignore
@@ -1,0 +1,12 @@
+# Ignore all files in the lib directory
+*
+
+# But not the following directories and files
+!.gitignore
+!*.c
+!*.h
+!*.bat
+!*.sh
+!makefile
+!CMakeLists.txt
+!rtklib_consapp.groupproj

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,0 +1,6 @@
+# Ignore all files in the lib directory
+*
+
+# But not the following directories and files
+!.gitignore
+!readme.txt

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,0 +1,10 @@
+# Ignore all files in the lib directory
+*
+
+# But not the following directories and files
+!.gitignore
+!iers
+!omf
+!openblas
+!sofa
+!CMakeLists.txt

--- a/test/utest/.gitignore
+++ b/test/utest/.gitignore
@@ -1,0 +1,9 @@
+# Ignore all files in the lib directory
+*
+
+# But not the following directories and files
+!.gitignore
+!*.c
+!*.m
+!makefile
+!figtest*.jpg


### PR DESCRIPTION
- Moved directory-specific ignore patterns from the root `.gitignore` to `.gitignore` files in `bin/`, `lib/`, `app/consapp/`, and `test/utest/`
- Improves clarity and maintainability of ignored files for each subdirectory
- Keeps the root `.gitignore` cleaner and more focused