### PR TITLE
rtkpos: relax test for initial position

### DIFF
--- a/src/rtkpos.c
+++ b/src/rtkpos.c
@@ -492,7 +492,7 @@ static void udpos(rtk_t *rtk, double tt)
         return;
     }
     /* initialize position for first epoch */
-    if (norm(rtk->x,3)<=0.0) {
+    if (norm(rtk->x, 3) <= RE_WGS84 / 2) {
         trace(3,"rr_init=");tracemat(3,rtk->sol.rr,1,6,15,6);
         for (i=0;i<3;i++) initx(rtk,rtk->sol.rr[i],VAR_POS,i);
         if (rtk->opt.dynamics) {
@@ -1028,7 +1028,7 @@ static int zdres(int base, const obsd_t *obs, int n, const double *rs,
     /* init residuals to zero */
     for (i=0;i<n*nf*2;i++) y[i]=0.0;
 
-    if (norm(rr,3)<=0.0) return 0; /* no receiver position */
+    if (norm(rr, 3) <= RE_WGS84/2) return 0; /* No receiver position */
 
     /* rr_ = local copy of rcvr pos */
     for (i=0;i<3;i++) rr_[i]=rr[i];


### PR DESCRIPTION
If the norm of the xyz vector is less than half the earth radius then assume it is an initial position, rather than having to be exactly zero.

On the windows rtknavi, was seeing an error that there were not enough double differentials when mistakenly failing to supply a base station position, but this should have been detected and better reported. These test of the initial position was failing because the norm was not exactly zero. This PR relaxes the test so a position with a norm less than half the earth radius is considered an initial position and reported as an uninitialised base station position.