### PR TITLE
rtkplot: add sky and DOP plots using the solution stat input

### DIFF
--- a/app/qtapp/rtkplot_qt/plotcmn.cpp
+++ b/app/qtapp/rtkplot_qt/plotcmn.cpp
@@ -23,12 +23,23 @@ extern "C" {
     }
 }
 //---------------------------------------------------------------------------
-const char *PTypes[] = {
-    QT_TRANSLATE_NOOP("Plot", "Ground Track"), QT_TRANSLATE_NOOP("Plot", "Position"), QT_TRANSLATE_NOOP("Plot", "Velocity"), QT_TRANSLATE_NOOP("Plot", "Acceleration"),
-    QT_TRANSLATE_NOOP("Plot", "NSat"), QT_TRANSLATE_NOOP("Plot", "Residuals"), QT_TRANSLATE_NOOP("Plot", "Residuals-El"),
-    QT_TRANSLATE_NOOP("Plot", "Sat Visibility"), QT_TRANSLATE_NOOP("Plot", "Skyplot"),  QT_TRANSLATE_NOOP("Plot", "DOP/NSat"), QT_TRANSLATE_NOOP("Plot", "SNR/MP/El"),
-    QT_TRANSLATE_NOOP("Plot", "SNR/MP-El"), QT_TRANSLATE_NOOP("Plot", "MP-Skyplot"),  QT_TRANSLATE_NOOP("Plot", "Iono-Skyplot"), ""
-};
+const char *PTypes[] = {QT_TRANSLATE_NOOP("Plot", "Ground Track"),
+                        QT_TRANSLATE_NOOP("Plot", "Position"),
+                        QT_TRANSLATE_NOOP("Plot", "Velocity"),
+                        QT_TRANSLATE_NOOP("Plot", "Acceleration"),
+                        QT_TRANSLATE_NOOP("Plot", "NSat"),
+                        QT_TRANSLATE_NOOP("Plot", "Skyplot"),
+                        QT_TRANSLATE_NOOP("Plot", "DOP/NSat"),
+                        QT_TRANSLATE_NOOP("Plot", "Residuals"),
+                        QT_TRANSLATE_NOOP("Plot", "Residuals-El"),
+                        QT_TRANSLATE_NOOP("Plot", "Sat Visibility"),
+                        QT_TRANSLATE_NOOP("Plot", "Skyplot obs"),
+                        QT_TRANSLATE_NOOP("Plot", "DOP/NSat obs"),
+                        QT_TRANSLATE_NOOP("Plot", "SNR/MP/El"),
+                        QT_TRANSLATE_NOOP("Plot", "SNR/MP-El"),
+                        QT_TRANSLATE_NOOP("Plot", "MP-Skyplot"),
+                        QT_TRANSLATE_NOOP("Plot", "Iono-Skyplot"),
+                        ""};
 // show message in status-bar -----------------------------------------------
 void Plot::showMessage(const QString &msg)
 {
@@ -125,7 +136,8 @@ bool Plot::getCenterPosition(double *rr)
 
     trace(3, "getCenterPosition\n");
 
-    if (PLOT_OBS <= plotType && plotType <= PLOT_DOP && plotType != PLOT_TRK) return false;
+    if (PLOT_OBS <= plotType && plotType <= PLOT_DOP && plotType != PLOT_TRK)
+      return false;
     if (norm(originPosition, 3) <= 0.0) return false;
     
     graphTrack->getCenter(xc, yc);

--- a/app/qtapp/rtkplot_qt/plotinfo.cpp
+++ b/app/qtapp/rtkplot_qt/plotinfo.cpp
@@ -291,15 +291,17 @@ void Plot::updatePlotTypeMenu()
         ui->cBPlotTypeSelection->addItem(tr(PTypes[PLOT_NSAT]), PLOT_NSAT);
     }
 
