### PR TITLE
gui console output cleanup

### DIFF
--- a/app/qtapp/appcmn_qt/console.cpp
+++ b/app/qtapp/appcmn_qt/console.cpp
@@ -64,22 +64,27 @@ void Console::addMessage(uint8_t *msg, int n)
     p += sprintf(p, "%s", qPrintable(consoleBuffer.last()));
 
     for (int i = 0; i < n; i++) {
-            if (mode) {
-                    if (msg[i] == '\r') continue;
-                    p += sprintf(p, "%c", msg[i] == '\n' || isprint(msg[i]) ? msg[i] : '.');
-            }
+        int add = 0;
+        if (mode) {
+            if (msg[i] == '\r') continue;
+            if (msg[i] == '\n') add = 1;
             else {
-                    p += sprintf(p, "%s%02X", (p - buff) % 17 == 16 ? " " : "", msg[i]);
-                    if (p - buff >= 67) p += sprintf(p,"\n");
+              p += sprintf(p, "%c", isprint(msg[i]) ? msg[i] : '.');
+              if (p - buff >= MAXLEN) add = 1;
             }
-            if (p-buff >= MAXLEN) p += sprintf(p,"\n");
+        } else {
+            if (strlen(buff) % 17 == 16) strcat(p++, " ");
+            p += sprintf(p, "%02X", msg[i]);
+            if (p - buff >= 67) add = 1;
+        }
 
-            if (*(p-1) == '\n') {
-                    consoleBuffer.last() = buff;
-                    consoleBuffer.append("");
-                    *(p=buff) = 0;
-                    if (consoleBuffer.count() >= MAXLINE) consoleBuffer.removeFirst();
-            }
+        if (add) {
+            strcat(p, "\n");
+            consoleBuffer.last() = buff;
+            consoleBuffer.append("");
+            *(p = buff) = 0;
+            if (consoleBuffer.count() >= MAXLINE) consoleBuffer.removeFirst();
+        }
     }
     consoleBuffer.last() = buff;
 

--- a/app/qtapp/appcmn_qt/console.ui
+++ b/app/qtapp/appcmn_qt/console.ui
@@ -131,7 +131,7 @@
       <item>
        <widget class="QPushButton" name="btnClear">
         <property name="enabled">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">

