### PR TITLE
convrnx sort sats: fix the comparison function

### DIFF
--- a/src/convrnx.c
+++ b/src/convrnx.c
@@ -1025,7 +1025,7 @@ static int screent_ttol(gtime_t time, gtime_t ts, gtime_t te, double tint,
 static int cmpobs(const void *p1, const void *p2)
 {
     obsd_t *obs1 = (obsd_t *)p1, *obs2 = (obsd_t *)p2;
-    return obs1->sat > obs2->sat;
+    return obs1->sat - obs2->sat;
 }
 /* convert observation data --------------------------------------------------*/
 static void convobs(FILE **ofp, rnxopt_t *opt, strfile_t *str, int *n,


### PR DESCRIPTION
which was not returning the expected difference and this caused some implementations of qsort to fail.

This caused the windows rtkconv to lockup when satellite sorting was enabled. It fixes my prior error here, but the linux glibc implementation of qsort must have been hardened to protect against this programming error and was working.
