### PR TITLE
Fix BeiDou week rollover calculation

### DIFF
--- a/src/rtcm3.c
+++ b/src/rtcm3.c
@@ -180,7 +180,7 @@ static int adjbdtweek(int week)
     int w;
     (void)time2bdt(gpst2bdt(utc2gpst(timeget())),&w);
     if (w<1) w=1; /* use 2006/1/1 if time is earlier than 2006/1/1 */
-    return week+(w-week+512)/1024*1024;
+    return week+(w-week+4095)/8192*8192;
 }
 /* adjust daily rollover of GLONASS time -------------------------------------*/
 static void adjday_glot(rtcm_t *rtcm, double tod)


### PR DESCRIPTION
Description:
This commit updates the weekly rollover adjustment for BDS (BeiDou) time in adjbdtweek() function.

Reason:
The previous calculation applied a smaller rollover interval (1024 weeks), which could lead to incorrect week numbers for BDS time in the long term. The BeiDou system has a week number rollover period of 8192 weeks. This change ensures that the adjbdtweek() function correctly handles weekly rollover according to the BeiDou specification.