### PR TITLE
Fix convbin only outputting the last SBF observation

### DIFF
--- a/src/rcv/septentrio.c
+++ b/src/rcv/septentrio.c
@@ -703,7 +703,7 @@ static int decode_measepoch(raw_t *raw)
     int i, j, idx, n, n1, n2, len1, len2, sig, ant, svid, info, sat, sys, lock, fcn, LLI, chn, ret=0;
     int ant_sel = 0; /* antenna selection (0:main) */
 
-    if (timediff(raw->time, sbf->current_time) != 0) {
+    if (timediff(raw->time, sbf->current_time) > 0) {
         sbf->current_time = raw->time;
         ret = flushobuf(raw);
     }


### PR DESCRIPTION
Previously, rtkconv could output only the last SBF observation. During conversion, the process would decode the same observation file twice. On the second pass, it would first read the last observation from the buffer in [sbf](src/rcv/septentrio.c:706). This caused [convrnx](src/convrnx.c:1043-1045) to reject all observations that were not newer than the last one, resulting in missing data.