### PR TITLE
rtkplot-qt: correct week start variable usage

### DIFF
--- a/app/qtapp/rtkplot_qt/plotcmn.cpp
+++ b/app/qtapp/rtkplot_qt/plotcmn.cpp
@@ -79,7 +79,7 @@ double Plot::timePosition(gtime_t time)
     else                                                 // jst
         tow = time2gpst(timeadd(gpst2utc(time), 9 * 3600.0), &week);
 
-    return tow + (week - week) * 86400.0 * 7;
+    return tow + (week - startWeek) * 86400.0 * 7;
 }
 // show legand in status-bar ------------------------------------------------
 void Plot::showLegend(const QStringList &msgs)

--- a/app/qtapp/rtkplot_qt/plotdata.cpp
+++ b/app/qtapp/rtkplot_qt/plotdata.cpp
@@ -95,7 +95,7 @@ void Plot::readSolution(const QStringList &files, int sel)
         ui->btnSolution2->setChecked(true);
 
     if (sel == 0 || solutionData[0].n <= 0) {
-        time2gpst(solutionData[sel].data[0].time, &week);
+        if (solutionData[sel].n > 0) time2gpst(solutionData[sel].data[0].time, &startWeek);
         updateOrigin();
     }
     solutionIndex[0] = solutionIndex[1] = observationIndex = 0;
@@ -194,7 +194,7 @@ void Plot::readObservation(const QStringList &files)
 
     ui->btnSolution1->setChecked(true);
 
-    time2gpst(observation.data[0].time, &week);
+    time2gpst(observation.data[0].time, &startWeek);
     solutionIndex[0] = solutionIndex[1] = observationIndex = 0;
 
     if (plotType < PLOT_OBS || PLOT_DOP < plotType)
@@ -459,7 +459,7 @@ void Plot::generateVisibilityData()
 
     setWindowTitle(tr("Satellite Visibility (Predicted)"));
     ui->btnSolution1->setChecked(true);
-    time2gpst(observation.data[0].time, &week);
+    time2gpst(observation.data[0].time, &startWeek);
     solutionIndex[0] = solutionIndex[1] = observationIndex = 0;
     if (plotType < PLOT_OBS || PLOT_DOP < plotType)
         updatePlotType(PLOT_OBS);
@@ -1461,7 +1461,7 @@ void Plot::clear()
 
     trace(3, "clear\n");
 
-    week = 0;
+    startWeek = 0;
 
     clearObservation();
     clearSolution();

--- a/app/qtapp/rtkplot_qt/plotdraw.cpp
+++ b/app/qtapp/rtkplot_qt/plotdraw.cpp
@@ -705,7 +705,7 @@ void Plot::drawSolution(QPainter &c, int level, int type)
         graphTriple[panel]->setLabelUnits("", " " + unit[type]);
         graphTriple[panel]->xLabelPosition = plotOptDialog->getTimeFormat() ? (panel == bottomPanel ? Graph::LabelPosition::Time : Graph::LabelPosition::None) : \
             (panel == bottomPanel ? Graph::LabelPosition::Outer : Graph::LabelPosition::Off);
-        graphTriple[panel]->week = week;
+        graphTriple[panel]->week = startWeek;
         graphTriple[panel]->drawAxis(c, plotOptDialog->getShowGridLabel(), plotOptDialog->getShowGridLabel());
     }
 
@@ -949,7 +949,7 @@ void Plot::drawNsat(QPainter &c, int level)
         graphTriple[panel]->setLabelUnits("", panel == 1 ? tr(" s") : "" );
         graphTriple[panel]->xLabelPosition = plotOptDialog->getTimeFormat() ? (panel == bottomPanel ? Graph::LabelPosition::Time : Graph::LabelPosition::None) :
                                                  (panel == bottomPanel ? Graph::LabelPosition::Outer : Graph::LabelPosition::Off);
-        graphTriple[panel]->week = week;
+        graphTriple[panel]->week = startWeek;
         graphTriple[panel]->drawAxis(c, plotOptDialog->getShowGridLabel(), plotOptDialog->getShowGridLabel());
     }
 
@@ -1025,7 +1025,7 @@ void Plot::drawObservation(QPainter &c, int level)
     
     graphSingle->xLabelPosition = plotOptDialog->getTimeFormat() ? Graph::LabelPosition::Time : Graph::LabelPosition::Outer;
     graphSingle->yLabelPosition = Graph::LabelPosition::Off;
-    graphSingle->week = week;
+    graphSingle->week = startWeek;
 
     graphSingle->getLimits(xl, yl);
     yl[0] = 0.5;
@@ -1884,7 +1884,7 @@ void Plot::drawDop(QPainter &c, int level)
     
     graphSingle->xLabelPosition = plotOptDialog->getTimeFormat() ? Graph::LabelPosition::Time : Graph::LabelPosition::Outer;
     graphSingle->yLabelPosition = Graph::LabelPosition::Outer;
-    graphSingle->week = week;
+    graphSingle->week = startWeek;
 
     // adjest plot limits
     graphSingle->getLimits(xl, yl);
