### PR TITLE
rtkconv: fix code mask init, for added 6D and 6P

### DIFF
--- a/app/winapp/rtkconv/convmain.cpp
+++ b/app/winapp/rtkconv/convmain.cpp
@@ -1041,7 +1041,7 @@ void __fastcall TMainWindow::LoadOpt(void)
 {
 	TIniFile *ini=new TIniFile(IniFile);
 	AnsiString opt,mask=
-        "11111111111111111111111111111111111111111111111111111111111111111111";
+        "1111111111111111111111111111111111111111111111111111111111111111111111";
 	
 	RnxVer				=ini->ReadInteger("opt","rnxver",	   7);
 	RnxFile				=ini->ReadInteger("opt","rnxfile",	   0);


### PR DESCRIPTION
missed updating this when codes 6D and 6P were added.