### PR TITLE
Update NFREQ to 4 in root CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ project(rtklib LANGUAGES C CXX VERSION 2.4.3)
 option(IERS_MODEL "Use Earth models from IERS" OFF)
 
 # configure rtklib
-add_definitions(-DENAGLO -DENAQZS -DENACMP -DENAGAL -DENAIRN -DNFREQ=3 -DNEXOBS=3 -DTRACE -DSVR_REUSEADDR)
+add_definitions(-DENAGLO -DENAQZS -DENACMP -DENAGAL -DENAIRN -DNFREQ=4 -DNEXOBS=3 -DTRACE -DSVR_REUSEADDR)
 
 
 # 3rd party libs


### PR DESCRIPTION
The source code now supports the L6 frequency band, but NFREQ was still defined as 3 in CMake. This mismatch could cause hardcoded array sizes (e.g., snrmask_[3] in options.c) to result in out-of-bounds memory access and unpredictable behavior.