### PR TITLE
getstapos: add sinex suport, and export

### DIFF
--- a/src/postpos.c
+++ b/src/postpos.c
@@ -841,47 +841,14 @@ static int avepos(double *ra, int rcv, const obs_t *obs, const nav_t *nav,
     for (i=0;i<3;i++) ra[i]/=n;
     return 1;
 }
-/* station position from file ------------------------------------------------*/
-static int getstapos(const char *file, const char *name, double *r)
-{
-    FILE *fp;
-    char buff[256],sname[256],*p;
-    const char *q;
-    double pos[3];
 
-    trace(3,"getstapos: file=%s name=%s\n",file,name);
-
-    if (!(fp=fopen(file,"r"))) {
-        trace(1,"station position file open error: %s\n",file);
-        return 0;
-    }
-    while (fgets(buff,sizeof(buff),fp)) {
-        if ((p=strchr(buff,'%'))) *p='\0';
-        
-        if (sscanf(buff,"%lf %lf %lf %255s",pos,pos+1,pos+2,sname)<4) continue;
-        
-        for (p=sname,q=name;*p&&*q;p++,q++) {
-            if (toupper((int)*p)!=toupper((int)*q)) break;
-        }
-        if (!*p) {
-            pos[0]*=D2R;
-            pos[1]*=D2R;
-            pos2ecef(pos,r);
-            fclose(fp);
-            return 1;
-        }
-    }
-    fclose(fp);
-    trace(1,"no station position: %s %s\n",name,file);
-    return 0;
-}
 /* antenna phase center position ---------------------------------------------*/
 static int antpos(prcopt_t *opt, int rcvno, const obs_t *obs, const nav_t *nav,
-                  const sta_t *sta, const char *posfile)
+                  const sta_t *stas, const char *posfile)
 {
     double *rr=rcvno==1?opt->ru:opt->rb,del[3],pos[3],dr[3]={0};
     int i,postype=rcvno==1?opt->rovpos:opt->refpos;
-    char *name;
+    const char *name;
 
     trace(3,"antpos  : rcvno=%d\n",rcvno);
 

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1862,6 +1862,7 @@ EXPORT int postpos(gtime_t ts, gtime_t te, double ti, double tu,
                    const prcopt_t *popt, const solopt_t *sopt,
                    const filopt_t *fopt, const char **infile, int n, const char *outfile,
                    const char *rov, const char *base);
+EXPORT int getstapos(const char *file, const char *name, double *r);
 
 /* stream server functions ---------------------------------------------------*/
 EXPORT void strsvrinit (strsvr_t *svr, int nout);


### PR DESCRIPTION
This allows POSOPT_FILE (read from pos file) to also read from a sinex position estimates file, whereas it currently only reads from a rtklib station position file. The GUI apps already have some support for reading positions from sinex files but that still requires manually selecting the station position and support for this code path was missing. This allows postpos to automatically obtain the station name from the input rinex file and then to automatically lookup the position from a sinex file.