### PR TITLE
Correct sept and ublox BDS CNAV UTC decoding

### DIFF
--- a/src/rcv/septentrio.c
+++ b/src/rcv/septentrio.c
@@ -2022,21 +2022,22 @@ static int decode_cmpraw(raw_t *raw){
         else return 0;
     }
     else { /* GEO */
-        pgn = getbitu(buff, 42, 4); /* page number */
-
-        if (id==1 && pgn>=1 && pgn<=10) {
-            memcpy(raw->subfrm[sat-1]+(pgn-1)*38, buff, 38);
-            if (pgn != 10) return 0;
-            if (!decode_bds_d2(raw->subfrm[sat-1], &eph, NULL)) return 0;
-        }
-        else if (id==1 && pgn==102) {
-            memcpy(raw->subfrm[sat-1]+10*38, buff, 38);
-            if (!decode_bds_d2(raw->subfrm[sat-1], NULL, utc)) return 0;
-            matcpy(raw->nav.utc_cmp, utc, 8, 1);
-            return 9;
-        }
-        else
-            return 0;
+      if (id == 1) {
+        int pgn = getbitu(buff, 42, 4);  // Page number.
+        if (pgn < 1 || pgn > 10) return 0;
+        memcpy(raw->subfrm[sat - 1] + (pgn - 1) * 38, buff, 38);
+        if (pgn != 10) return 0;
+        if (!decode_bds_d2(raw->subfrm[sat - 1], &eph, NULL)) return 0;
+      } else if (id == 5) {
+        int pgn = getbitu(buff, 43, 7);  // Page number.
+        if (pgn != 102) return 0;
+        memcpy(raw->subfrm[sat - 1] + 10 * 38, buff, 38);
+        double utc[8];
+        if (!decode_bds_d2(raw->subfrm[sat - 1], NULL, utc)) return 0;
+        matcpy(raw->nav.utc_cmp, utc, 8, 1);
+        return 9;
+      } else
+        return 0;
     }
     if (!strstr(raw->opt, "-EPHALL")) {
         if (timediff(eph.toe, raw->nav.eph[sat-1].toe) == 0.0)

--- a/src/rcv/ublox.c
+++ b/src/rcv/ublox.c
@@ -1028,18 +1028,20 @@ static int decode_cnav(raw_t *raw, int sat, int off)
         else return 0;
     }
     else { /* GEO */
-        pgn=getbitu(buff,42,4); /* page numuber */
-        
-        if (id==1&&pgn>=1&&pgn<=10) {
-            memcpy(raw->subfrm[sat-1]+(pgn-1)*38,buff,38);
-            if (pgn!=10) return 0;
-            if (!decode_bds_d2(raw->subfrm[sat-1],&eph,NULL)) return 0;
+        if (id == 1) {
+          pgn = getbitu(buff, 42, 4); // Page numuber.
+          if (pgn < 1 || pgn > 10) return 0;
+          memcpy(raw->subfrm[sat-1]+(pgn-1)*38,buff,38);
+          if (pgn!=10) return 0;
+          if (!decode_bds_d2(raw->subfrm[sat-1],&eph,NULL)) return 0;
         }
-        else if (id==5&&pgn==102) {
-            memcpy(raw->subfrm[sat-1]+10*38,buff,38);
-            if (!decode_bds_d2(raw->subfrm[sat-1],NULL,utc)) return 0;
-            matcpy(raw->nav.utc_cmp,utc,8,1);
-            return 9;
+        else if (id == 5) {
+          int pgn = getbitu(buff, 43, 7); // Page number.
+          if (pgn != 102) return 0;
+          memcpy(raw->subfrm[sat-1]+10*38,buff,38);
+          if (!decode_bds_d2(raw->subfrm[sat-1],NULL,utc)) return 0;
+          matcpy(raw->nav.utc_cmp,utc,8,1);
+          return 9;
         }
         else return 0;
     }


### PR DESCRIPTION
For the GEO satellites nav subframe 5 the page number is a 7 bits rather than four and this is needed to find page 105.