@@ -2027,7 +2027,7 @@ void Plot::drawSolDop(QPainter &c, int level) {
   graphSingle->xLabelPosition =
       plotOptDialog->getTimeFormat() ? Graph::LabelPosition::Time : Graph::LabelPosition::Outer;
   graphSingle->yLabelPosition = Graph::LabelPosition::Outer;
-  graphSingle->week = week;
+  graphSingle->week = startWeek;
 
   // Adjust plot limits.
   double xl[2], yl[2];
@@ -2312,7 +2312,7 @@ void Plot::drawSnr(QPainter &c, int level)
         graphTriple[panel]->setLabelUnits("", " " + unit[panel]);
         graphTriple[panel]->xLabelPosition = plotOptDialog->getTimeFormat() ? (panel == bottomPanel ? Graph::LabelPosition::Time : Graph::LabelPosition::None) :
                                         (panel == bottomPanel ? Graph::LabelPosition::Outer : Graph::LabelPosition::Off);
-        graphTriple[panel]->week = week;
+        graphTriple[panel]->week = startWeek;
         graphTriple[panel]->drawAxis(c, plotOptDialog->getShowGridLabel(), plotOptDialog->getShowGridLabel());
     }
 
@@ -2915,7 +2915,7 @@ void Plot::drawResidual(QPainter &c, int level)
         graphTriple[panel]->setLabelUnits("", panel == 2 ? tr("") : tr(" m"));
         graphTriple[panel]->xLabelPosition = plotOptDialog->getTimeFormat() ? (panel == bottomPanel ? Graph::LabelPosition::Time : Graph::LabelPosition::None) :
                                         (panel == bottomPanel ? Graph::LabelPosition::Outer : Graph::LabelPosition::Off);
-        graphTriple[panel]->week = week;
+        graphTriple[panel]->week = startWeek;
         graphTriple[panel]->drawAxis(c, plotOptDialog->getShowGridLabel(), plotOptDialog->getShowGridLabel());
     }
 

--- a/app/qtapp/rtkplot_qt/plotinfo.cpp
+++ b/app/qtapp/rtkplot_qt/plotinfo.cpp
@@ -470,7 +470,7 @@ void Plot::updatePoint(int x, int y)
         msg = tr("El: %1°").arg(q[0], 4, 'f', 1);
     } else {
         graphTriple[0]->toPos(p, xx, yy);
-        time = gpst2time(week, xx);
+        time = gpst2time(startWeek, xx);
         if (plotOptDialog->getTimeFormat() == 2)
             time = utc2gpst(time);                         // UTC
         else if (plotOptDialog->getTimeFormat() == 3)
@@ -519,7 +519,7 @@ QString Plot::plotDetails(const QPoint &globalPos) {
                     int sat = static_cast<int>((yy/ys) / (p2.y() - p1.y()) * nSats - 0.5);
                     satno2id(yp[sat] + 1, id);
 
-                    time = gpst2time(week, xx);
+                    time = gpst2time(startWeek, xx);
                     if (plotOptDialog->getTimeFormat() == 2)
                         time = utc2gpst(time);                         // UTC
                     else if (plotOptDialog->getTimeFormat() == 3)

--- a/app/qtapp/rtkplot_qt/plotmain.cpp
+++ b/app/qtapp/rtkplot_qt/plotmain.cpp
@@ -124,7 +124,7 @@ Plot::Plot(QWidget *parent) : QMainWindow(parent), ui(new Ui::Plot)
     dragCurrentX = dragCurrentY = -1;
     nObservation = 0;
     indexObservation = NULL;
-    week = flush = plotType = 0;
+    startWeek = flush = plotType = 0;
 
     for (int i = 0; i < 2; i++) {
         initsolbuf(solutionData + i, 0, 0);
@@ -1921,10 +1921,10 @@ void Plot::timerTimer()
                         disconnectStream();
                         return;
                     }
-                    if (week == 0 && solutionData[streamNo].n == 1) { // first data
+                    if (startWeek == 0 && solutionData[streamNo].n == 1) { // first data
                         if (plotType > PLOT_NSAT)
                             updatePlotType(PLOT_TRK);
-                        time2gpst(solutionData[streamNo].time, &week);
+                        time2gpst(solutionData[streamNo].time, &startWeek);
                         updateOrigin();
                         ecef2pos(solutionData[streamNo].data[0].rr, pos);
                         mapView->setCenter(pos[0] * R2D, pos[1] * R2D);

--- a/app/qtapp/rtkplot_qt/plotmain.h
+++ b/app/qtapp/rtkplot_qt/plotmain.h
@@ -260,7 +260,7 @@ private:
     int formWidth, formHeight;
     int connectState, openRaw;
     int nObservation, *indexObservation, observationIndex;
-    int week;
+    int startWeek;
     int flush, plotType;
     int satelliteMask[MAXSAT];
     bool satelliteSelection[MAXSAT];

--- a/app/winapp/rtkplot/plotdata.cpp
+++ b/app/winapp/rtkplot/plotdata.cpp
@@ -87,7 +87,8 @@ void __fastcall TPlot::ReadSol(TStrings *files, int sel)
     else        BtnSol2->Down=true;
     
     if (sel==0||SolData[0].n<=0) {
-        time2gpst(SolData[sel].data[0].time,&Week);
+        if (SolData[sel].n > 0)
+          time2gpst(SolData[sel].data[0].time,&Week);
         UpdateOrigin();
     }
     SolIndex[0]=SolIndex[1]=ObsIndex=0;


### PR DESCRIPTION
also avoid oob access when solution empty.

rtkplot-qt was not handling data spanning a week boundary. It was conflating two 'week' variables which are separate in the windows app 'Week' vs 'week'.

Bundling in another fix, crashing on empty solution data set. Patches would conflict.