+    if (solutionStat[0].n > 0 || solutionStat[1].n > 0) {
+        ui->cBPlotTypeSelection->addItem(tr(PTypes[PLOT_SSKY]), PLOT_SSKY);
+        ui->cBPlotTypeSelection->addItem(tr(PTypes[PLOT_SDOP]), PLOT_SDOP);
+        ui->cBPlotTypeSelection->addItem(tr(PTypes[PLOT_RES]), PLOT_RES);
+        ui->cBPlotTypeSelection->addItem(tr(PTypes[PLOT_RESE]), PLOT_RESE);
+    }
+
     if (nObservation > 0) {
         ui->cBPlotTypeSelection->addItem(tr(PTypes[PLOT_OBS]), PLOT_OBS);
         ui->cBPlotTypeSelection->addItem(tr(PTypes[PLOT_SKY]), PLOT_SKY);
         ui->cBPlotTypeSelection->addItem(tr(PTypes[PLOT_DOP]), PLOT_DOP);
-    }
-
-    if (solutionStat[0].n > 0 || solutionStat[1].n > 0) {
-        ui->cBPlotTypeSelection->addItem(tr(PTypes[PLOT_RES]), PLOT_RES);
-        ui->cBPlotTypeSelection->addItem(tr(PTypes[PLOT_RESE]), PLOT_RESE);
     }
 
     if ((nObservation > 0)  && (!simulatedObservation)) {
@@ -450,7 +452,8 @@ void Plot::updatePoint(int x, int y)
 
             msg = latLonString(pos, 8);
         }
-    } else if (plotType == PLOT_SKY || plotType == PLOT_MPS || plotType == PLOT_IONOS) { // sky-plot
+    } else if (plotType == PLOT_SKY || plotType == PLOT_SSKY || plotType == PLOT_MPS ||
+               plotType == PLOT_IONOS) { // sky-plot
         graphSky->getLimits(xl, yl);
         graphSky->toPos(p, q[0], q[1]);
         r = (xl[1] - xl[0] < yl[1] - yl[0] ? xl[1] - xl[0] : yl[1] - yl[0]) * 0.45;

--- a/app/qtapp/rtkplot_qt/plotmain.h
+++ b/app/qtapp/rtkplot_qt/plotmain.h
@@ -35,15 +35,17 @@
 #define PLOT_SOLV   2                   // plot-type: velocity-plot
 #define PLOT_SOLA   3                   // plot-type: accel-plot
 #define PLOT_NSAT   4                   // plot-type: number-of-satellite-plot
-#define PLOT_RES    5                   // plot-type: residual-plot
-#define PLOT_RESE   6                   // plot-type: residual-elevation plot
-#define PLOT_OBS    7                   // plot-type: observation-data-plot
-#define PLOT_SKY    8                   // plot-type: sky-plot
-#define PLOT_DOP    9                   // plot-type: dop-plot
-#define PLOT_SNR    10                  // plot-type: snr/mp-plot
-#define PLOT_SNRE   11                  // plot-type: snr/mp-el-plot
-#define PLOT_MPS    12                  // plot-type: mp-skyplot
-#define PLOT_IONOS  13                  // plot-type: iono-skyplot
+#define PLOT_SSKY   5                   // plot-type: sky-plot (solution)
+#define PLOT_SDOP   6                   // plot-type: dop-plot
+#define PLOT_RES    7                   // plot-type: residual-plot
+#define PLOT_RESE   8                   // plot-type: residual-elevation plot
+#define PLOT_OBS    9                   // plot-type: observation-data-plot
+#define PLOT_SKY    10                  // plot-type: sky-plot
+#define PLOT_DOP    11                  // plot-type: dop-plot (solution)
+#define PLOT_SNR    12                  // plot-type: snr/mp-plot
+#define PLOT_SNRE   13                  // plot-type: snr/mp-el-plot
+#define PLOT_MPS    14                  // plot-type: mp-skyplot
+#define PLOT_IONOS  15                  // plot-type: iono-skyplot
 
 #define ORG_STARTPOS 0                  // plot-origin: start position
 #define ORG_ENDPOS  1                   // plot-origin: end position
@@ -345,7 +347,9 @@ private:
     void drawObservationEphemeris(QPainter &g,double *yp);
     void drawSkyImage(QPainter &g,int level);
     void drawSky(QPainter &g,int level);
+    void drawSolSky(QPainter &g,int level);
     void drawDop(QPainter &g,int level);
+    void drawSolDop(QPainter &g,int level);
     void drawDopStat(QPainter &g,double *dop, int *ns, int n);
     void drawSnr(QPainter &g,int level);
     void drawSnrE(QPainter &g,int level);

--- a/app/winapp/rtkplot/plotcmn.cpp
+++ b/app/winapp/rtkplot/plotcmn.cpp
@@ -12,8 +12,9 @@ int showmsg(const char *format,...) {return 0;}
 }
 //---------------------------------------------------------------------------
 const char *PTypes[]={
-    "Gnd Trk","Position","Velocity","Accel","NSat","Residuals","Resid-EL",
-    "Sat Vis","Skyplot","DOP/NSat","SNR/MP/EL","SNR/MP-EL","MP-Skyplot",""
+  "Gnd Trk","Position","Velocity","Accel","NSat","Skyplot","DOP/NSat",
+  "Residuals","Resid-EL","Sat Vis","Skyplot obs","DOP/NSat obs","SNR/MP/EL",
+  "SNR/MP-EL","MP-Skyplot",""
 };
 // show message in status-bar -----------------------------------------------
 void __fastcall TPlot::ShowMsg(UTF8String msg)

