### PR TITLE
gitignore: use positive logic

### DIFF
--- a/app/consapp/.gitignore
+++ b/app/consapp/.gitignore
@@ -1,12 +1,5 @@
-# Ignore all files in the lib directory
-*
-
-# But not the following directories and files
-!.gitignore
-!*.c
-!*.h
-!*.bat
-!*.sh
-!makefile
-!CMakeLists.txt
-!rtklib_consapp.groupproj
+convbin/gcc/convbin
+pos2kml/gcc/pos2kml
+rnx2rtkp/gcc/rnx2rtkp
+rtkrcv/gcc/rtkrcv
+str2str/gcc/str2str

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,10 +1,2 @@
-# Ignore all files in the lib directory
-*
-
-# But not the following directories and files
-!.gitignore
-!iers
-!omf
-!openblas
-!sofa
-!CMakeLists.txt
+libRTKLib.so*
+librtklib.so

--- a/test/utest/.gitignore
+++ b/test/utest/.gitignore
@@ -1,9 +1,15 @@
-# Ignore all files in the lib directory
-*
+*.out
+t_atmos
+t_coord
+t_geoid
+t_gloeph
+t_ionex
+t_lambda
+t_matrix
+t_misc
+t_ppp
+t_preceph
+t_rinex
+t_time
+t_tle
 
-# But not the following directories and files
-!.gitignore
-!*.c
-!*.m
-!makefile
-!figtest*.jpg


### PR DESCRIPTION
rather than using this as a 'gitconsider'.

The current .gitignore failed to include the directories in the app/consapp/ and perhaps there are other issues. Not an expert on gitignore but it would appear to have been intended to ignore the particular rather than to ignore all and then consider the particular.