### PR TITLE
rtcm3: skip processing on satellite error in MSM observation

### DIFF
--- a/src/rtcm3.c
+++ b/src/rtcm3.c
@@ -2075,6 +2075,7 @@ static void save_msm_obs(rtcm_t *rtcm, int sys, msm_h_t *h, const double *r,
         }
         else {
             trace(2,"rtcm3 %d satellite error: prn=%d\n",type,prn);
+            continue;
         }
         fcn=0;
         if (sys==SYS_GLO) {


### PR DESCRIPTION
Title: Skip processing on satellite error in MSM observation

Summary: This pull request adds a critical bug fix to the RTCM3 MSM (Multiple Signal Message) processing function in RTKLIB. The change prevents the processing of invalid satellite data when satellite errors are detected.

Changes Made:

File: [rtcm3.c](vscode-file://vscode-app/c:/Users/user/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Function: save_msm_obs()
Line: Added continue; statement after satellite error detection
Technical Details: The modification adds a continue statement in the save_msm_obs function when a satellite error is detected. Previously, when the satno() function returned 0 (indicating an invalid satellite), the code would log an error message but continue processing the invalid satellite data, which could lead to:

Corrupted observation data
Potential crashes or undefined behavior
Invalid positioning calculations

Impact:

Improved Stability: Prevents processing of invalid satellite data
Better Error Handling: Ensures the loop continues to the next satellite when errors are detected
Data Integrity: Maintains clean observation data by skipping corrupted satellite information
Testing: This change improves the robustness of RTCM3 MSM message processing and should be thoroughly tested with various RTCM3 data streams containing potential satellite errors.

Backward Compatibility: This change is backward compatible and only affects error handling behavior. Normal operation with valid satellite data remains unchanged.