--- a/app/winapp/rtkplot/plotinfo.cpp
+++ b/app/winapp/rtkplot/plotinfo.cpp
@@ -259,14 +259,16 @@ void __fastcall TPlot::UpdatePlotType(void)
         PlotTypeS->AddItem(PTypes[PLOT_SOLA],NULL);
         PlotTypeS->AddItem(PTypes[PLOT_NSAT],NULL);
     }
+    if (SolStat[0].n>0||SolStat[1].n>0) {
+        PlotTypeS->AddItem(PTypes[PLOT_SSKY],NULL);
+        PlotTypeS->AddItem(PTypes[PLOT_SDOP],NULL);
+        PlotTypeS->AddItem(PTypes[PLOT_RES ],NULL);
+        PlotTypeS->AddItem(PTypes[PLOT_RESE],NULL);
+    }
     if (NObs>0) {
         PlotTypeS->AddItem(PTypes[PLOT_OBS ],NULL);
         PlotTypeS->AddItem(PTypes[PLOT_SKY ],NULL);
         PlotTypeS->AddItem(PTypes[PLOT_DOP ],NULL);
-    }
-    if (SolStat[0].n>0||SolStat[1].n>0) {
-        PlotTypeS->AddItem(PTypes[PLOT_RES ],NULL);
-        PlotTypeS->AddItem(PTypes[PLOT_RESE],NULL);
     }
     if (NObs>0) {
         PlotTypeS->AddItem(PTypes[PLOT_SNR ],NULL);
@@ -395,7 +397,7 @@ void __fastcall TPlot::UpdatePoint(int x, int y)
             msg=LatLonStr(pos,8);
         }
     }
