### PR TITLE
Fix GPS week rollover calculation

### DIFF
--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -2031,7 +2031,7 @@ extern int adjgpsweek(int week)
     int w;
     (void)time2gpst(utc2gpst(timeget()),&w);
     if (w<1560) w=1560; /* use 2009/12/1 if time is earlier than 2009/12/1 */
-    return week+(w-week+1)/1024*1024;
+    return week+(w-week+511)/1024*1024;
 }
 /* get tick time ---------------------------------------------------------------
 * get current tick in ms


### PR DESCRIPTION
Description

This PR isolates and includes only the fix related to adjgpsweek().
Previously, several simplifications were proposed around rtcm->time and eph.week adjustments, but these affected multiple complex code paths. To reduce risk and maintain stability, those changes have been excluded.

Reference:https://github.com/rtklibexplorer/RTKLIB/pull/767