### PR TITLE
Clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+# see https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+---
+BasedOnStyle: Google
+Language: Cpp
+ColumnLimit: 100
+UseTab: Never

--- a/app/consapp/convbin/convbin.c
+++ b/app/consapp/convbin/convbin.c
@@ -617,7 +617,9 @@ static int cmdopts(int argc, char **argv, rnxopt_t *opt, char **ifile,
         if      (!strcmp(fmt,"rtcm2")) format=STRFMT_RTCM2;
         else if (!strcmp(fmt,"rtcm3")) format=STRFMT_RTCM3;
         else if (!strcmp(fmt,"nov"  )) format=STRFMT_OEM4;
-        /* else if (!strcmp(fmt,"cnav" )) format=STRFMT_CNAV; */
+#ifdef RTK_DISABLED
+        else if (!strcmp(fmt,"cnav" )) format=STRFMT_CNAV;
+#endif
         else if (!strcmp(fmt,"ubx"  )) format=STRFMT_UBX;
         else if (!strcmp(fmt,"sbp"  )) format=STRFMT_SBP;
         else if (!strcmp(fmt,"hemis")) format=STRFMT_CRES;
@@ -628,7 +630,9 @@ static int cmdopts(int argc, char **argv, rnxopt_t *opt, char **ifile,
         else if (!strcmp(fmt,"rt17" )) format=STRFMT_RT17;
         else if (!strcmp(fmt,"sbf"  )) format=STRFMT_SEPT;
         else if (!strcmp(fmt,"unicore")) format=STRFMT_UNICORE;
-        /* else if (!strcmp(fmt,"tersus")) format=STRFMT_TERSUS; */
+#ifdef RTK_DISABLED
+        else if (!strcmp(fmt,"tersus")) format=STRFMT_TERSUS;
+#endif
         else if (!strcmp(fmt,"rinex")) format=STRFMT_RINEX;
     }
     else {
@@ -637,7 +641,9 @@ static int cmdopts(int argc, char **argv, rnxopt_t *opt, char **ifile,
         if      (!strcmp(p,".rtcm2"))  format=STRFMT_RTCM2;
         else if (!strcmp(p,".rtcm3"))  format=STRFMT_RTCM3;
         else if (!strcmp(p,".gps"  ))  format=STRFMT_OEM4;
-        /* else if (!strcmp(p,"cnav" )) format=STRFMT_CNAV; */
+#ifdef RTK_DISABLED
+        else if (!strcmp(p,"cnav" )) format=STRFMT_CNAV
+#endif
         else if (!strcmp(p,".ubx"  ))  format=STRFMT_UBX;
         else if (!strcmp(p,".sbp"  ))  format=STRFMT_SBP;
         else if (!strcmp(p,".bin"  ))  format=STRFMT_CRES;
@@ -648,7 +654,9 @@ static int cmdopts(int argc, char **argv, rnxopt_t *opt, char **ifile,
         else if (!strcmp(p,".rt17" ))  format=STRFMT_RT17;
         else if (!strcmp(p,".sbf"  ))  format=STRFMT_SEPT;
         else if (!strcmp(p,".unc"  ))  format=STRFMT_UNICORE;
-        /* else if (!strcmp(p,".trs"  ))  format=STRFMT_TERSUS; */
+#ifdef RTK_DISABLED
+        else if (!strcmp(p,".trs"  ))  format=STRFMT_TERSUS;
+#endif
         else if (!strcmp(p,".obs"  ))  format=STRFMT_RINEX;
         else if (!strcmp(p+3,"o"   ))  format=STRFMT_RINEX;
         else if (!strcmp(p+3,"O"   ))  format=STRFMT_RINEX;

--- a/app/consapp/str2str/str2str.c
+++ b/app/consapp/str2str/str2str.c
@@ -153,7 +153,9 @@ static void decodefmt(char *path, int *fmt)
         if      (!strcmp(p,"#rtcm2")) *fmt=STRFMT_RTCM2;
         else if (!strcmp(p,"#rtcm3")) *fmt=STRFMT_RTCM3;
         else if (!strcmp(p,"#nov"  )) *fmt=STRFMT_OEM4;
-        /* else if (!strcmp(p,"#cnav" )) *fmt=STRFMT_CNAV; */
+#ifdef RTK_DISABLED
+        else if (!strcmp(p,"#cnav" )) *fmt=STRFMT_CNAV;
+#endif
         else if (!strcmp(p,"#ubx"  )) *fmt=STRFMT_UBX;
         else if (!strcmp(p,"#swift")) *fmt=STRFMT_SBP;
         else if (!strcmp(p,"#hemis")) *fmt=STRFMT_CRES;

--- a/app/qtapp/rtkplot_qt/plotmain.cpp
+++ b/app/qtapp/rtkplot_qt/plotmain.cpp
@@ -1194,7 +1194,7 @@ void Plot::arrangePlotMapViewHorizontally()
     mapView->setVisible(true);
 }
 //---------------------------------------------------------------------------
-#if 0
+#ifdef RTK_DISABLED
 void Plot::DispGesture()
 {
     AnsiString s;

--- a/app/winapp/appcmn/graph.cpp
+++ b/app/winapp/appcmn/graph.cpp
@@ -322,7 +322,7 @@ void TGraph::DrawMark(TPoint p, int mark, TColor color, int size, int rot)
 	// rot  = rotation angle (deg)
 	
 	// if the same mark already drawn, skip it
-#if 0
+#ifdef RTK_DISABLED
 	if (p.x==p_.x&&p.y==p_.y&&mark==mark_&&color==color_&&size==size_&&
 		rot==rot_) {
 		return;

--- a/app/winapp/rtkconv/convmain.cpp
+++ b/app/winapp/rtkconv/convmain.cpp
@@ -892,8 +892,10 @@ void __fastcall TMainWindow::ConvertFile(void)
 		else if (!strcmp(p,".rt17" )) format=STRFMT_RT17;
 		else if (!strcmp(p,".sbf"  )) format=STRFMT_SEPT;
 		else if (!strcmp(p,".unc"  )) format=STRFMT_UNICORE;
-		/* else if (!strcmp(p,".trs"  )) format=STRFMT_TERSUS; */
-		/* else if (!strcmp(p,".cnb"  )) format=STRFMT_CNAV; */
+#ifdef RTK_DISABLED
+		else if (!strcmp(p,".trs"  )) format=STRFMT_TERSUS;
+		else if (!strcmp(p,".cnb"  )) format=STRFMT_CNAV;
+#endif
 		else if (!strcmp(p,".obs"  )) format=STRFMT_RINEX;
 		else if (!strcmp(p,".OBS"  )) format=STRFMT_RINEX;
 		else if (!strcmp(p,".nav"  )) format=STRFMT_RINEX;
@@ -1040,7 +1042,7 @@ void __fastcall TMainWindow::ConvertFile(void)
 	LabelOutFile->Enabled=true;
 	LabelFormat ->Enabled=true;
 	
-#if 0
+#ifdef RTK_DISABLED
 	// set time-start/end if time not specified
 	if (!TimeStartF->Checked&&rnxopt.tstart.time!=0) {
 		time2str(rnxopt.tstart,tstr,0);

--- a/app/winapp/rtknavi/navimain.cpp
+++ b/app/winapp/rtknavi/navimain.cpp
@@ -24,7 +24,9 @@
 //                           fix bug on unable deselecting antenna PCV
 //                           fix bug on unable saving TGD2 of ephemeris
 //---------------------------------------------------------------------------
+// clang-format off
 #include <vcl.h>
+// clang-format on
 #include <inifiles.hpp>
 #include <mmsystem.h>
 #include <stdio.h>

--- a/app/winapp/rtkplot/plotmain.cpp
+++ b/app/winapp/rtkplot/plotmain.cpp
@@ -1032,7 +1032,7 @@ void __fastcall TPlot::MenuPlotMapViewClick(TObject *Sender)
 void __fastcall TPlot::DispGesture(TObject *Sender, const TGestureEventInfo &EventInfo,
           bool &Handled)
 {
-#if 0
+#ifdef RTK_DISABLED
     AnsiString s;
     int b,e;
     

--- a/app/winapp/strsvr/svrmain.cpp
+++ b/app/winapp/strsvr/svrmain.cpp
@@ -19,7 +19,9 @@
 //						 add option -auto and -tray
 //			 2020/11/30  1.5 number of output channels 3 -> 5
 //---------------------------------------------------------------------------
+// clang-format off
 #include <vcl.h>
+// clang-format on
 #include <inifiles.hpp>
 #include <mmsystem.h>
 #include <stdio.h>

--- a/src/convrnx.c
+++ b/src/convrnx.c
@@ -625,7 +625,7 @@ static void update_stainf(strfile_t *str)
 /* dump station list ---------------------------------------------------------*/
 static void dump_stas(const strfile_t *str)
 {
-#if 1 /* for debug */
+ // #ifdef RTK_DISABLED  // For debug
     stas_t *p;
     double pos[3];
     char s1[40],s2[40];
@@ -644,7 +644,7 @@ static void dump_stas(const strfile_t *str)
               p->sta.rectype,pos[0]*R2D,pos[1]*R2D,pos[2],p->sta.deltype,
               p->sta.del[0],p->sta.del[1],p->sta.del[2]);
     }
-#endif
+  // #endif
 }
 /* add half-cycle ambiguity list ---------------------------------------------*/
 static int add_halfc(strfile_t *str, int sat, int idx, gtime_t time)
@@ -701,7 +701,7 @@ static void update_halfc(strfile_t *str, obsd_t *obs)
 /* dump half-cycle ambiguity list --------------------------------------------*/
 static void dump_halfc(const strfile_t *str)
 {
-#if 0 /* for debug */
+#ifdef RTK_DISABLED
     halfc_t *p;
     char s0[8],s1[40],s2[40],*stats[]={"ADD","SUB","NON"};
     int i,j;

--- a/src/convrnx.c
+++ b/src/convrnx.c
@@ -94,6 +94,7 @@ static const int navsys[RNX_NUMSYS]={     /* system codes */
 
 // Supported obs-type by RINEX version.
 static const char ver3code[][MAXCODE] = {
+  // clang-format off
   // 0........1.........2.........3.........4.........5.........6.........7
   // 1111111111111222222222255577766666668882266333115559999155567778844466 CODE
   // CPWYMNSLEABXZCDSLXPWYMNIQXIQXABCXZSLIQXIQIQIQXIQABCABCXDDPZEDPZDPABXDP
@@ -104,8 +105,10 @@ static const char ver3code[][MAXCODE] = {
     "0......................000............................................", // SBS
     ".4...455.4.45....1.......41114..15....41111............444..44444...55", // BDS
     ".........................3......................3333333..............."  // IRN
+  // clang-format on
 };
 static const char ver4code[][MAXCODE] = {
+  // clang-format off
   // 0........1.........2.........3.........4.........5.........6.........7
   // 1111111111111222222222255577766666668882266333115559999155567778844466 CODE
   // CPWYMNSLEABXZCDSLXPWYMNIQXIQXABCXZSLIQXIQIQIQXIQABCABCXDDPZEDPZDPABXDP
@@ -116,6 +119,7 @@ static const char ver4code[][MAXCODE] = {
     "0......................000............................................", // SBS
     ".0....00...00....0.......0000...00....00000............000..00000...00", // BDS
     ".1.........1.............0......................00000001.............."  // IRN
+  // clang-format on
 };
 
 /* convert RINEX obs-type ver.3 -> ver.2 -------------------------------------*/

--- a/src/geoid.c
+++ b/src/geoid.c
@@ -118,7 +118,7 @@ static double geoidh_egm08(const double *pos, int model)
     /* http://earth-info.nga.mil/GandG/wgs84/gravitymod/egm2008/egm08_wgs84.html */
     /* (1) Und_min1x1_egm2008_isw=82_WGS84_TideFree_SE.gz */
     /* (2) Und_min2.5x2.5_egm2008_isw=82_WGS84_TideFree_SE.gz */
-#if 0
+#ifdef RTK_DISABLED
     /* not zero-inserted */
     y[0]=fget4f(fp_geoid,4L*(i1+j1*(nlon)));
     y[1]=fget4f(fp_geoid,4L*(i2+j1*(nlon)));

--- a/src/rcv/comnav.c
+++ b/src/rcv/comnav.c
@@ -279,7 +279,7 @@ static int decode_rangecmpb(raw_t *raw)
         }
 
         if (!parity) lli|=LLI_HALFC;
-#if 0
+#ifdef RTK_DISABLED
         if (halfc  ) lli|=LLI_HALFA;
 #else
         if (halfc!=raw->halfc[sat-1][pos]) lli|=LLI_SLIP;
@@ -302,7 +302,7 @@ static int decode_rangecmpb(raw_t *raw)
             raw->obs.data[index].SNR[pos]=0.0<=snr&&snr<255.0?snr:0;
             raw->obs.data[index].LLI[pos]=(unsigned char)lli;
             raw->obs.data[index].code[pos]=code;
-#if 0
+#ifdef RTK_DISABLED
             /* L2C phase shift correction (L2C->L2P) */
             if (code==CODE_L2X) {
                 raw->obs.data[index].L[pos]+=0.25;
@@ -390,7 +390,7 @@ static int decode_rangeb(raw_t *raw)
             raw->obs.data[index].SNR[pos]=0.0<=snr&&snr<255.0?snr:0;
             raw->obs.data[index].LLI[pos]=(unsigned char)lli;
             raw->obs.data[index].code[pos]=code;
-#if 0
+#ifdef RTK_DISABLED
             /* L2C phase shift correction */
             if (code==CODE_L2X) {
                 raw->obs.data[index].L[pos]+=0.25;

--- a/src/rcv/javad.c
+++ b/src/rcv/javad.c
@@ -1625,7 +1625,7 @@ static int decode_Fx(raw_t *raw, char sig)
         
         if ((idx=checkpri(sys,code,raw->opt,idx))>=0) {
             if (!settag(raw->obuf.data+i,raw->time)) continue;
-#if 0 /* disable to suppress overdetection of cycle-slips */
+#ifdef RTK_DISABLED /* disable to suppress overdetection of cycle-slips */
             if (flags&0x20) { /* loss-of-lock potential */
                 raw->obuf.data[i].LLI[idx]|=1;
             }

--- a/src/rcv/nvs.c
+++ b/src/rcv/nvs.c
@@ -280,15 +280,15 @@ static int decode_gloephem(int sat, raw_t *raw)
     geph.iode=(tb/900)&0x7F;
     geph.toe=utc2gpst(adjday(raw->time,tb-10800.0));
     geph.tof=utc2gpst(adjday(raw->time,tk-10800.0));
-#if 0
+#ifdef RTK_DISABLED
     /* check illegal ephemeris by toe */
-    tt=timediff(raw->time,geph.toe);
+    double tt=timediff(raw->time,geph.toe);
     if (fabs(tt)>3600.0) {
         trace(3,"nvs NE illegal toe: prn=%2d tt=%6.0f\n",prn,tt);
         return 0;
     }
 #endif
-#if 0
+#ifdef RTK_DISABLED
     /* check illegal ephemeris by frequency number consistency */
     if (raw->nav.geph[prn-MINPRNGLO].toe.time&&
         geph.frq!=raw->nav.geph[prn-MINPRNGLO].frq) {

--- a/src/rcv/rt17.c
+++ b/src/rcv/rt17.c
@@ -812,7 +812,7 @@ static int DecodeBeidouEphemeris(raw_t *Raw)
     tracet(3, "DecodeBeidouEphemeris(); not yet implemented.\n");
     return 0;
 
-#if 0
+#ifdef RTK_DISABLED
     rt17_t *rt17 = (rt17_t*) Raw->rcv_data;
     uint8_t *p = rt17->PacketBuffer;
     int prn, sat, toc, tow;
@@ -944,7 +944,7 @@ static int DecodeGalileoEphemeris(raw_t *Raw)
     tracet(3, "DecodeGalileoEphemeris(); not yet implemented.\n");
     return 0;
 
-#if 0
+#ifdef RTK_DISABLED
     rt17_t *rt17 = (rt17_t*) Raw->rcv_data;
     uint8_t *p = rt17->PacketBuffer;
     int prn, sat, toc, tow;
@@ -1421,7 +1421,7 @@ static int DecodeQZSSEphemeris(raw_t *Raw)
     tracet(3, "DecodeQZSSEphemeris(); not yet implemented.\n");
     return 0;
 
-#if 0
+#ifdef RTK_DISABLED
     rt17_t *rt17 = (rt17_t*) Raw->rcv_data;
     uint8_t *p = rt17->PacketBuffer;
     int prn, sat, toc, tow;
@@ -1666,7 +1666,7 @@ static int DecodeType17(raw_t *Raw, uint32_t rif)
     tow = R8(p) * 0.001; p += 8;         /* Receive time within the current GPS week. */
     ClockOffset = R8(p) * 0.001; p += 8; /* Clock offset value. 0.0 = not known */ 
 
-#if 0
+#ifdef RTK_DISABLED
     tow += ClockOffset;
 #endif
  
@@ -1851,7 +1851,7 @@ static int DecodeType17(raw_t *Raw, uint32_t rif)
             continue;
         }
 
-#if 0
+#ifdef RTK_DISABLED
         /* Apply clock offset to observables */
         if (ClockOffset != 0.0)
         {

--- a/src/rcv/septentrio.c
+++ b/src/rcv/septentrio.c
@@ -4088,7 +4088,7 @@ static int decode_sbf(raw_t *raw)
 
             return 0;
         default:
-#if 0 /* debug output */
+#ifdef RTK_DISABLED /* debug output */
             if (raw->outtype) {
                 sprintf(raw->msgtype,"SBF 0x%04X (%4d):",type, raw->len);
             }

--- a/src/rcv/tersus.c
+++ b/src/rcv/tersus.c
@@ -350,7 +350,7 @@ static int decode_rangecmpb(raw_t *raw)
             raw->obs.data[index].LLI[pos]=(unsigned char)lli;
             raw->obs.data[index].code[pos]=code;
         }
-#if 0 /* for debug */
+#ifdef RTK_DISABLED /* for debug */
         char tstr[40];
         trace(3,"sys=%d prn=%3d cp=%12.5f lli=%2d plock=%2d clock=%2d lockt=%4.2f halfc=%2d parity=%2d ts=%s\n",
               sys,prn,adr,lli,plock,clock,lockt,halfc,parity,time2str(raw->tobs,tstr,3));

--- a/src/rcv/ublox.c
+++ b/src/rcv/ublox.c
@@ -675,7 +675,7 @@ static int decode_trkmeas(raw_t *raw)
         if (lock2==0||lock2<raw->lockt[sat-1][0]) raw->lockt[sat-1][1]=1.0;
         raw->lockt[sat-1][0]=lock2;
         
-#if 0 /* for debug */
+#ifdef RTK_DISABLED /* for debug */
         trace(2,"[%2d] qi=%d sys=%d prn=%3d frq=%2d flag=%02X ?=%02X %02X "
               "%02X %02X %02X %02X %02X lock=%3d %3d ts=%10.3f snr=%4.1f "
               "dop=%9.3f adr=%13.3f %6.3f\n",U1(p),qi,U1(p+4),prn,frq,flag,
@@ -804,7 +804,7 @@ static int decode_trkd5(raw_t *raw)
         
         if (snr<=10.0) raw->lockt[sat-1][1]=1.0;
         
-#if 0 /* for debug */
+#ifdef RTK_DISABLED /* for debug */
         trace(2,"[%2d] qi=%d sys=%d prn=%3d frq=%2d flag=%02X ts=%1.3f "
               "snr=%4.1f dop=%9.3f adr=%13.3f %6.3f\n",U1(p+35),qi,U1(p+56),
               prn,frq,flag,ts,snr,dop,adr,

--- a/src/rinex.c
+++ b/src/rinex.c
@@ -437,14 +437,16 @@ static void decode_obsh(FILE *fp, char *buff, double ver, int *tsys,
         if (i==RNX_SYS_CMP&&fabs(ver-3.02)<1e-3) {
             for (j=0;j<nt;j++) if (tobs[i][j][1]=='1') tobs[i][j][1]='2';
         }
+#ifdef RTK_DISABLED
         /* uncomment this code to convert unknown codes to defaults */
-        /* for (j=0;j<nt;j++) {
+        for (j=0;j<nt;j++) {
             if (tobs[i][j][2]) continue;
             if (!(p=strchr(frqcodes,tobs[i][j][1]))) continue;
             tobs[i][j][2]=defcodes[i][(int)(p-frqcodes)];
             trace(2,"set default for unknown code: sys=%c code=%s\n",buff[0],
                   tobs[i][j]);
-        }  */
+        }
+#endif
     }
     else if (strstr(label,"WAVELENGTH FACT L1/2")) ; /* opt ver.2 */
     else if (strstr(label,"# / TYPES OF OBSERV" )) { /* ver.2 */
@@ -1027,9 +1029,9 @@ static void set_index(double ver, int sys, const char *opt,
         trace(4,"reject obs type: sys=%2d, obs=%s\n",sys,tobs[i]);
     }
     ind->n=n;
-
-#if 0 /* for debug */
-    for (i=0;i<n;i++) {
+    
+#ifdef RTK_DISABLED /* for debug */
+    for (int i=0;i<n;i++) {
         trace(2,"set_index: sys=%2d,tobs=%s code=%2d pri=%2d idx=%d pos=%d shift=%5.2f\n",
               sys,tobs[i],ind->code[i],ind->pri[i],ind->idx[i],ind->pos[i],
               ind->shift[i]);

--- a/src/rtcm3.c
+++ b/src/rtcm3.c
@@ -1986,7 +1986,7 @@ static void sigindex(int sys, const uint8_t *code, int n, const char *opt,
             trace(2,"rtcm msm: no space in obs data sys=%d code=%d\n",sys,code[i]);
             idx[i]=-1;
         }
-#if 0 /* for debug */
+#ifdef RTK_DISABLED /* for debug */
         trace(2,"sig pos: sys=%d code=%d ex=%d idx=%d\n",sys,code[i],ex[i],idx[i]);
 #endif
     }

--- a/src/rtksvr.c
+++ b/src/rtksvr.c
@@ -419,7 +419,7 @@ static int decoderaw(rtksvr_t *svr, int index)
             ephset=svr->raw[index].ephset;
             sbsmsg=&svr->raw[index].sbsmsg;
         }
-#if 0 /* record for receiving tick for debug */
+#ifdef RTK_DISABLED /* record for receiving tick for debug */
         if (ret==1) {
             char tstr[40];
             trace(0,"%d %10d T=%s NS=%2d\n",index,tickget(),

--- a/src/solution.c
+++ b/src/solution.c
@@ -969,16 +969,14 @@ extern sol_t *getsol(solbuf_t *solbuf, int index)
 *-----------------------------------------------------------------------------*/
 extern void initsolbuf(solbuf_t *solbuf, int cyclic, int nmax)
 {
-#if 0
-    gtime_t time0={0};
-#endif
     int i;
     
     trace(3,"initsolbuf: cyclic=%d nmax=%d\n",cyclic,nmax);
     
     solbuf->n=solbuf->nmax=solbuf->start=solbuf->end=solbuf->nb=0;
     solbuf->cyclic=cyclic;
-#if 0
+#ifdef RTK_DISABLED
+    gtime_t time0={0};
     solbuf->time=time0;
 #endif
     solbuf->data=NULL;

--- a/src/stream.c
+++ b/src/stream.c
@@ -1400,7 +1400,7 @@ static int statextcp(tcp_t *tcp, char *msg)
     p+=sprintf(p,"    saddr = %s\n",tcp->saddr);
     p+=sprintf(p,"    port  = %d\n",tcp->port);
     p+=sprintf(p,"    sock  = %d\n",(int)tcp->sock);
-#if 0 /* for debug */
+#ifdef RTK_DISABLED /* for debug */
     p+=sprintf(p,"    tcon  = %d\n",tcp->tcon);
     p+=sprintf(p,"    tact  = %u\n",tcp->tact);
     p+=sprintf(p,"    tdis  = %u\n",tcp->tdis);

--- a/src/tle.c
+++ b/src/tle.c
@@ -520,7 +520,7 @@ extern int tle_pos(gtime_t time, const char *name, const char *satno,
     gtime_t tutc;
     double tsince,rs_tle[6],rs_pef[6],gmst;
     double R1[9]={0},R2[9]={0},R3[9]={0},W[9],erpv[5]={0};
-    int i=0,j,k,stat=1;
+    int i=0,stat=1;
 
     /* serial search by satellite name or alias if name is empty */
     if (*name) {
@@ -530,16 +530,17 @@ extern int tle_pos(gtime_t time, const char *name, const char *satno,
                !(stat=strcmp(name,tle->data[i].alias)))) break;
         }
         if (i<tle->n) stat=0;
-	    /* binary search by satellite name or alias if name is empty */        
-        /*
-        for (i=j=0,k=tle->n-1;j<=k;) {
+#ifdef RTK_DISABLED
+        // Binary search by satellite name or alias if name is empty.
+        i = 0;
+        for (int j=0,k=tle->n-1;j<=k;) {
             i=(j+k)/2;
             if (!(stat=strcmp(name,tle->data[i].name)) ||
                 ( (tle->data[i].name[0]=='\0') &&
                  !(stat=strcmp(name,tle->data[i].alias)))) break;
             if (stat<0) k=i-1; else j=i+1;
         }
-         */
+#endif
     }
     /* serial search by catalog no or international designator */
     if (stat&&(*satno||*desig)) {

--- a/test/utest/t_geoid.c
+++ b/test/utest/t_geoid.c
@@ -51,7 +51,7 @@ void utest1(void)
     ret=opengeoid(GEOID_EMBEDDED, "");
         assert(ret==1);
     closegeoid();
-#if 0  // geoid files are not included in the rtklib distribution
+#ifdef RTK_DISABLED  // geoid files are not included in the rtklib distribution
     ret=opengeoid(GEOID_EGM96_M150,file1);
         assert(ret==1);
     closegeoid();

--- a/test/utest/t_tle.c
+++ b/test/utest/t_tle.c
@@ -55,7 +55,7 @@ static void utest1(void)
         assert(stat);
         assert(tle.n==114);
 
-#if 0 /* for debug */
+#if RTK_DISABLED /* for debug */
     dumptle(OUT,&tle);
 #endif
 

--- a/util/geniono/geniono.c
+++ b/util/geniono/geniono.c
@@ -215,7 +215,7 @@ static int res_iono(const obsd_t *obs, int n, const nav_t *nav,
         
         /* residuals of ionosphere (geometriy-free) LC */
         v[nv  ]=(L1-L2)-LG;
-#if 0
+#if RTK_DISABLED
         v[nv+1]=(P1-P2)-PG;
 #else
         v[nv+1]=0.0;

--- a/util/geniono/genstec.c
+++ b/util/geniono/genstec.c
@@ -214,7 +214,7 @@ static int res_iono(const obsd_t *obs, int n, const nav_t *nav,
         
         /* residuals of ionosphere (geometriy-free) LC */
         v[nv  ]=(L1-L2)-LG;
-#if 0
+#if RTK_DISABLED
         v[nv+1]=(P1-P2)-PG;
 #else
         v[nv+1]=0.0;

--- a/util/geniono/rcvdcb.c
+++ b/util/geniono/rcvdcb.c
@@ -69,7 +69,7 @@ static void ekf_free(ekf_t *ekf)
 /* mapping function of ionosphere ---------------------------------------------*/
 static double map_iono(const double *pos, const double *azel)
 {
-#if 0
+#if RTK_DISABLED
     return ionmapf(pos,azel);
 #else
     return 1.0;
@@ -203,7 +203,7 @@ static int res_iono(const obsd_t *obs, int n, const nav_t *nav,
         
         /* residuals of ionosphere (geometriy-free) LC */
         v[nv  ]=(L1-L2)-LG;
-#if 0
+#if RTK_DISABLED
         v[nv+1]=(P1-P2)-PG;
 #else
         v[nv+1]=0.0;


### PR DESCRIPTION
In case a source code reformat is being considered with the transition to the new branch and naming, here is a proposal. 

There are just a few preparation patches to assist. Clang-format also reordered include files, and this caused an issue with one file on the windows app. Also code within `#if 0` was not reformatted, so use `#ifdef` , and code that was commented out was not reformatted so replacing that with `#ifdef`.

This does not include the actual reformat which would be a huge PR, but on linux the command line to reformat the code in a directory:

```
find . -name "*.cpp" |xargs clang-format -i
find . -name "*.c" |xargs clang-format -i
find . -name "*.h" |xargs clang-format -i

```

This proposes using the same format for all the code, but perhaps a variation could be considered for the Qt app with the verbose C++ names and comment styling etc so perhaps a longer line length etc. There are other styles, but the Google style appeared to be the most consistent with the existing style - both terse styles.

Many of my larger PRs have been using this style as it is unproductive to be reformatting to the original style, such as the whole septentrio decoder which is thousands of lines.