-    else if (PlotType==PLOT_SKY||PlotType==PLOT_MPS) { // sky-plot
+    else if (PlotType==PLOT_SKY||PlotType==PLOT_SSKY||PlotType==PLOT_MPS) { // sky-plot
         
         GraphS->GetLim(xl,yl);
         GraphS->ToPos(p,q[0],q[1]);

--- a/app/winapp/rtkplot/plotmain.cpp
+++ b/app/winapp/rtkplot/plotmain.cpp
@@ -367,7 +367,7 @@ void __fastcall TPlot::DropFiles(TWMDropFiles msg)
         if (PlotType==PLOT_TRK) {
             ReadMapData(file);
         }
-        else if (PlotType==PLOT_SKY||PlotType==PLOT_MPS) {
+        else if (PlotType==PLOT_SKY||PlotType==PLOT_SSKY||PlotType==PLOT_MPS) {
             ReadSkyData(file);
         }
     }
@@ -1362,7 +1362,7 @@ void __fastcall TPlot::TimeScrollChange(TObject *Sender)
     
     trace(3,"TimeScrollChange\n");
     
-    if (PlotType<=PLOT_NSAT||PlotType==PLOT_RES) {
+    if (PlotType<=PLOT_SDOP||PlotType==PLOT_RES) {
         SolIndex[sel]=TimeScroll->Position;
     }
     else {
@@ -1390,7 +1390,7 @@ void __fastcall TPlot::DispMouseDown(TObject *Sender, TMouseButton Button,
     if (PlotType==PLOT_TRK) {
         MouseDownTrk(X,Y);
     }
-    else if (PlotType<=PLOT_NSAT||PlotType==PLOT_RES||PlotType==PLOT_SNR) {
+    else if (PlotType<=PLOT_SDOP||PlotType==PLOT_RES||PlotType==PLOT_SNR) {
         MouseDownSol(X,Y);
     }
     else if (PlotType==PLOT_OBS||PlotType==PLOT_DOP) {
@@ -1421,7 +1421,7 @@ void __fastcall TPlot::DispMouseMove(TObject *Sender, TShiftState Shift, int X, 
     else if (PlotType==PLOT_TRK) {
         MouseMoveTrk(X,Y,dx,dy,dxs,dys);
     }
-    else if (PlotType<=PLOT_NSAT||PlotType==PLOT_RES||PlotType==PLOT_SNR) {
+    else if (PlotType<=PLOT_SDOP||PlotType==PLOT_RES||PlotType==PLOT_SNR) {
         MouseMoveSol(X,Y,dx,dy,dxs,dys);
     }
     else if (PlotType==PLOT_OBS||PlotType==PLOT_DOP) {
@@ -1460,7 +1460,7 @@ void __fastcall TPlot::DispDblClick(TObject *Sender)
         SetCentX(x);
         Refresh();
     }
-    else if (PlotType==PLOT_OBS||PlotType==PLOT_DOP) {
+    else if (PlotType==PLOT_OBS||PlotType==PLOT_DOP||PlotType==PLOT_SDOP) {
         GraphR->ToPos(p,x,y);
         SetCentX(x);
         Refresh();
@@ -1743,7 +1743,7 @@ void __fastcall TPlot::MouseWheel(TObject *Sender, TShiftState Shift,
             }
         }
     }
-    else if (PlotType==PLOT_OBS||PlotType==PLOT_DOP) {
+    else if (PlotType==PLOT_OBS||PlotType==PLOT_DOP||PlotType==PLOT_SDOP) {
         area=GraphR->OnAxis(p);
         if (area==0||area==8) {
             GraphR->GetScale(xs,ys);
@@ -1820,7 +1820,7 @@ void __fastcall TPlot::FormKeyDown(TObject *Sender, WORD &Key,
         GraphG[1]->SetScale(xs,ys2);
         GraphG[2]->SetScale(xs,ys3);
     }
-    else if (PlotType==PLOT_OBS||PlotType==PLOT_DOP||PlotType==PLOT_SNR) {
+    else if (PlotType==PLOT_OBS||PlotType==PLOT_DOP||PlotType==PLOT_SDOP||PlotType==PLOT_SNR) {
         GraphR->GetCent(xc,yc);
         GraphR->GetScale(xs,ys);
         if (key== 1) {if (!BtnFixVert ->Down) yc+=fact*ys;}
@@ -1907,7 +1907,7 @@ void __fastcall TPlot::TimerTimer(TObject *Sender)
     else if (BtnAnimate->Enabled&&BtnAnimate->Down) { // animation mode
         cycle=AnimCycle<=0?1:AnimCycle;
         
-        if (PlotType<=PLOT_NSAT||PlotType==PLOT_RES) {
+        if (PlotType<=PLOT_SDOP||PlotType==PLOT_RES) {
             SolIndex[sel]+=cycle;
             if (SolIndex[sel]>=SolData[sel].n-1) {
                 SolIndex[sel]=SolData[sel].n-1;
@@ -1938,7 +1938,7 @@ void __fastcall TPlot::TimerTimer(TObject *Sender)
                 NStrBuff = 0;
             }
         }
-        if (time.time&&(PlotType<=PLOT_NSAT||PlotType<=PLOT_RES)) {
+        if (time.time&&(PlotType<=PLOT_SDOP||PlotType<=PLOT_RES)) {
            i=SolIndex[sel];
            if (!(sol=getsol(SolData+sel,i))) return;
            double tt=timediff(sol->time,time);
@@ -2083,7 +2083,7 @@ void __fastcall TPlot::UpdateTime(void)
     trace(3,"UpdateTime\n");
     
     // time-cursor change on solution-plot
-    if (PlotType<=PLOT_NSAT||PlotType<=PLOT_RESE) {
+    if (PlotType<=PLOT_SDOP||PlotType<=PLOT_RESE) {
         TimeScroll->Max=MAX(1,SolData[sel].n-1);
         TimeScroll->Position=SolIndex[sel];
         if (!(sol=getsol(SolData+sel,SolIndex[sel]))) return;
@@ -2270,17 +2270,18 @@ void __fastcall TPlot::UpdateEnable(void)
     
     BtnConnect     ->Down   = ConnectState;
     BtnSol1        ->Enabled=true;
-    BtnSol2        ->Enabled=PlotType<=PLOT_NSAT||PlotType==PLOT_RES||PlotType==PLOT_RESE;
+    BtnSol2        ->Enabled=PlotType<=PLOT_SDOP||PlotType==PLOT_RES||PlotType==PLOT_RESE;
     BtnSol12       ->Enabled=!ConnectState&&PlotType<=PLOT_SOLA&&SolData[0].n>0&&SolData[1].n>0;
     QFlag          ->Visible=PlotType==PLOT_TRK ||PlotType==PLOT_SOLP||
                              PlotType==PLOT_SOLV||PlotType==PLOT_SOLA||
                              PlotType==PLOT_NSAT;
     ObsType        ->Visible=PlotType==PLOT_OBS||PlotType==PLOT_SKY;
     ObsType2       ->Visible=PlotType==PLOT_SNR||PlotType==PLOT_SNRE||PlotType==PLOT_MPS;
-    FrqType        ->Visible=PlotType==PLOT_RES||PlotType==PLOT_RESE;
-    DopType        ->Visible=PlotType==PLOT_DOP;
+    FrqType        ->Visible=PlotType==PLOT_SSKY||PlotType==PLOT_RES||PlotType==PLOT_RESE;
+    DopType        ->Visible=PlotType==PLOT_DOP||PlotType==PLOT_SDOP;
     SatList        ->Visible=PlotType==PLOT_RES||PlotType==PLOT_RESE||PlotType>=PLOT_OBS||
-                             PlotType==PLOT_SKY||PlotType==PLOT_DOP||
+                             PlotType==PLOT_SSKY||PlotType==PLOT_SKY||
+                             PlotType==PLOT_SDOP||PlotType==PLOT_DOP||
                              PlotType==PLOT_SNR||PlotType==PLOT_SNRE||
                              PlotType==PLOT_MPS;
     QFlag          ->Enabled=data;
@@ -2309,8 +2310,8 @@ void __fastcall TPlot::UpdateEnable(void)
     BtnFitHoriz    ->Visible=PlotType==PLOT_SOLP||PlotType==PLOT_SOLV||
                              PlotType==PLOT_SOLA||PlotType==PLOT_NSAT||
                              PlotType==PLOT_RES ||PlotType==PLOT_OBS ||
-                             PlotType==PLOT_DOP ||PlotType==PLOT_SNR ||
-                             PlotType==PLOT_SNRE;
+                             PlotType==PLOT_DOP ||PlotType==PLOT_SDOP||
+                             PlotType==PLOT_SNR ||PlotType==PLOT_SNRE;
     BtnFitHoriz    ->Enabled=data;
     BtnFitVert     ->Visible=PlotType==PLOT_TRK ||PlotType==PLOT_SOLP||
                              PlotType==PLOT_SOLV||PlotType==PLOT_SOLA;
@@ -2321,7 +2322,8 @@ void __fastcall TPlot::UpdateEnable(void)
     BtnFixHoriz    ->Visible=PlotType==PLOT_SOLP||PlotType==PLOT_SOLV||
                              PlotType==PLOT_SOLA||PlotType==PLOT_NSAT||
                              PlotType==PLOT_RES ||PlotType==PLOT_OBS ||
-                             PlotType==PLOT_DOP ||PlotType==PLOT_SNR;
+                             PlotType==PLOT_DOP ||PlotType==PLOT_DOP ||
+                             PlotType==PLOT_SNR;
     BtnFixHoriz    ->Enabled=data;
     BtnFixVert     ->Visible=PlotType==PLOT_SOLP||PlotType==PLOT_SOLV||
                              PlotType==PLOT_SOLA;
@@ -2330,7 +2332,7 @@ void __fastcall TPlot::UpdateEnable(void)
     BtnShowSkyplot ->Visible=PlotType==PLOT_SKY||PlotType==PLOT_MPS;
     BtnShowMap     ->Visible=PlotType==PLOT_TRK;
     BtnShowMap     ->Enabled=!BtnSol12->Down;
-    BtnShowImg     ->Visible=PlotType==PLOT_TRK||PlotType==PLOT_SKY||
+    BtnShowImg     ->Visible=PlotType==PLOT_TRK||PlotType==PLOT_SKY||PlotType==PLOT_SSKY||
                              PlotType==PLOT_MPS;
     BtnMapView     ->Visible=PlotType==PLOT_TRK||PlotType==PLOT_SOLP;
     Panel12        ->Visible=!ConnectState;

--- a/app/winapp/rtkplot/plotmain.h
+++ b/app/winapp/rtkplot/plotmain.h
@@ -48,14 +48,16 @@
 #define PLOT_SOLV   2                   // plot-type: velocity-plot
 #define PLOT_SOLA   3                   // plot-type: accel-plot
 #define PLOT_NSAT   4                   // plot-type: number-of-satellite-plot
-#define PLOT_RES    5                   // plot-type: residual-plot
-#define PLOT_RESE   6                   // plot-type: residual-elevation plot
-#define PLOT_OBS    7                   // plot-type: observation-data-plot
-#define PLOT_SKY    8                   // plot-type: sky-plot
-#define PLOT_DOP    9                   // plot-type: dop-plot
-#define PLOT_SNR    10                  // plot-type: snr/mp-plot
-#define PLOT_SNRE   11                  // plot-type: snr/mp-el-plot
-#define PLOT_MPS    12                  // plot-type: mp-skyplot
+#define PLOT_SSKY   5                   // plot-type: sky-plot
+#define PLOT_SDOP   6                   // plot-type: dop-plot
+#define PLOT_RES    7                   // plot-type: residual-plot
+#define PLOT_RESE   8                   // plot-type: residual-elevation plot
+#define PLOT_OBS    9                   // plot-type: observation-data-plot
+#define PLOT_SKY    10                  // plot-type: sky-plot
+#define PLOT_DOP    11                  // plot-type: dop-plot
+#define PLOT_SNR    12                  // plot-type: snr/mp-plot
+#define PLOT_SNRE   13                  // plot-type: snr/mp-el-plot
+#define PLOT_MPS    14                  // plot-type: mp-skyplot
 
 #define ORG_STARTPOS 0                  // plot-origin: start position
 #define ORG_ENDPOS  1                   // plot-origin: end position
@@ -512,7 +514,9 @@ private:
     void __fastcall DrawObsEphem (double *yp);
     void __fastcall DrawSkyImage (int level);
     void __fastcall DrawSky      (int level);
+    void __fastcall DrawSolSky   (int level);
     void __fastcall DrawDop      (int level);
+    void __fastcall DrawSolDop   (int level);
     void __fastcall DrawDopStat  (double *dop, int *ns, int n);
     void __fastcall DrawSnr      (int level);
     void __fastcall DrawSnrE     (int level);

--- a/src/solution.c
+++ b/src/solution.c
@@ -1025,7 +1025,13 @@ static int cmpsolstat(const void *p1, const void *p2)
 {
     solstat_t *q1=(solstat_t *)p1,*q2=(solstat_t *)p2;
     double tt=timediff(q1->time,q2->time);
-    return tt<-0.0?-1:(tt>0.0?1:0);
+    if (tt < -0.0) return -1;
+    if (tt > 0.0) return 1;
+    if (q1->sat < q2->sat) return -1;
+    if (q1->sat > q2->sat) return 1;
+    if (q1->frq < q2->frq) return -1;
+    if (q1->frq > q2->frq) return 1;
+    return 0;
 }
 /* sort solution data --------------------------------------------------------*/
 static int sort_solstat(solstatbuf_t *statbuf)
@@ -1115,7 +1121,7 @@ static int readsolstatdata(FILE *fp, gtime_t ts, gtime_t te, double tint,
     char buff[MAXSOLLEN+1];
     
     trace(3,"readsolstatdata:\n");
-    
+
     while (fgets(buff,sizeof(buff),fp)) {
         
         /* decode solution status */


### PR DESCRIPTION
In part prompted by the discussion in https://github.com/rtklibexplorer/RTKLIB/discussions/712 This is for the Qt rtkplot, but can have a look at windows app support if this is considered useful.

The solution stat file has the satellites used in the solution and the satellite azimuth and elevation which is a usable input for these plots, and without loading the observation and navigation data. It also gives the data used in the solution. These are added as additional plots to the current observation data based sky and DOP plot which are still useful when examining this data and planning solutions.