### PR TITLE
qtapp glofcndlg: correct zero fill of nav struct

### DIFF
--- a/app/qtapp/appcmn_qt/glofcndlg.cpp
+++ b/app/qtapp/appcmn_qt/glofcndlg.cpp
@@ -39,9 +39,6 @@ void GloFcnDialog::readRinex()
       return;
     }
 
-
-    memset(&nav, 0, sizeof(nav_t));
-
     filename = QFileDialog::getOpenFileName(this, tr("Open RINEX file"), "", tr("Rinex (*.obs *.*O);;All (*.*)"));
 
     if (filename.isEmpty()) return;


### PR DESCRIPTION
failed to update a ref to nav in prior patch, but the memset is not needed as calloc zero fills so just remove this code.