### PR TITLE
fix compiler warnings about unused variables

### DIFF
--- a/src/rcv/septentrio.c
+++ b/src/rcv/septentrio.c
@@ -1674,13 +1674,13 @@ static int decode_gpsrawcnav(raw_t *raw, int sys) {
     return -1;
   }
   offset += 8;
-  uint8_t prn2 = getbitu(buff, offset, 6);
+  //uint8_t prn2 = getbitu(buff, offset, 6);
   offset += 6;
   uint8_t type = getbitu(buff, offset, 6);
   offset += 8;
-  uint32_t tow = getbitu(buff, offset, 17);
+  //uint32_t tow = getbitu(buff, offset, 17);
   offset += 17;
-  uint8_t alert = getbitu(buff, offset, 1);
+  //uint8_t alert = getbitu(buff, offset, 1);
   offset += 1;
 
   switch (type) {
@@ -1968,7 +1968,7 @@ static int decode_cmpraw(raw_t *raw){
     eph_t eph = {0};
     double ion[8], utc[8];
     uint8_t *p = raw->buff+14, buff[40];
-    int i, id, svid, sat, prn, pgn;
+    int i, id, svid, sat, prn;
 
     if (raw->len < 52) {
         trace(2, "sbf cmpraw length error: len=%d\n", raw->len);

--- a/src/rcv/unicore.c
+++ b/src/rcv/unicore.c
@@ -40,7 +40,6 @@
 #define I1(p) (*((int8_t  *)(p)))
 static uint16_t U2(uint8_t* p) { uint16_t u; memcpy(&u, p, 2); return u; }
 static uint32_t U4(uint8_t* p) { uint32_t u; memcpy(&u, p, 4); return u; }
-static int32_t  I4(uint8_t* p) { int32_t  i; memcpy(&i, p, 4); return i; }
 static float    R4(uint8_t* p) { float    r; memcpy(&r, p, 4); return r; }
 static double   R8(uint8_t* p) { double   r; memcpy(&r, p, 8); return r; }
 
@@ -254,9 +253,9 @@ static int decode_gpsephb(raw_t* raw)
     eph_t eph = { 0 };
     uint8_t* p = raw->buff + HLEN;
 
-    double tow, tocs, N, URA;
-    int prn, as, sat, week, zweek, health;
-    int iode1, iode2;
+    double tow, tocs, N;
+    int prn, as, sat, week, health;
+    /*int zweek, iode2;*/
 
     if (raw->len < HLEN + 224) {
         trace(2, "unicore gpsephb length error: len=%d\n", raw->len);
@@ -267,10 +266,10 @@ static int decode_gpsephb(raw_t* raw)
     tow = R8(p); p += 8;
     health = U4(p) & 0x3f; p += 4;
     eph.iode = U4(p); p += 4;
-    iode2 = U4(p); p += 4;
+    /*iode2 = U4(p);*/ p += 4;
 
     eph.week = U4(p); p += 4;
-    zweek = U4(p); p += 4;
+    /*zweek = U4(p);*/ p += 4;
     eph.toes = R8(p); p += 8;
     eph.A = R8(p); p += 8;
     eph.deln = R8(p); p += 8;
@@ -351,12 +350,12 @@ static int decode_gloephb(raw_t* raw)
         sprintf(raw->msgtype + strlen(raw->msgtype), " prn=%d", prn);
     }
     geph.frq = U2(p) + OFF_FRQNO; p += 2;
-    int satType = U1(p); p += 1 + 1;
+    /*int satType = U1(p);*/ p += 1 + 1;
 
     week = U2(p); p += 2;
     tow = floor(U4(p) / 1000.0 + 0.5); p += 4; /* rounded to integer sec */
     toff = U4(p); p += 4;
-    int Nt = U2(p); p += 2 + 2;
+    /*int Nt = U2(p);*/ p += 2 + 2;
     geph.iode = U4(p) & 0x7F; p += 4;
     geph.svh = (U4(p) < 4) ? 0 : 1; p += 4; /* 0:healthy,1:unhealthy */
     geph.pos[0] = R8(p); p += 8;
@@ -373,8 +372,8 @@ static int decode_gloephb(raw_t* raw)
     geph.gamn = R8(p); p += 8;
     tof = U4(p) - toff; p += 4; /* glonasst->gpst */
 
-    int P = U4(p); p += 4;
-    int Ft = U4(p); p += 4;
+    /*int P = U4(p);*/ p += 4;
+    /*int Ft = U4(p);*/ p += 4;
     geph.age = U4(p); p += 4;
 
     geph.toe = gpst2time(week, tow);
@@ -502,12 +501,12 @@ static int decode_bdsephb(raw_t* raw)
         return -1;
     }
     prn = U4(p);   p += 4;
-    double tow = R8(p); p += 8;
+    /*double tow = R8(p);*/ p += 8;
     eph.svh = U4(p); p += 4;
     eph.iode = U4(p); p += 4;
-    uint32_t AODE2 = U4(p); p += 4;
+    /* uint32_t AODE2 = U4(p);*/ p += 4;
     eph.week = U4(p) - 1356;   p += 4;
-    int zweek = U4(p);   p += 4;
+    /*int zweek = U4(p);*/   p += 4;
     eph.toes = R8(p);   p += 8;
     eph.A = R8(p);   p += 8;
     eph.deln = R8(p);   p += 8;
@@ -535,8 +534,8 @@ static int decode_bdsephb(raw_t* raw)
     eph.f1 = R8(p);   p += 8;
     eph.f2 = R8(p);   p += 8;
 
-    int as = U4(p); p += 4;
-    double N = R8(p);   p += 8;
+    /*int as = U4(p);*/ p += 4;
+    /*double N = R8(p);*/   p += 8;
     ura = R8(p);   p += 8;
 
 
@@ -567,9 +566,9 @@ static int decode_qzssephb(raw_t* raw) {
     eph_t eph = { 0 };
     uint8_t* p = raw->buff + HLEN;
 
-    double tow, tocs, N, URA;
+    double tow, tocs, N;
     int prn, as, sat, week, zweek, health;
-    int iode1, iode2;
+    /*int iode2;*/
 
     if (raw->len < HLEN + 224) {
         trace(2, "unicore qzssephemrisb length error: len=%d\n", raw->len);
@@ -580,7 +579,7 @@ static int decode_qzssephb(raw_t* raw) {
     tow = R8(p); p += 8;
     health = U4(p) & 0x3f; p += 4;
     eph.iode = U4(p); p += 4;
-    iode2 = U4(p); p += 4;
+    /*iode2 = U4(p);*/ p += 4;
 
     eph.week = U4(p); p += 4;
     zweek = U4(p); p += 4;
@@ -655,7 +654,7 @@ static int decode_irnssephb(raw_t* raw) {
     }
 
     prn = U4(p);   p += 4;
-    double towc = R8(p); p += 8;
+    /*double towc = R8(p);*/ p += 8;
     l5_health = U4(p) & 1; p += 4;
     eph.iode = U4(p);   p += 4; /* IODEC */
     s_health = U4(p);   p += 4;
@@ -686,8 +685,8 @@ static int decode_irnssephb(raw_t* raw) {
     eph.f1 = R8(p);   p += 8;
     eph.f2 = R8(p);   p += 8;
 
-    uint32_t flag = U4(p); p += 4;
-    double N = R8(p); p += 8;
+    /*uint32_t flag = U4(p);*/ p += 4;
+    /*double N = R8(p);*/ p += 8;
     eph.sva = uraindex(R8(p)); p += 8;
 
     if (toc != eph.toes) { /* toe and toc should be matched */
@@ -727,7 +726,7 @@ static int decode_obsvmb(raw_t* raw)
     uint8_t* p = raw->buff + HLEN;
     char* q;
     double psr, adr, dop, snr, lockt, tt, freq, glo_bias = 0.0;
-    int i, index, prn, sat, sys, code, idx, track, plock, clock, lli;
+    int i, index, prn, sat, sys, code, idx, plock, clock, lli;
     int gfrq;
 
     if ((q = strstr(raw->opt, "-GLOBIAS="))) sscanf(q, "-GLOBIAS=%lf", &glo_bias);

--- a/src/rinex.c
+++ b/src/rinex.c
@@ -353,16 +353,16 @@ static void decode_obsh(FILE *fp, char *buff, double ver, int *tsys,
                         char tobs[][MAXOBSTYPE][4], nav_t *nav, sta_t *sta)
 {
     /* default codes for unknown code */
-    const char frqcodes[]="1256789";
-    const char *defcodes[]={
-        "CWX    ",  /* GPS: L125____ */
-        "CCXX X ",  /* GLO: L1234_6_ */
-        "CXXXXX ",  /* GAL: L125678_ */ /* FIXME: Galileo should not have L2! */
-        "CXXX   ",  /* QZS: L1256___ */
-        "C X    ",  /* SBS: L1_5____ */
-        "XIXIIX ",  /* BDS: L125678_ */
-        "  A   A"   /* IRN: L__5___9 */
-    };
+    //const char frqcodes[]="1256789";
+    //const char *defcodes[]={
+    //    "CWX    ",  /* GPS: L125____ */
+    //    "CCXX X ",  /* GLO: L1234_6_ */
+    //    "CXXXXX ",  /* GAL: L125678_ */ /* FIXME: Galileo should not have L2! */
+    //    "CXXX   ",  /* QZS: L1256___ */
+    //    "C X    ",  /* SBS: L1_5____ */
+    //    "XIXIIX ",  /* BDS: L125678_ */
+    //    "  A   A"   /* IRN: L__5___9 */
+    //};
     double del[3];
     int i,j,k,n,nt,prn,fcn;
     const char *p;

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -2799,7 +2799,7 @@ extern int readerp(const char *file, erp_t *erp) {
   }
   char buff[256];
   int state = 0;
-  int utcp = 0, taip = 0;
+  int /*utcp = 0,*/ taip = 0;
   while (fgets(buff, sizeof(buff), fp)) {
     // Detect the IGS format, and support concatenated files.
     if (strstr(buff, "version 2") || strstr(buff, "VERSION 2")) {
@@ -2820,7 +2820,7 @@ extern int readerp(const char *file, erp_t *erp) {
           strstr(buff, "utc") || strstr(buff, "TAI") || strstr(buff, "tai") ||
           strstr(buff, "LOD") || strstr(buff, "lod")) {
         // Note UTC vs TAI.
-        utcp = !!(strstr(buff, "UTC") || strstr(buff, "utc"));
+        /*utcp = !!(strstr(buff, "UTC") || strstr(buff, "utc"));*/
         taip = !!(strstr(buff, "TAI") || strstr(buff, "tai"));
         state = 2;
       }


### PR DESCRIPTION
This request removes lots of compiler warnings about unused variables to allow to see anything new which pops up.

The patch keeps the logic as comments, as in the future these values may be used and uncommenting is much easier than rereading the docs.

There are no functional changes.