--- a/app/qtapp/rtknavi_qt/mondlg.cpp
+++ b/app/qtapp/rtknavi_qt/mondlg.cpp
@@ -33,7 +33,8 @@ MonitorDialog::MonitorDialog(QWidget *parent, rtksvr_t *server, stream_t* stream
 
     fontScale = QFontMetrics(ui->tWConsole->font()).height() * 4;
 
-    consoleFormat = -1;
+    consoleFormat = 1;
+    ui->cBSelectFormat->setCurrentIndex(consoleFormat);
     inputStream = solutionStream = 0;
 
     for (int i = 0; i <= MAXRCVFMT; i++) ui->cBSelectFormat->addItem(formatstrs[i]);
@@ -330,24 +331,30 @@ void MonitorDialog::addConsole(const uint8_t *msg, int n, int mode, bool newline
     p += sprintf(p, "%s", qPrintable(consoleBuffer.at(consoleBuffer.count() - 1)));
 
     for (int i = 0; i < n; i++) {
+        int add = 0;
         if (mode) {
             if (msg[i] == '\r') continue;
-            p += sprintf(p, "%c", msg[i] == '\n' || isprint(msg[i]) ? msg[i] : '.');
-        } else { // add a space after 16 and a line break after 67 characters
-            p += sprintf(p, "%s%02X", (p - buff) % 17 == 16 ? " " : "", msg[i]);
-            if (p - buff >= 67) p += sprintf(p, "\n");
+            if (msg[i] == '\n') add = 1;
+            else {
+              p += sprintf(p, "%c", isprint(msg[i]) ? msg[i] : '.');
+              if (p - buff >= MAXLEN) add = 1;
+            }
+        } else {
+            // Add a space after 16 and a line break after 67 characters.
+            if (strlen(buff) % 17 == 16) strcat(p++, " ");
+            p += sprintf(p, "%02X", msg[i]);
+            if (p - buff >= 67) add = 1;
         }
-        if (p - buff >= MAXLEN) p += sprintf(p, "\n");
 
-        if (*(p - 1) == '\n') {
-            consoleBuffer[consoleBuffer.count() - 1] = QString(buff).remove(QString(buff).size()-1, 1);
+        if (add) {
+            consoleBuffer[consoleBuffer.count() - 1] = QString(buff);
             consoleBuffer.append("");
             *(p = buff) = 0;
             while (consoleBuffer.count() >= MAXLINE) consoleBuffer.removeFirst();
         }
     }
     // store last (incomplete) line
-    consoleBuffer[consoleBuffer.count() - 1] = QString(buff).remove(QString(buff).size()-1, 1);
+    consoleBuffer[consoleBuffer.count() - 1] = QString(buff);
 
     // write consoleBuffer to table widget
     ui->tWConsole->setColumnCount(1);

--- a/app/qtapp/strsvr_qt/mondlg.cpp
+++ b/app/qtapp/strsvr_qt/mondlg.cpp
@@ -108,17 +108,23 @@ void StrMonDialog::addConsole(unsigned char *msg, int n, int mode, bool newline)
     p += sprintf(p, "%s", qPrintable(consoleBuffer.at(consoleBuffer.count() - 1)));
 
     for (int i = 0; i < n; i++) {
+        int add = 0;
         if (mode) {
             if (msg[i] == '\r') continue;
-            p += sprintf(p, "%c", (msg[i] == '\n' || isprint(msg[i])) ? msg[i] : '.');
-        } else {  // add a space after 16 and a line break after 67 characters
-            p += sprintf(p, "%s%02X", (p - buff) % 17 == 16 ? " " : "", msg[i]);
-            if (p - buff >= 67) p += sprintf(p, "\n");
+            if (msg[i] == '\n') add = 1;
+            else {
+              p += sprintf(p, "%c", isprint(msg[i]) ? msg[i] : '.');
+              if (p - buff >= MAXLEN) add = 1;
+            }
+        } else {
+            // Add a space after 16 and a line break after 67 characters.
+            if (strlen(buff) % 17 == 16) strcat(p++, " ");
+            p += sprintf(p, "%02X", msg[i]);
+            if (p - buff >= 67) add = 1;
         }
-        if (p - buff >= MAXLEN) p += sprintf(p, "\n");
 
-        if (*(p - 1) == '\n') {
-            consoleBuffer[consoleBuffer.count() - 1] = QString(buff).remove(QString(buff).size()-1, 1);
+        if (add) {
+            consoleBuffer[consoleBuffer.count() - 1] = QString(buff);
             consoleBuffer.append("");
             *(p = buff) = 0;
             while (consoleBuffer.count() >= MAXLINE) consoleBuffer.removeFirst();

--- a/app/winapp/appcmn/console.cpp
+++ b/app/winapp/appcmn/console.cpp
@@ -108,17 +108,22 @@ void __fastcall TConsole::AddMsg(uint8_t *msg, int n)
 	p+=sprintf(p,"%s",str.c_str());
 	
 	for (int i=0;i<n;i++) {
+        int add = 0;
 		if (mode) {
-			if (msg[i]=='\r') continue;
-			p+=sprintf(p,"%c",msg[i]=='\n'||isprint(msg[i])?msg[i]:'.');
+            if (msg[i] == '\r') continue;
+            if (msg[i] == '\n') add = 1;
+            else {
+              p+=sprintf(p,"%c",isprint(msg[i])?msg[i]:'.');
+              if (p-buff >= MAXLEN) add = 1;
+            }
 		}
 		else {
-			p+=sprintf(p,"%s%02X",(p-buff)%17==16?" ":"",msg[i]);
-			if (p-buff>=67) p+=sprintf(p,"\n");
+            if (strlen(buff) % 17 == 16) strcat(p++, " ");
+			p+=sprintf(p,"%02X",msg[i]);
+			if (p-buff>=67) add = 1;
 		}
-		if (p-buff>=MAXLEN) p+=sprintf(p,"\n");
 		
-		if (*(p-1)=='\n') {
+		if (add) {
 			ConBuff->Strings[ConBuff->Count-1]=buff;
 			ConBuff->Add("");
 			*(p=buff)=0;

--- a/app/winapp/rtknavi/mondlg.cpp
+++ b/app/winapp/rtknavi/mondlg.cpp
@@ -267,17 +267,22 @@ void __fastcall TMonitorDialog::AddConsole(uint8_t *msg, int len, int mode)
 	p+=sprintf(p,"%s",ConBuff_Str.c_str());
 	
 	for (int i=0;i<len;i++) {
+        int add = 0;
 		if (mode) {
-			if (msg[i]=='\r') continue;
-			p+=sprintf(p,"%c",msg[i]=='\n'||isprint(msg[i])?msg[i]:'.');
+            if (msg[i] == '\r') continue;
+            if (msg[i] == '\n') add = 1;
+            else {
+              p+=sprintf(p,"%c",isprint(msg[i])?msg[i]:'.');
+              if (p-buff >= MAXLEN) add = 1;
+            }
 		}
 		else {
-			p+=sprintf(p,"%s%02X",(p-buff)%17==16?" ":"",msg[i]);
-			if (p-buff>=67) p+=sprintf(p,"\n");
+            if (strlen(buff) % 17 == 16) strcat(p++, " ");
+			p+=sprintf(p,"%02X",msg[i]);
+			if (p-buff>=67) add = 1;
 		}
-		if (p-buff>=MAXLEN) p+=sprintf(p,"\n");
 		
-		if (*(p-1)=='\n') {
+		if (add) {
 			ConBuff->Strings[ConBuff->Count-1]=buff;
 			ConBuff->Add("");
 			*(p=buff)=0;

--- a/app/winapp/strsvr/mondlg.cpp
+++ b/app/winapp/strsvr/mondlg.cpp
@@ -124,17 +124,22 @@ void __fastcall TStrMonDialog::AddConsole(uint8_t *msg, int n, int mode)
 	p+=sprintf(p,"%s",str.c_str());
 	
 	for (int i=0;i<n;i++) {
+        int add = 0;
 		if (mode) {
-			if (msg[i]=='\r') continue;
-			p+=sprintf(p,"%c",msg[i]=='\n'||isprint(msg[i])?msg[i]:'.');
+            if (msg[i] == '\r') continue;
+            if (msg[i] == '\n') add = 1;
+            else {
+              p+=sprintf(p,"%c",isprint(msg[i])?msg[i]:'.');
+              if (p-buff >= MAXLEN) add = 1;
+            }
 		}
 		else {
-			p+=sprintf(p,"%s%02X",(p-buff)%17==16?" ":"",msg[i]);
-			if (p-buff>=67) p+=sprintf(p,"\n");
+            if (strlen(buff) % 17 == 16) strcat(p++, " ");
+			p+=sprintf(p,"%02X",msg[i]);
+			if (p-buff>=67) add = 1;
 		}
-		if (p-buff>=MAXLEN) p+=sprintf(p,"\n");
 		
-		if (*(p-1)=='\n') {
+		if (add) {
 			ConBuff->Strings[ConBuff->Count-1]=buff;
 			ConBuff->Add("");
 			*(p=buff)=0;


### PR DESCRIPTION
A few functions use similar code to output stream ASCII or hex to a console. The code was adding linefeeds to wrap lines and then detecting these, and also leaving them which was noise in most cases. This reworks the code to avoid these trailing linefeeds.

rtknavi_qt was initializing the stream console output checkbox to 'HEX' but the initial output was ASCII.

TODO Noticed that the qt app uses a proportional font for this console output which does not present well for the HEX output and also some of the other output presents better in a mono-space font as used in the windows gui apps.
