### PR TITLE
quieten misc compiler warnings

### DIFF
--- a/src/convkml.c
+++ b/src/convkml.c
@@ -35,6 +35,7 @@ static const char *mark="http://maps.google.com/mapfiles/kml/pal2/icon18.png";
 static void outtrack(FILE *f, const solbuf_t *solbuf, const char *color,
                      int outalt, int outtime)
 {
+    (void)outtime;
     double pos[3];
     int i;
     

--- a/src/convrnx.c
+++ b/src/convrnx.c
@@ -705,6 +705,7 @@ static void update_halfc(strfile_t *str, obsd_t *obs)
 /* dump half-cycle ambiguity list --------------------------------------------*/
 static void dump_halfc(const strfile_t *str)
 {
+    (void)str;
 #ifdef RTK_DISABLED
     halfc_t *p;
     char s0[8],s1[40],s2[40],*stats[]={"ADD","SUB","NON"};

--- a/src/download.c
+++ b/src/download.c
@@ -564,7 +564,7 @@ static int test_local(gtime_t ts, gtime_t te, double ti, const char *path,
                       FILE *fp)
 {
     gtime_t time;
-    char remot[1024],remot_p[1024],dir_t[1024],local[1024],str[1024];
+    char remot[1024],dir_t[1024],local[1024],str[1024];
     int stat,abort=0;
     
     for (time=ts;timediff(time,te)<=1E-3;time=timeadd(time,ti)) {
@@ -844,7 +844,6 @@ extern void dl_test(gtime_t ts, gtime_t te, double ti, const url_t *urls,
                     int ncol, int datefmt, FILE *fp)
 {
     gtime_t time;
-    double tow;
     char year[32],date[32],date_p[32];
     int i,j,n,m,*nc,*nt,week,flag,abort=0;
     

--- a/src/geoid.c
+++ b/src/geoid.c
@@ -136,6 +136,7 @@ static double geoidh_egm08(const double *pos, int model)
 /* get gsi geoid data --------------------------------------------------------*/
 static double fgetgsi(FILE *fp, int nlon, int nlat, int i, int j)
 {
+    (void)nlat;
     const int nf=28,wf=9,nl=nf*wf+2,nr=(nlon-1)/nf+1;
     double v;
     int off=nl+j*nr*nl+i/nf*nl+i%nf*wf;

--- a/src/pntpos.c
+++ b/src/pntpos.c
@@ -259,6 +259,7 @@ extern int ionocorr(gtime_t time, const nav_t *nav, int sat, const double *pos,
 extern int tropcorr(gtime_t time, const nav_t *nav, const double *pos,
                     const double *azel, int tropopt, double *trp, double *var)
 {
+    (void)nav;
     char tstr[40];
     trace(4,"tropcorr: time=%s opt=%d pos=%.3f %.3f azel=%.3f %.3f\n",
           time2str(time,tstr,3),tropopt,pos[0]*R2D,pos[1]*R2D,azel[0]*R2D,

--- a/src/postpos.c
+++ b/src/postpos.c
@@ -896,6 +896,7 @@ static int antpos(prcopt_t *opt, int rcvno, const obs_t *obs, const nav_t *nav,
 static int openses(const prcopt_t *popt, const solopt_t *sopt,
                    const filopt_t *fopt, nav_t *nav, pcvs_t *pcvs, pcvs_t *pcvr)
 {
+    (void)popt; (void)nav;
     trace(3,"openses :\n");
 
     /* read satellite antenna parameters */

--- a/src/ppp.c
+++ b/src/ppp.c
@@ -243,6 +243,9 @@ static double yaw_nominal(double beta, double mu)
 extern int yaw_angle(int sat, const char *type, int opt, double beta, double mu,
                      double *yaw)
 {
+    (void)sat;
+    (void)type;
+    (void)opt;
     *yaw=yaw_nominal(beta,mu);
     return 1;
 }
@@ -327,6 +330,7 @@ static int model_phw(gtime_t time, int sat, const char *type, int opt,
 static double varerr(int sat, int sys, double el, double snr_rover,
                      int f, const prcopt_t *opt, const obsd_t *obs)
 {
+    (void)sat;
     double a,b,e;
     double snr_max=opt->err[5];
     double fact=1.0;
@@ -459,6 +463,7 @@ static void detslp_ll(rtk_t *rtk, const obsd_t *obs, int n)
 
     trace(3,"detslp_ll: n=%d\n",n);
 
+    if (nf > NFREQ) nf = NFREQ; // Quieten compiler warnings on slip[] write.
     for (i=0;i<n&&i<MAXOBS;i++) for (j=0;j<nf;j++) {
         if (obs[i].L[j]==0.0||!(obs[i].LLI[j]&(LLI_SLIP|LLI_HALFC))) continue;
 
@@ -880,6 +885,7 @@ static int model_trop(gtime_t time, const double *pos, const double *azel,
                       const prcopt_t *opt, const double *x, double *dtdx,
                       const nav_t *nav, double *dtrp, double *var)
 {
+    (void)nav;
     double trp[3]={0};
 
     if (opt->tropopt==TROPOPT_SAAS) {

--- a/src/ppp_ar.c
+++ b/src/ppp_ar.c
@@ -17,5 +17,6 @@
 extern int ppp_ar(rtk_t *rtk, const obsd_t *obs, int n, int *exc,
                   const nav_t *nav, const double *azel, double *x, double *P)
 {
+    (void)rtk; (void)obs; (void)n; (void)exc; (void)nav; (void)azel; (void)x; (void)P;
     return 0;
 }

--- a/src/preceph.c
+++ b/src/preceph.c
@@ -171,6 +171,7 @@ static int addpeph(nav_t *nav, peph_t *peph)
 static void readsp3b(FILE *fp, char type, int *sats, int ns, double *bfact,
                      char *tsys, int index, int opt, nav_t *nav)
 {
+    (void)sats;
     peph_t peph;
     gtime_t time;
     double val,std,base;

--- a/src/rcv/binex.c
+++ b/src/rcv/binex.c
@@ -229,6 +229,7 @@ static int decode_bnx_00(raw_t *raw, uint8_t *buff, int len)
 /* decode BINEX mesaage 0x01-00: coded (raw bytes) GNSS ephemeris ------------*/
 static int decode_bnx_01_00(raw_t *raw, uint8_t *buff, int len)
 {
+    (void)raw; (void)buff; (void)len;
     trace(2,"BINEX 0x01-00: unsupported message\n");
     return 0;
 }
@@ -786,54 +787,63 @@ static int decode_bnx_01(raw_t *raw, uint8_t *buff, int len)
 /* decode BINEX mesaage 0x02: generalized GNSS data --------------------------*/
 static int decode_bnx_02(raw_t *raw, uint8_t *buff, int len)
 {
+    (void)raw; (void)buff; (void)len;
     trace(2,"BINEX 0x02: unsupported message\n");
     return 0;
 }
 /* decode BINEX mesaage 0x03: generalized ancillary site data ----------------*/
 static int decode_bnx_03(raw_t *raw, uint8_t *buff, int len)
 {
+    (void)raw; (void)buff; (void)len;
     trace(2,"BINEX 0x03: unsupported message\n");
     return 0;
 }
 /* decode BINEX mesaage 0x7d: receiver internal state prototyping ------------*/
 static int decode_bnx_7d(raw_t *raw, uint8_t *buff, int len)
 {
+    (void)raw; (void)buff; (void)len;
     trace(2,"BINEX 0x7d: unsupported message\n");
     return 0;
 }
 /* decode BINEX mesaage 0x7e: ancillary site data prototyping ----------------*/
 static int decode_bnx_7e(raw_t *raw, uint8_t *buff, int len)
 {
+    (void)raw; (void)buff; (void)len;
     trace(2,"BINEX 0x7e: unsupported message\n");
     return 0;
 }
 /* decode BINEX mesaage 0x7f-00: JPL fiducial site ---------------------------*/
 static int decode_bnx_7f_00(raw_t *raw, uint8_t *buff, int len)
 {
+    (void)raw; (void)buff; (void)len;
     trace(2,"BINEX 0x7f-00: unsupported message\n");
     return 0;
 }
 /* decode BINEX mesaage 0x7f-01: UCAR COSMIC ---------------------------------*/
 static int decode_bnx_7f_01(raw_t *raw, uint8_t *buff, int len)
 {
+    (void)raw; (void)buff; (void)len;
     trace(2,"BINEX 0x7f-01: unsupported message\n");
     return 0;
 }
 /* decode BINEX mesaage 0x7f-02: Trimble 4700 --------------------------------*/
 static int decode_bnx_7f_02(raw_t *raw, uint8_t *buff, int len)
 {
+    (void)raw; (void)buff; (void)len;
     trace(2,"BINEX 0x7f-02: unsupported message\n");
     return 0;
 }
 /* decode BINEX mesaage 0x7f-03: Trimble NetRS -------------------------------*/
 static int decode_bnx_7f_03(raw_t *raw, uint8_t *buff, int len)
 {
+    (void)raw; (void)buff; (void)len;
     trace(2,"BINEX 0x7f-03: unsupported message\n");
     return 0;
 }
 /* decode BINEX mesaage 0x7f-04: Trimble NetRS -------------------------------*/
 static int decode_bnx_7f_04(raw_t *raw, uint8_t *buff, int len)
 {
+    (void)raw; (void)buff; (void)len;
     trace(2,"BINEX 0x7f-04: unsupported message\n");
     return 0;
 }

--- a/src/rcv/javad.c
+++ b/src/rcv/javad.c
@@ -406,6 +406,7 @@ static int decode_NN(raw_t *raw)
 /* decode [GA] GPS almanac ---------------------------------------------------*/
 static int decode_GA(raw_t *raw)
 {
+    (void)raw;
     trace(3,"javad GA unsupported\n");
     
     return 0;
@@ -413,6 +414,7 @@ static int decode_GA(raw_t *raw)
 /* decode [NA] GLONASS almanac -----------------------------------------------*/
 static int decode_NA(raw_t *raw)
 {
+    (void)raw;
     trace(3,"javad NA unsupported\n");
     
     return 0;
@@ -420,6 +422,7 @@ static int decode_NA(raw_t *raw)
 /* decode [EA] Galileo almanac -----------------------------------------------*/
 static int decode_EA(raw_t *raw)
 {
+    (void)raw;
     trace(3,"javad EA unsupported\n");
     
     return 0;
@@ -427,6 +430,7 @@ static int decode_EA(raw_t *raw)
 /* decode [WA] WAAS almanac --------------------------------------------------*/
 static int decode_WA(raw_t *raw)
 {
+    (void)raw;
     trace(3,"javad WA unsupported\n");
     
     return 0;
@@ -434,6 +438,7 @@ static int decode_WA(raw_t *raw)
 /* decode [QA] QZSS almanac --------------------------------------------------*/
 static int decode_QA(raw_t *raw)
 {
+    (void)raw;
     trace(3,"javad QA unsupported\n");
     
     return 0;
@@ -441,6 +446,7 @@ static int decode_QA(raw_t *raw)
 /* decode [CA] Beidou almanac ------------------------------------------------*/
 static int decode_CA(raw_t *raw)
 {
+    (void)raw;
     trace(3,"javad CA unsupported\n");
     
     return 0;
@@ -448,6 +454,7 @@ static int decode_CA(raw_t *raw)
 /* decode [IA] IRNSS almanac -------------------------------------------------*/
 static int decode_IA(raw_t *raw)
 {
+    (void)raw;
     trace(3,"javad IA unsupported\n");
     
     return 0;
@@ -785,6 +792,7 @@ static int decode_UO(raw_t *raw)
 /* decode [NU] GLONASS UTC and GPS time parameters ---------------------------*/
 static int decode_NU(raw_t *raw)
 {
+    (void)raw;
     trace(3,"javad NU unsupported\n");
     
     return 0;
@@ -792,6 +800,7 @@ static int decode_NU(raw_t *raw)
 /* decode [EU] Galileo UTC and GPS time parameters ---------------------------*/
 static int decode_EU(raw_t *raw)
 {
+    (void)raw;
     trace(3,"javad EU unsupported\n");
     
     return 0;
@@ -799,6 +808,7 @@ static int decode_EU(raw_t *raw)
 /* decode [WU] WAAS UTC time parameters --------------------------------------*/
 static int decode_WU(raw_t *raw)
 {
+    (void)raw;
     trace(3,"javad WU unsupported\n");
     
     return 0;
@@ -806,6 +816,7 @@ static int decode_WU(raw_t *raw)
 /* decode [QU] QZSS UTC and GPS time parameters ------------------------------*/
 static int decode_QU(raw_t *raw)
 {
+    (void)raw;
     trace(3,"javad QU unsupported\n");
     
     return 0;
@@ -915,6 +926,7 @@ static int decode_L1nav(uint8_t *buff, int len, int sat, raw_t *raw)
 /* decode raw L2C CNAV data --------------------------------------------------*/
 static int decode_L2nav(uint8_t *buff, int len, int sat, raw_t *raw)
 {
+    (void)raw;
     uint8_t msg[1024]={0};
     int i,j,preamb,prn,msgid,tow,alert;
     
@@ -942,6 +954,7 @@ static int decode_L2nav(uint8_t *buff, int len, int sat, raw_t *raw)
 /* decode raw L5 CNAV data ---------------------------------------------------*/
 static int decode_L5nav(uint8_t *buff, int len, int sat, raw_t *raw)
 {
+    (void)raw;
     uint8_t msg[1024]={0};
     int i,j,preamb,prn,msgid,tow,alert;
     
@@ -969,6 +982,8 @@ static int decode_L5nav(uint8_t *buff, int len, int sat, raw_t *raw)
 /* decode raw L1C CNAV2 data -------------------------------------------------*/
 static int decode_L1Cnav(uint8_t *buff, int len, int sat, raw_t *raw)
 {
+    (void)buff;
+    (void)raw;
     trace(3,"javad *d len=%2d sat=%2d L1C CNAV2 unsupported\n",len,sat);
     
     return 0;
@@ -1044,6 +1059,7 @@ static int decode_nd(raw_t *raw, int sys)
 /* decode [LD] GLONASS raw navigation data -----------------------------------*/
 static int decode_LD(raw_t *raw)
 {
+    (void)raw;
     trace(3,"javad LD unsupported\n");
     
     return 0;
@@ -1108,6 +1124,7 @@ static int decode_lD(raw_t *raw)
 /* decode [ED] Galileo raw navigation data -----------------------------------*/
 static int decode_ED(raw_t *raw)
 {
+    (void)raw;
     trace(3,"javad ED unsupported\n");
     
     return 0;
@@ -1115,6 +1132,7 @@ static int decode_ED(raw_t *raw)
 /* decode [cd] Beidou raw navigation data ------------------------------------*/
 static int decode_cd(raw_t *raw)
 {
+    (void)raw;
     trace(3,"javad cd unsupported\n");
     
     return 0;
@@ -1122,6 +1140,7 @@ static int decode_cd(raw_t *raw)
 /* decode [id] IRNSS raw navigation data -------------------------------------*/
 static int decode_id(raw_t *raw)
 {
+    (void)raw;
     trace(3,"javad id unsupported\n");
     
     return 0;

--- a/src/rcv/nvs.c
+++ b/src/rcv/nvs.c
@@ -245,6 +245,7 @@ static gtime_t adjday(gtime_t time, double tod)
 /* decode gloephem -----------------------------------------------------------*/
 static int decode_gloephem(int sat, raw_t *raw)
 {
+    (void)sat;
     geph_t geph={0};
     uint8_t *p=(raw->buff)+2;
     int prn,tk,tb;

--- a/src/rcv/rt17.c
+++ b/src/rcv/rt17.c
@@ -809,6 +809,7 @@ static void ClearPacketBuffer(rt17_t *rt17)
 */
 static int DecodeBeidouEphemeris(raw_t *Raw)
 {
+    (void)Raw;
     tracet(3, "DecodeBeidouEphemeris(); not yet implemented.\n");
     return 0;
 
@@ -941,6 +942,7 @@ static int DecodeBeidouEphemeris(raw_t *Raw)
 */
 static int DecodeGalileoEphemeris(raw_t *Raw)
 {
+    (void)Raw;
     tracet(3, "DecodeGalileoEphemeris(); not yet implemented.\n");
     return 0;
 
@@ -1046,6 +1048,7 @@ static int DecodeGalileoEphemeris(raw_t *Raw)
 */
 static int DecodeGLONASSEphemeris(raw_t *Raw)
 {
+    (void)Raw;
     tracet(3, "DecodeGLONASSEphemeris(); not yet implemented.\n");
     return 0;
 }
@@ -1418,6 +1421,7 @@ static int DecodeIONAndUTCData(raw_t *Raw)
 */
 static int DecodeQZSSEphemeris(raw_t *Raw)
 {
+    (void)Raw;
     tracet(3, "DecodeQZSSEphemeris(); not yet implemented.\n");
     return 0;
 

--- a/src/rcv/septentrio.c
+++ b/src/rcv/septentrio.c
@@ -1675,12 +1675,15 @@ static int decode_gpsrawcnav(raw_t *raw, int sys) {
   }
   offset += 8;
   uint8_t prn2 = getbitu(buff, offset, 6);
+  (void)prn2;
   offset += 6;
   uint8_t type = getbitu(buff, offset, 6);
   offset += 8;
   uint32_t tow = getbitu(buff, offset, 17);
+  (void)tow;
   offset += 17;
   uint8_t alert = getbitu(buff, offset, 1);
+  (void)alert;
   offset += 1;
 
   switch (type) {
@@ -1968,7 +1971,7 @@ static int decode_cmpraw(raw_t *raw){
     eph_t eph = {0};
     double ion[8], utc[8];
     uint8_t *p = raw->buff+14, buff[40];
-    int i, id, svid, sat, prn, pgn;
+    int i, id, svid, sat, prn;
 
     if (raw->len < 52) {
         trace(2, "sbf cmpraw length error: len=%d\n", raw->len);

--- a/src/rcv/unicore.c
+++ b/src/rcv/unicore.c
@@ -40,7 +40,6 @@
 #define I1(p) (*((int8_t  *)(p)))
 static uint16_t U2(uint8_t* p) { uint16_t u; memcpy(&u, p, 2); return u; }
 static uint32_t U4(uint8_t* p) { uint32_t u; memcpy(&u, p, 4); return u; }
-static int32_t  I4(uint8_t* p) { int32_t  i; memcpy(&i, p, 4); return i; }
 static float    R4(uint8_t* p) { float    r; memcpy(&r, p, 4); return r; }
 static double   R8(uint8_t* p) { double   r; memcpy(&r, p, 8); return r; }
 
@@ -254,9 +253,8 @@ static int decode_gpsephb(raw_t* raw)
     eph_t eph = { 0 };
     uint8_t* p = raw->buff + HLEN;
 
-    double tow, tocs, N, URA;
+    double tow, tocs, N;
     int prn, as, sat, week, zweek, health;
-    int iode1, iode2;
 
     if (raw->len < HLEN + 224) {
         trace(2, "unicore gpsephb length error: len=%d\n", raw->len);
@@ -267,7 +265,8 @@ static int decode_gpsephb(raw_t* raw)
     tow = R8(p); p += 8;
     health = U4(p) & 0x3f; p += 4;
     eph.iode = U4(p); p += 4;
-    iode2 = U4(p); p += 4;
+    int iode2 = U4(p); p += 4;
+    (void)iode2;
 
     eph.week = U4(p); p += 4;
     zweek = U4(p); p += 4;
@@ -352,11 +351,13 @@ static int decode_gloephb(raw_t* raw)
     }
     geph.frq = U2(p) + OFF_FRQNO; p += 2;
     int satType = U1(p); p += 1 + 1;
+    (void)satType;
 
     week = U2(p); p += 2;
     tow = floor(U4(p) / 1000.0 + 0.5); p += 4; /* rounded to integer sec */
     toff = U4(p); p += 4;
     int Nt = U2(p); p += 2 + 2;
+    (void)Nt;
     geph.iode = U4(p) & 0x7F; p += 4;
     geph.svh = (U4(p) < 4) ? 0 : 1; p += 4; /* 0:healthy,1:unhealthy */
     geph.pos[0] = R8(p); p += 8;
@@ -374,7 +375,9 @@ static int decode_gloephb(raw_t* raw)
     tof = U4(p) - toff; p += 4; /* glonasst->gpst */
 
     int P = U4(p); p += 4;
+    (void) P;
     int Ft = U4(p); p += 4;
+    (void) Ft;
     geph.age = U4(p); p += 4;
 
     geph.toe = gpst2time(week, tow);
@@ -503,11 +506,14 @@ static int decode_bdsephb(raw_t* raw)
     }
     prn = U4(p);   p += 4;
     double tow = R8(p); p += 8;
+    (void)tow;
     eph.svh = U4(p); p += 4;
     eph.iode = U4(p); p += 4;
     uint32_t AODE2 = U4(p); p += 4;
+    (void)AODE2;
     eph.week = U4(p) - 1356;   p += 4;
     int zweek = U4(p);   p += 4;
+    (void)zweek;
     eph.toes = R8(p);   p += 8;
     eph.A = R8(p);   p += 8;
     eph.deln = R8(p);   p += 8;
@@ -536,7 +542,9 @@ static int decode_bdsephb(raw_t* raw)
     eph.f2 = R8(p);   p += 8;
 
     int as = U4(p); p += 4;
+    (void)as;
     double N = R8(p);   p += 8;
+    (void)N;
     ura = R8(p);   p += 8;
 
 
@@ -567,9 +575,8 @@ static int decode_qzssephb(raw_t* raw) {
     eph_t eph = { 0 };
     uint8_t* p = raw->buff + HLEN;
 
-    double tow, tocs, N, URA;
+    double tow, tocs, N;
     int prn, as, sat, week, zweek, health;
-    int iode1, iode2;
 
     if (raw->len < HLEN + 224) {
         trace(2, "unicore qzssephemrisb length error: len=%d\n", raw->len);
@@ -580,7 +587,8 @@ static int decode_qzssephb(raw_t* raw) {
     tow = R8(p); p += 8;
     health = U4(p) & 0x3f; p += 4;
     eph.iode = U4(p); p += 4;
-    iode2 = U4(p); p += 4;
+    int iode2 = U4(p); p += 4;
+    (void)iode2;
 
     eph.week = U4(p); p += 4;
     zweek = U4(p); p += 4;
@@ -656,6 +664,7 @@ static int decode_irnssephb(raw_t* raw) {
 
     prn = U4(p);   p += 4;
     double towc = R8(p); p += 8;
+    (void)towc;
     l5_health = U4(p) & 1; p += 4;
     eph.iode = U4(p);   p += 4; /* IODEC */
     s_health = U4(p);   p += 4;
@@ -687,7 +696,9 @@ static int decode_irnssephb(raw_t* raw) {
     eph.f2 = R8(p);   p += 8;
 
     uint32_t flag = U4(p); p += 4;
+    (void)flag;
     double N = R8(p); p += 8;
+    (void)N;
     eph.sva = uraindex(R8(p)); p += 8;
 
     if (toc != eph.toes) { /* toe and toc should be matched */
@@ -727,7 +738,7 @@ static int decode_obsvmb(raw_t* raw)
     uint8_t* p = raw->buff + HLEN;
     char* q;
     double psr, adr, dop, snr, lockt, tt, freq, glo_bias = 0.0;
-    int i, index, prn, sat, sys, code, idx, track, plock, clock, lli;
+    int i, index, prn, sat, sys, code, idx, plock, clock, lli;
     int gfrq;
 
     if ((q = strstr(raw->opt, "-GLOBIAS="))) sscanf(q, "-GLOBIAS=%lf", &glo_bias);

--- a/src/rcvraw.c
+++ b/src/rcvraw.c
@@ -1214,19 +1214,18 @@ static int decode_frame_alm(const uint8_t *buff, alm_t *alm)
 /* decode GPS/QZSS iono parameters -------------------------------------------*/
 static int decode_frame_ion(const uint8_t *buff, double *ion)
 {
-    int i,frm;
-    
     trace(4,"decode_frame_ion:\n");
         
     /* subframe 4/5 and svid=56 (page18) (wide area for QZSS) */
-    for (frm=4,buff+=90;frm<=5;frm++,buff+=30) {
+    buff += 90;
+    for (unsigned frm=4;frm<=5;frm++,buff+=30) {
         if (frm==5&&getbitu(buff,48,2)==1) continue;
         if (getbitu(buff,43,3)!=frm||getbitu(buff,50,6)!=56) continue;
-            i=56;
-            ion[0]=getbits(buff,i, 8)*P2_30;     i+= 8;
-            ion[1]=getbits(buff,i, 8)*P2_27;     i+= 8;
-            ion[2]=getbits(buff,i, 8)*P2_24;     i+= 8;
-            ion[3]=getbits(buff,i, 8)*P2_24;     i+= 8;
+        int i=56;
+        ion[0]=getbits(buff,i, 8)*P2_30;     i+= 8;
+        ion[1]=getbits(buff,i, 8)*P2_27;     i+= 8;
+        ion[2]=getbits(buff,i, 8)*P2_24;     i+= 8;
+        ion[3]=getbits(buff,i, 8)*P2_24;     i+= 8;
         ion[4]=getbits(buff,i,8)*P2P11; i+=8;
         ion[5]=getbits(buff,i,8)*P2P14; i+=8;
         ion[6]=getbits(buff,i,8)*P2P16; i+=8;
@@ -1238,15 +1237,14 @@ static int decode_frame_ion(const uint8_t *buff, double *ion)
 /* decode GPS/QZSS UTC parameters --------------------------------------------*/
 static int decode_frame_utc(const uint8_t *buff, double *utc)
 {
-    int i,frm;
-    
     trace(4,"decode_frame_utc:\n");
     
     /* subframe 4/5 and svid=56 (page18) */
-    for (frm=4,buff+=90;frm<=5;frm++,buff+=30) {
+    buff += 90;
+    for (unsigned frm=4;frm<=5;frm++,buff+=30) {
         if (frm==5&&getbitu(buff,48,2)==1) continue;
         if (getbitu(buff,43,3)!=frm||getbitu(buff,50,6)!=56) continue;
-        i=120;
+        int i=120;
         utc[1]=getbits(buff,i,24)*P2_50; i+=24; /* A1 (s) */
         utc[0]=getbits(buff,i,32)*P2_30; i+=32; /* A0 (s) */
         utc[2]=getbitu(buff,i, 8)*P2P12; i+= 8; /* tot (s) */

--- a/src/rtcm2.c
+++ b/src/rtcm2.c
@@ -341,41 +341,49 @@ static int decode_type22(rtcm_t *rtcm)
 /* decode type 23: antenna type definition record ----------------------------*/
 static int decode_type23(rtcm_t *rtcm)
 {
+    (void)rtcm;
     return 0;
 }
 /* decode type 24: antenna reference point (arp) -----------------------------*/
 static int decode_type24(rtcm_t *rtcm)
 {
+    (void)rtcm;
     return 0;
 }
 /* decode type 31: differential glonass correction ---------------------------*/
 static int decode_type31(rtcm_t *rtcm)
 {
+    (void)rtcm;
     return 0;
 }
 /* decode type 32: differential glonass reference station parameters ---------*/
 static int decode_type32(rtcm_t *rtcm)
 {
+    (void)rtcm;
     return 0;
 }
 /* decode type 34: glonass partial differential correction set ---------------*/
 static int decode_type34(rtcm_t *rtcm)
 {
+    (void)rtcm;
     return 0;
 }
 /* decode type 36: glonass special message -----------------------------------*/
 static int decode_type36(rtcm_t *rtcm)
 {
+    (void)rtcm;
     return 0;
 }
 /* decode type 37: gnss system time offset -----------------------------------*/
 static int decode_type37(rtcm_t *rtcm)
 {
+    (void)rtcm;
     return 0;
 }
 /* decode type 59: proprietary message ---------------------------------------*/
 static int decode_type59(rtcm_t *rtcm)
 {
+    (void)rtcm;
     return 0;
 }
 /* decode rtcm ver.2 message -------------------------------------------------*/

--- a/src/rtcm3.c
+++ b/src/rtcm3.c
@@ -725,6 +725,7 @@ static int decode_type1012(rtcm_t *rtcm)
 /* decode type 1013: system parameters ---------------------------------------*/
 static int decode_type1013(rtcm_t *rtcm)
 {
+    (void)rtcm;
     return 0;
 }
 /* decode type 1019: GPS ephemerides -----------------------------------------*/
@@ -885,42 +886,49 @@ static int decode_type1020(rtcm_t *rtcm)
 /* decode type 1021: helmert/abridged molodenski -----------------------------*/
 static int decode_type1021(rtcm_t *rtcm)
 {
+    (void)rtcm;
     trace(2,"rtcm3 1021: not supported message\n");
     return 0;
 }
 /* decode type 1022: Moledenski-Badekas transfromation -----------------------*/
 static int decode_type1022(rtcm_t *rtcm)
 {
+    (void)rtcm;
     trace(2,"rtcm3 1022: not supported message\n");
     return 0;
 }
 /* decode type 1023: residual, ellipsoidal grid representation ---------------*/
 static int decode_type1023(rtcm_t *rtcm)
 {
+    (void)rtcm;
     trace(2,"rtcm3 1023: not supported message\n");
     return 0;
 }
 /* decode type 1024: residual, plane grid representation ---------------------*/
 static int decode_type1024(rtcm_t *rtcm)
 {
+    (void)rtcm;
     trace(2,"rtcm3 1024: not supported message\n");
     return 0;
 }
 /* decode type 1025: projection (types except LCC2SP,OM) ---------------------*/
 static int decode_type1025(rtcm_t *rtcm)
 {
+    (void)rtcm;
     trace(2,"rtcm3 1025: not supported message\n");
     return 0;
 }
 /* decode type 1026: projection (LCC2SP - lambert conic conformal (2sp)) -----*/
 static int decode_type1026(rtcm_t *rtcm)
 {
+    (void)rtcm;
     trace(2,"rtcm3 1026: not supported message\n");
     return 0;
 }
 /* decode type 1027: projection (type OM - oblique mercator) -----------------*/
 static int decode_type1027(rtcm_t *rtcm)
 {
+    (void)rtcm;
     trace(2,"rtcm3 1027: not supported message\n");
     return 0;
 }
@@ -959,18 +967,21 @@ static int decode_type1029(rtcm_t *rtcm)
 /* decode type 1030: network RTK residual ------------------------------------*/
 static int decode_type1030(rtcm_t *rtcm)
 {
+    (void)rtcm;
     trace(2,"rtcm3 1030: not supported message\n");
     return 0;
 }
 /* decode type 1031: GLONASS network RTK residual ----------------------------*/
 static int decode_type1031(rtcm_t *rtcm)
 {
+    (void)rtcm;
     trace(2,"rtcm3 1031: not supported message\n");
     return 0;
 }
 /* decode type 1032: physical reference station position information ---------*/
 static int decode_type1032(rtcm_t *rtcm)
 {
+    (void)rtcm;
     trace(2,"rtcm3 1032: not supported message\n");
     return 0;
 }
@@ -1034,30 +1045,35 @@ static int decode_type1033(rtcm_t *rtcm)
 /* decode type 1034: GPS network FKP gradient --------------------------------*/
 static int decode_type1034(rtcm_t *rtcm)
 {
+    (void)rtcm;
     trace(2,"rtcm3 1034: not supported message\n");
     return 0;
 }
 /* decode type 1035: GLONASS network FKP gradient ----------------------------*/
 static int decode_type1035(rtcm_t *rtcm)
 {
+    (void)rtcm;
     trace(2,"rtcm3 1035: not supported message\n");
     return 0;
 }
 /* decode type 1037: GLONASS network RTK ionospheric correction difference ---*/
 static int decode_type1037(rtcm_t *rtcm)
 {
+    (void)rtcm;
     trace(2,"rtcm3 1037: not supported message\n");
     return 0;
 }
 /* decode type 1038: GLONASS network RTK geometic correction difference ------*/
 static int decode_type1038(rtcm_t *rtcm)
 {
+    (void)rtcm;
     trace(2,"rtcm3 1038: not supported message\n");
     return 0;
 }
 /* decode type 1039: GLONASS network RTK combined correction difference ------*/
 static int decode_type1039(rtcm_t *rtcm)
 {
+    (void)rtcm;
     trace(2,"rtcm3 1039: not supported message\n");
     return 0;
 }

--- a/src/rtcm3e.c
+++ b/src/rtcm3e.c
@@ -1974,6 +1974,7 @@ static void gen_msm_index(const rtcm_t *rtcm, int sys, int *nsat, int *nsig,
 static void gen_msm_sat(rtcm_t *rtcm, int sys, int nsat, const uint8_t *sat_ind,
                         double *rrng, double *rrate, uint8_t *info)
 {
+    (void)nsat;
     obsd_t *data;
     double freq;
     int i,j,k,sat,sig,fcn;
@@ -2010,6 +2011,7 @@ static void gen_msm_sig(rtcm_t *rtcm, int sys, int nsat, int nsig, int ncell,
                         const double *rrate, double *psrng, double *phrng,
                         double *rate, double *lock, uint8_t *half, float *cnr)
 {
+    (void)nsat;
     obsd_t *data;
     double freq,lambda,psrng_s,phrng_s,rate_s,lt;
     int i,j,k,sat,sig,fcn,cell,LLI;
@@ -2588,6 +2590,8 @@ static int encode_type1230(rtcm_t *rtcm, int sync)
 /* encode type 4073: proprietary message Mitsubishi Electric -----------------*/
 static int encode_type4073(rtcm_t *rtcm, int subtype, int sync)
 {
+    (void)rtcm;
+    (void)sync;
     trace(2,"rtcm3 4073: unsupported message subtype=%d\n",subtype);
     return 0;
 }

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -2864,6 +2864,7 @@ extern int readerp(const char *file, erp_t *erp) {
       erp->data[erp->n].xp = v[1] * 1E-6 * AS2R;
       erp->data[erp->n].yp = v[2] * 1E-6 * AS2R;
       erp->data[erp->n].ut1_utc = v[3] * 1E-7;
+      (void)utcp;
       if (taip) {
         // Convert UT1-TAI to UT1-UTC.
         const double ep[] = {2000, 1, 1, 12, 0, 0};
@@ -3753,6 +3754,7 @@ extern int seliflc(int optnf,int sys)
 extern double tropmodel(gtime_t time, const double *pos, const double *azel,
                         double humi)
 {
+    (void)time;
     const double temp0=15.0; /* temperature at sea level */
     double hgt,pres,temp,e,z,trph,trpw;
 
@@ -3942,6 +3944,7 @@ static void sunpos_eci(gtime_t tutc, const double *erpv, double *rsun) {
   trace(4, "sunpos_eci: tutc=%s\n", time2str(tutc, tstr, 3));
 
 #ifdef SUNPOS_SOFA  /* use high accuracy functions in sofa.c */
+  (void)erpv;
   static THREADLOCAL gtime_t tutc_ = {0, 0};
   static THREADLOCAL double rsun_[3];
 
@@ -3993,6 +3996,7 @@ static void moonpos_eci(gtime_t tutc, const double *erpv, double *rmoon) {
   trace(4, "moonpos_eci: tutc=%s\n", time2str(tutc, tstr, 3));
 
 #ifdef MOONPOS_SOFA   /* use high accuracy functions in sofa.c */
+  (void)erpv;
   static THREADLOCAL gtime_t tutc_ = {0, 0};
   static THREADLOCAL double rmoon_[3];
 

--- a/src/rtkpos.c
+++ b/src/rtkpos.c
@@ -348,6 +348,7 @@ static void swapsolstat(void)
 /* output solution status ----------------------------------------------------*/
 static void outsolstat(rtk_t *rtk,const nav_t *nav)
 {
+    (void)nav;
     if (statlevel<=0||!fp_stat||!rtk->sol.stat) return;
 
     trace(3,"outsolstat:\n");
@@ -401,6 +402,7 @@ static double gfobs(const obsd_t *obs, int i, int j, int k, const nav_t *nav)
 static double varerr(int sat, int sys, double el, double snr_rover, double snr_base,
                      double bl, double dt, int f, const prcopt_t *opt, const obsd_t *obs)
 {
+    (void)sat;
     double a,b,c,d,e;
     double snr_max=opt->err[5];
     double fact;
@@ -599,6 +601,7 @@ static void udion(rtk_t *rtk, double tt, double bl, const int *sat, int ns)
 /* temporal update of tropospheric parameters --------------------------------*/
 static void udtrop(rtk_t *rtk, double tt, double bl)
 {
+    (void)bl;
     int i,j,k;
 
     trace(3,"udtrop  : tt=%.3f\n",tt);
@@ -652,7 +655,9 @@ static void udrcvbias(rtk_t *rtk, double tt)
 // observation code changes then consider it a slip.
 static void detslp_code(rtk_t *rtk, const obsd_t *obs, int i, int rcv) {
   int sat = obs[i].sat;
-  for (int f = 0; f < rtk->opt.nf; f++) {
+  int nf = rtk->opt.nf;
+  if (nf > NFREQ) nf = NFREQ; // Quieten compiler warnings on slip[] write.
+  for (int f = 0; f < nf; f++) {
     int code = obs[i].code[f];
     if (code == CODE_NONE) continue;
     int ccode = rtk->ssat[sat - 1].code[f][rcv - 1];
@@ -749,6 +754,7 @@ static void detslp_gf(rtk_t *rtk, const obsd_t *obs, int i, int j,
 static void detslp_dop(rtk_t *rtk, const obsd_t *obs, const int *ix, int ns,
                        int rcv, const nav_t *nav)
 {
+    (void)nav;
     int i,ii,f,sat,ndop=0,nf=rtk->opt.nf;
     double dph,dpt,mean_dop=0;
     double dopdif[MAXSAT][NFREQ], tt[MAXSAT][NFREQ];
@@ -1569,6 +1575,7 @@ static int ddidx(rtk_t *rtk, int *ix, int gps, int glo, int sbs)
 /* translate double diff fixed phase-bias values to single diff fix phase-bias values */
 static void restamb(rtk_t *rtk, const double *bias, int nb, double *xa)
 {
+    (void)nb;
     int i,n,m,f,index[MAXSAT]={0},nv=0,nf=NF(&rtk->opt);
 
     trace(3,"restamb :\n");

--- a/src/sbas.c
+++ b/src/sbas.c
@@ -604,6 +604,7 @@ extern void sbsoutmsg(FILE *fp, sbsmsg_t *sbsmsg)
 static void searchigp(gtime_t time, const double *pos, const sbsion_t *ion,
                       const sbsigp_t **igp, double *x, double *y)
 {
+    (void)time;
     int i,latp[2],lonp[4];
     double lat=pos[0]*R2D,lon=pos[1]*R2D;
     const sbsigp_t *p;

--- a/src/solution.c
+++ b/src/solution.c
@@ -631,6 +631,7 @@ static int decode_solsss(char *buff, sol_t *sol)
 /* decode GSI F solution -----------------------------------------------------*/
 static int decode_solgsi(char *buff, const solopt_t *opt, sol_t *sol)
 {
+    (void)opt;
     double val[MAXFIELD];
     int i=0,j;
     
@@ -1406,6 +1407,7 @@ extern int outnmea_gsa(uint8_t *buff, const sol_t *sol, const ssat_t *ssat)
 /* output solution in the form of NMEA GSV sentences -------------------------*/
 extern int outnmea_gsv(uint8_t *buff, const sol_t *sol, const ssat_t *ssat)
 {
+    (void)sol;
     double az,el,snr;
     int i,j,k,n,nsat,nmsg,prn,sys,sats[MAXSAT];
     char *p=(char *)buff,*q,*s,sum;

--- a/src/stream.c
+++ b/src/stream.c
@@ -517,6 +517,7 @@ static void closeserial(serial_t *serial)
 /* read serial ---------------------------------------------------------------*/
 static int readserial(serial_t *serial, uint8_t *buff, int n, char *msg)
 {
+    (void)msg;
     char msg_tcp[128];
 #ifdef WIN32
     DWORD nr;
@@ -542,6 +543,7 @@ static int readserial(serial_t *serial, uint8_t *buff, int n, char *msg)
 /* write serial --------------------------------------------------------------*/
 static int writeserial(serial_t *serial, uint8_t *buff, int n, char *msg)
 {
+    (void)msg;
     int ns=0;
     
     tracet(3,"writeserial: dev=%d n=%d\n",serial->dev,n);
@@ -1563,6 +1565,7 @@ static int statetcpcli(tcpcli_t *tcpcli)
 /* get extended state tcp client ---------------------------------------------*/
 static int statextcpcli(tcpcli_t *tcpcli, char *msg)
 {
+    (void)msg;
     return tcpcli?tcpcli->svr.state:0;
 }
 /* base64 encoder ------------------------------------------------------------*/
@@ -2215,6 +2218,7 @@ static void closeudpsvr(udp_t *udpsvr)
 /* read udp server -----------------------------------------------------------*/
 static int readudpsvr(udp_t *udpsvr, uint8_t *buff, int n, char *msg)
 {
+    (void)msg;
     struct timeval tv={0};
     fd_set rs;
     int ret,nr;
@@ -2274,6 +2278,7 @@ static void closeudpcli(udp_t *udpcli)
 /* write udp client -----------------------------------------------------------*/
 static int writeudpcli(udp_t *udpcli, uint8_t *buff, int n, char *msg)
 {
+    (void)msg;
     tracet(4,"writeudpcli: sock=%d n=%d\n",udpcli->sock,n);
     
     return (int)sendto(udpcli->sock,(char *)buff,n,0,
@@ -2552,6 +2557,7 @@ static int stateftp(ftp_t *ftp)
 /* get extended state ftp ----------------------------------------------------*/
 static int statexftp(ftp_t *ftp, char *msg)
 {
+    (void)msg;
     return !ftp?0:(ftp->state==0?2:(ftp->state<=2?3:-1));
 }
 /* open memory buffer --------------------------------------------------------*/
@@ -2592,6 +2598,7 @@ static void closemembuf(membuf_t *membuf)
 /* read memory buffer --------------------------------------------------------*/
 static int readmembuf(membuf_t *membuf, uint8_t *buff, int n, char *msg)
 {
+    (void)msg;
     tracet(4,"readmembuf: n=%d\n",n);
     
     if (!membuf) return 0;

--- a/src/streamsvr.c
+++ b/src/streamsvr.c
@@ -310,6 +310,7 @@ static void write_obs(gtime_t time, stream_t *str, strconv_t *conv)
 /* write nav data messages ---------------------------------------------------*/
 static void write_nav(gtime_t time, stream_t *str, strconv_t *conv)
 {
+    (void)time;
     int i;
     
     for (i=0;i<conv->nmsg;i++) {


### PR DESCRIPTION
Unused variable warnings are quietened by using (void)var.

Deals with issues raised in https://github.com/rtklibexplorer/RTKLIB/pull/732 but without commenting out code.
