### PR TITLE
Misc issues with GLONASS not enabled in a build

### DIFF
--- a/src/rcvraw.c
+++ b/src/rcvraw.c
@@ -1303,7 +1303,6 @@ extern int init_raw(raw_t *raw, int format)
     obsd_t data0={{0}};
     eph_t  eph0 ={0,-1,-1};
     alm_t  alm0 ={0,-1};
-    geph_t geph0={0,-1};
     seph_t seph0={0};
     sbsmsg_t sbsmsg0={0};
     int i,j,ret=1;
@@ -1346,7 +1345,6 @@ extern int init_raw(raw_t *raw, int format)
         !(raw->obuf.data=(obsd_t *)malloc(sizeof(obsd_t)*MAXOBS))||
         !(raw->nav.eph  =(eph_t  *)malloc(sizeof(eph_t )*MAXSAT*2))||
         !(raw->nav.alm  =(alm_t  *)malloc(sizeof(alm_t )*MAXSAT))||
-        !(raw->nav.geph =(geph_t *)malloc(sizeof(geph_t)*NSATGLO))||
         !(raw->nav.seph =(seph_t *)malloc(sizeof(seph_t)*NSATSBS*2))) {
         free_raw(raw);
         return 0;
@@ -1355,13 +1353,11 @@ extern int init_raw(raw_t *raw, int format)
     raw->obuf.n=0;
     raw->nav.n =raw->nav.nmax =MAXSAT*2;
     raw->nav.na=raw->nav.namax=MAXSAT;
-    raw->nav.ng=raw->nav.ngmax=NSATGLO;
     raw->nav.ns=raw->nav.nsmax=NSATSBS*2;
     for (i=0;i<MAXOBS   ;i++) raw->obs.data [i]=data0;
     for (i=0;i<MAXOBS   ;i++) raw->obuf.data[i]=data0;
     for (i=0;i<MAXSAT*2 ;i++) raw->nav.eph  [i]=eph0;
     for (i=0;i<MAXSAT   ;i++) raw->nav.alm  [i]=alm0;
-    for (i=0;i<NSATGLO  ;i++) raw->nav.geph [i]=geph0;
     for (i=0;i<NSATSBS*2;i++) raw->nav.seph [i]=seph0;
     raw->sta.name[0]=raw->sta.markerno[0]=raw->sta.markertype[0]='\0';
     raw->sta.observer[0]=raw->sta.agency[0]='\0';
@@ -1372,7 +1368,18 @@ extern int init_raw(raw_t *raw, int format)
         raw->sta.pos[i]=raw->sta.del[i]=0.0;
     }
     raw->sta.hgt=0.0;
