### PR TITLE
Change _POSIX_C_SOURCE from 199506 to 200112L

### DIFF
--- a/app/consapp/convbin/convbin.c
+++ b/app/consapp/convbin/convbin.c
@@ -44,7 +44,7 @@
 *                           delete option -noscan
 *                           suppress warnings
 *-----------------------------------------------------------------------------*/
-#define _POSIX_C_SOURCE 199506
+#define _POSIX_C_SOURCE 200112L
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/app/consapp/rtkrcv/rtkrcv.c
+++ b/app/consapp/rtkrcv/rtkrcv.c
@@ -36,7 +36,7 @@
 *                           add option -w
 *           2017/09/01 1.21 add command ssr
 *-----------------------------------------------------------------------------*/
-#define _POSIX_C_SOURCE 199506
+#define _POSIX_C_SOURCE 200112L
 #include <stdlib.h>
 #include <signal.h>
 #include <unistd.h>

--- a/app/consapp/str2str/str2str.c
+++ b/app/consapp/str2str/str2str.c
@@ -29,7 +29,7 @@
 *           2017/05/26  1.17 add input format tersus
 *           2020/11/30  1.18 support api change strsvrstart(),strsvrstat()
 *-----------------------------------------------------------------------------*/
-#define _POSIX_C_SOURCE 199506
+#define _POSIX_C_SOURCE 200112L
 #include <fcntl.h>
 #include <signal.h>
 #include <unistd.h>

--- a/src/download.c
+++ b/src/download.c
@@ -14,7 +14,7 @@
 *                            limit max number of download paths
 *                            use integer types in stdint.h
 *-----------------------------------------------------------------------------*/
-#define _POSIX_C_SOURCE 199506
+#define _POSIX_C_SOURCE 200112L
 #include <errno.h>
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/src/options.c
+++ b/src/options.c
@@ -28,7 +28,7 @@
 *                             pos1-tropopt, pos1-sateph, pos1-navsys,
 *                             pos2-gloarmode,
 *-----------------------------------------------------------------------------*/
-#define _POSIX_C_SOURCE 199506
+#define _POSIX_C_SOURCE 200112L
 #include "rtklib.h"
 
 /* system options buffer -----------------------------------------------------*/

--- a/src/rcv/nvs.c
+++ b/src/rcv/nvs.c
@@ -21,7 +21,7 @@
 *           2020/07/10 1.8  suppress warnings
 *           2020/11/30 1.9  use integer type in stdint.h
 *-----------------------------------------------------------------------------*/
-#define _POSIX_C_SOURCE 199506
+#define _POSIX_C_SOURCE 200112L
 #include "rtklib.h"
 
 #define NVSSYNC     0x10        /* nvs message sync code 1 */

--- a/src/rcv/skytraq.c
+++ b/src/rcv/skytraq.c
@@ -44,7 +44,7 @@
 *                           use integer type in stdint.h
 *                           suppress warnings
 *-----------------------------------------------------------------------------*/
-#define _POSIX_C_SOURCE 199506
+#define _POSIX_C_SOURCE 200112L
 #include "rtklib.h"
 
 #define STQSYNC1    0xA0        /* skytraq binary sync code 1 */

--- a/src/rcv/ublox.c
+++ b/src/rcv/ublox.c
@@ -76,7 +76,7 @@
 *                           CODE_L1I -> CODE_L2I for BDS B1I (RINEX 3.04)
 *                           use integer types in stdint.h
 *-----------------------------------------------------------------------------*/
-#define _POSIX_C_SOURCE 199506
+#define _POSIX_C_SOURCE 200112L
 #include "rtklib.h"
 
 #define UBXSYNC1    0xB5        /* ubx message sync code 1 */

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -143,7 +143,7 @@
 *                           use integer types in stdint.h
 *                           suppress warnings
 *-----------------------------------------------------------------------------*/
-#define _POSIX_C_SOURCE 199506
+#define _POSIX_C_SOURCE 200112L
 #include <stdarg.h>
 #include <ctype.h>
 #include <errno.h>

--- a/src/stream.c
+++ b/src/stream.c
@@ -75,7 +75,7 @@
 *                           suppress warning for buffer overflow by sprintf()
 *                           use integer types in stdint.h
 *-----------------------------------------------------------------------------*/
-#define _POSIX_C_SOURCE 199506
+#define _POSIX_C_SOURCE 200112L
 #include <ctype.h>
 #include "rtklib.h"
 #ifndef WIN32

--- a/src/streamsvr.c
+++ b/src/streamsvr.c
@@ -32,7 +32,7 @@
 *                           delete API strsvrsetsrctbl()
 *                           use integer types in stdint.h
 *-----------------------------------------------------------------------------*/
-#define _POSIX_C_SOURCE 199506
+#define _POSIX_C_SOURCE 200112L
 #include "rtklib.h"
 
 /* test observation data message ---------------------------------------------*/


### PR DESCRIPTION
`snprintf` settled in c99, the code is now c99, and define _POSIX_C_SOURCE to 200112L to get the `snprintf `definition. This seems necessary on Apple Darwin. See https://github.com/rtklibexplorer/RTKLIB/pull/797 which proposed to change just a couple of cases. Still compiles on Linux.