### PR TITLE
rtkpos: only apply glomodear fixhold if modear is fixhold

### DIFF
--- a/src/rtkpos.c
+++ b/src/rtkpos.c
@@ -2143,7 +2143,10 @@ static int relpos(rtk_t *rtk, const obsd_t *obs, int nu, int nr,
 
                     /* hold integer ambiguity if meet minfix count */
                     if (++rtk->nfix>=rtk->opt.minfix) {
-                        if (rtk->opt.modear==ARMODE_FIXHOLD||rtk->opt.glomodear==GLO_ARMODE_FIXHOLD)
+                        // Note that the modear needs to be fix-and-hold in
+                        // order for glomodear fix-and-hold to be applied here,
+                        // to prevent glomodear alone forcing fix-and-hold.
+                        if (rtk->opt.modear==ARMODE_FIXHOLD)
                             holdamb(rtk,xa);
                         /* switch to kinematic after qualify for hold if in static-start mode */
                         if (rtk->opt.mode==PMODE_STATIC_START) {


### PR DESCRIPTION
for application of fix-and-hold in general, otherwise setting modear to 'continuous' and inadvertently setting the glomodear to fixhold with GLONASS disabled would force applicaton of fix-and-hold.

Noted different results, with GLONASS disabled, and tracked it down to the glomodear being fix-and-hold in one case versus off in another which was unexpected, it forced the modear setting of 'continuous' to be ignored and fix-and-hold to be applied when glomodear was fix-and-hold. The holdamb() function tests glomodear but not modear, it does not appear to just be able to apply fix-and-hold for GLONASS, so this PR changes operation to require modear to be fix-and-hold if GLONASS fix-and-hold is used. This code seems hard to follow, and it also applies to SBAS signals, and perhaps needs much more work to independently apply a fix-and-hold for only GLONASS if that is practical. I rarely even use GLONASS now, perhaps with post processed precise data, it just seems to frustrate getting a fix, and receivers now support so many other satellites.