-    
+
+    if (MAXPRNGLO > 0) {
+      raw->nav.geph = (geph_t *)malloc(sizeof(geph_t) * MAXPRNGLO);
+      if (raw->nav.geph == NULL) {
+        free_raw(raw);
+        return 0;
+      }
+      geph_t geph0 = {0, -1};
+      for (int i = 0; i < MAXPRNGLO; i++) raw->nav.geph[i] = geph0;
+    }
+    raw->nav.ng = raw->nav.ngmax = MAXPRNGLO;
+
     /* initialize receiver dependent data */
     raw->format=format;
     switch (format) {

--- a/src/rinex.c
+++ b/src/rinex.c
@@ -1864,7 +1864,6 @@ extern int init_rnxctr(rnxctr_t *rnx)
     gtime_t time0={0};
     obsd_t data0={{0}};
     eph_t  eph0={0,-1,-1};
-    geph_t geph0={0,-1};
     seph_t seph0={0};
     int i,j;
 
@@ -1877,7 +1876,6 @@ extern int init_rnxctr(rnxctr_t *rnx)
 
     if (!(rnx->obs.data=(obsd_t *)malloc(sizeof(obsd_t)*MAXOBS   ))||
         !(rnx->nav.eph =(eph_t  *)malloc(sizeof(eph_t )*MAXSAT*2 ))||
-        !(rnx->nav.geph=(geph_t *)malloc(sizeof(geph_t)*NSATGLO  ))||
         !(rnx->nav.seph=(seph_t *)malloc(sizeof(seph_t)*NSATSBS*2))) {
         free_rnxctr(rnx);
         return 0;
@@ -1889,14 +1887,23 @@ extern int init_rnxctr(rnxctr_t *rnx)
     rnx->obs.n=0;
     rnx->obs.nmax=MAXOBS;
     rnx->nav.n=rnx->nav.nmax=MAXSAT*2;
-    rnx->nav.ng=rnx->nav.ngmax=NSATGLO;
     rnx->nav.ns=rnx->nav.nsmax=NSATSBS*2;
     for (i=0;i<MAXOBS   ;i++) rnx->obs.data[i]=data0;
     for (i=0;i<MAXSAT*2 ;i++) rnx->nav.eph [i]=eph0;
-    for (i=0;i<NSATGLO  ;i++) rnx->nav.geph[i]=geph0;
     for (i=0;i<NSATSBS*2;i++) rnx->nav.seph[i]=seph0;
     rnx->ephsat=rnx->ephset=0;
     rnx->opt[0]='\0';
+
+    if (MAXPRNGLO > 0) {
+      rnx->nav.geph = (geph_t *)malloc(sizeof(geph_t) * MAXPRNGLO);
+      if (rnx->nav.geph == NULL) {
+        free_rnxctr(rnx);
+        return 0;
+      }
+      geph_t geph0 = {0, -1};
+      for (int i = 0; i < MAXPRNGLO ; i++) rnx->nav.geph[i] = geph0;
+    }
+    rnx->nav.ng = rnx->nav.ngmax = MAXPRNGLO;
 
     return 1;
 }

--- a/src/rtcm.c
+++ b/src/rtcm.c
@@ -68,7 +68,6 @@ extern int init_rtcm(rtcm_t *rtcm)
     gtime_t time0={0};
     obsd_t data0={{0}};
     eph_t  eph0 ={0,-1,-1};
-    geph_t geph0={0,-1};
     ssr_t ssr0={{{0}}};
     int i,j;
     
@@ -107,20 +106,29 @@ extern int init_rtcm(rtcm_t *rtcm)
     rtcm->nav.geph=NULL;
     rtcm->nav.seph=NULL;
     
-    /* reallocate memory for observation and ephemeris buffer */
+    // Allocate memory for observation and ephemeris buffer.
     if (!(rtcm->obs.data=(obsd_t *)malloc(sizeof(obsd_t)*MAXOBS))||
-        !(rtcm->nav.eph =(eph_t  *)malloc(sizeof(eph_t )*MAXSAT*2))||
-        !(rtcm->nav.geph=(geph_t *)malloc(sizeof(geph_t)*MAXPRNGLO))) {
+        !(rtcm->nav.eph =(eph_t  *)malloc(sizeof(eph_t )*MAXSAT*2))) {
         free_rtcm(rtcm);
         return 0;
     }
     rtcm->obs.n=0;
     rtcm->nav.n=rtcm->nav.nmax=MAXSAT*2;
-    rtcm->nav.ng=rtcm->nav.ngmax=MAXPRNGLO;
     rtcm->nav.ns=rtcm->nav.nsmax=0;
     for (i=0;i<MAXOBS   ;i++) rtcm->obs.data[i]=data0;
     for (i=0;i<MAXSAT*2 ;i++) rtcm->nav.eph [i]=eph0;
-    for (i=0;i<MAXPRNGLO;i++) rtcm->nav.geph[i]=geph0;
+
+    if (MAXPRNGLO > 0) {
+      rtcm->nav.geph = (geph_t *)malloc(sizeof(geph_t) * MAXPRNGLO);
+      if (rtcm->nav.geph == NULL) {
+        free_rtcm(rtcm);
+        return 0;
+      }
+      geph_t geph0 = {0, -1};
+      for (int i = 0; i < MAXPRNGLO; i++) rtcm->nav.geph[i] = geph0;
+    }
+    rtcm->nav.ng = rtcm->nav.ngmax = MAXPRNGLO;
+
     return 1;
 }
 /* free rtcm control ----------------------------------------------------------

--- a/src/rtcm3.c
+++ b/src/rtcm3.c
@@ -2085,7 +2085,7 @@ static void save_msm_obs(rtcm_t *rtcm, int sys, msm_h_t *h, const double *r,
                     rtcm->nav.glo_fcn[prn-1]=fcn+8; /* fcn+8 */
                 }
             }
-            else if (rtcm->nav.geph[prn-1].sat==sat) {
+            else if (sat && rtcm->nav.geph[prn-1].sat == sat) {
                 fcn=rtcm->nav.geph[prn-1].frq;
             }
             else if (rtcm->nav.glo_fcn[prn-1]>0) {


### PR DESCRIPTION
https://github.com/rtklibexplorer/RTKLIB/pull/756

rtcm3 save_msm_obs: better guard against a GLONASS satellite not being found.

Avoid the nav geph array allocation when GLONASS is not enabled. It was calling malloc() with a zero size allocation which may correctly return NULL in this case, but the caller was using NULL to detected an allocation failure and aborting.