### PR TITLE
qt app refdlg: relax id and name test, fix dist start index

### DIFF
--- a/app/qtapp/appcmn_qt/refdlg.cpp
+++ b/app/qtapp/appcmn_qt/refdlg.cpp
@@ -116,15 +116,16 @@ void RefDialog::loadList(QString filename)
 
         QList<QByteArray> tokens = buff.trimmed().split(' ');
 
-        if (tokens.size() != 5) continue;
+        if (tokens.size() < 3) continue;
 
         ui->tWStationList->setRowCount(++n);
 
         for (int i = 0; i < 3; i++)
             pos[i] = tokens.at(i).toDouble();
 
-        addReference(n, pos, tokens.at(3), tokens.at(4));
-	}
+        addReference(n, pos, tokens.size() > 3 ? tokens.at(3) : "",
+                     tokens.size() > 4 ? tokens.at(4) : "");
+    }
     if (n == 0) ui->tWStationList->setRowCount(0);
 
     updateDistances();
@@ -212,7 +213,7 @@ void RefDialog::updateDistances()
     pos[1] *= D2R;
     pos2ecef(pos, ru);
 
-    for (int i = 1; i < ui->tWStationList->rowCount(); i++) {
+    for (int i = 0; i < ui->tWStationList->rowCount(); i++) {
         if (ui->tWStationList->item(i, 1)->text() == "") continue;
 
         pos[0] = ui->tWStationList->item(i, 1)->text().toDouble(&ok) * D2R;

--- a/app/qtapp/appcmn_qt/refdlg.ui
+++ b/app/qtapp/appcmn_qt/refdlg.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>542</width>
+    <width>900</width>
     <height>445</height>
    </rect>
   </property>


### PR DESCRIPTION
The windows app accepts station position file entries without either an ID or Name, perhaps some are just positions, and an ID alone is useful as for the SINEX files.

TODO the windows app and getstapos() in postpos.c use scanf() to parse the station file and this is tolerant of multiple spaces as a field separator but that breaks the current qt refdlg parser which appears to consider each space a separator.
