### PR TITLE
- Clean up DCB/OSB code for PPP solutions:

### DIFF
--- a/src/pntpos.c
+++ b/src/pntpos.c
@@ -111,7 +111,7 @@ static double prange(const obsd_t *obs, const nav_t *nav, const prcopt_t *opt,
                      double *var)
 {
     double P1,P2,gamma,b1,b2;
-    int sat,sys,f2,bias_ix;
+    int sat,sys,f2;
 
     sat=obs->sat;
     sys=satsys(sat,NULL);
@@ -121,20 +121,13 @@ static double prange(const obsd_t *obs, const nav_t *nav, const prcopt_t *opt,
     *var=0.0;
     
     if (P1==0.0||(opt->ionoopt==IONOOPT_IFLC&&P2==0.0)) return 0.0;
-    bias_ix=code2bias_ix(sys,obs->code[0]);  /* L1 code bias */
-    if (bias_ix>0) { /* 0=ref code */
-        P1+=nav->cbias[sat-1][0][bias_ix-1];
+    P1-=code2bias(nav,sys,sat,obs->code[0],0);  /* L1 differential code bias */
+    if (sys!=SYS_GAL||f2!=1) { /* skip GAL P2 code bias for now to match previous version */
+        P2-=code2bias(nav,sys,sat,obs->code[f2],0); /* L2 or L5 differential code bias */
     }
-    /* GPS code biases are L1/L2, Galileo are L1/L5 */
-    if (sys==SYS_GAL&&f2==1) {
-        /* skip code bias, no GAL L2 bias available */
-    }
-    else {  /* apply L2 or L5 code bias */
-        bias_ix=code2bias_ix(sys,obs->code[f2]);
-        if (bias_ix>0) { /* 0=ref code */
-            P2+=nav->cbias[sat-1][1][bias_ix-1]; /* L2 or L5 code bias */
-        }
-    }
+    trace(5,"sys=%d sat=%d frq=%d, P: %.3f->%.3f, dt=%.3f\n",sys,obs->sat,0,obs->P[0],P1,(P1-obs->P[0])/(1E-9*CLIGHT));
+    trace(5,"sys=%d sat=%d frq=%d, P: %.3f->%.3f, dt=%.3f\n",sys,obs->sat,f2,obs->P[f2],P2,(P2-obs->P[f2])/(1E-9*CLIGHT));
+
     if (opt->ionoopt==IONOOPT_IFLC) { /* dual-frequency */
         
         if (sys==SYS_GPS||sys==SYS_QZS) { /* L1-L2 or L1-L5 */
@@ -284,7 +277,7 @@ extern int tropcorr(gtime_t time, const nav_t *nav, const double *pos,
 static int rescode(int iter, const obsd_t *obs, int n, const double *rs,
                    const double *dts, const double *vare, const int *svh,
                    const nav_t *nav, const double *x, const prcopt_t *opt,
-                   const ssat_t *ssat, double *v, double *H, double *var,
+                   double *v, double *H, double *var,
                    double *azel, int *vsat, double *resp, int *ns)
 {
     gtime_t time;
@@ -407,7 +400,7 @@ static int valsol(const double *azel, const int *vsat, int n,
 /* estimate receiver position ------------------------------------------------*/
 static int estpos(const obsd_t *obs, int n, const double *rs, const double *dts,
                   const double *vare, const int *svh, const nav_t *nav,
-                  const prcopt_t *opt, const ssat_t *ssat, sol_t *sol, double *azel,
+                  const prcopt_t *opt, sol_t *sol, double *azel,
                   int *vsat, double *resp, char *msg)
 {
     double x[NX]={0},dx[NX],Q[NX*NX],*v,*H,*var,sig;
@@ -422,7 +415,7 @@ static int estpos(const obsd_t *obs, int n, const double *rs, const double *dts,
     for (i=0;i<MAXITR;i++) {
 
         /* pseudorange residuals (m) */
-        nv=rescode(i,obs,n,rs,dts,vare,svh,nav,x,opt,ssat,v,H,var,azel,vsat,resp,
+        nv=rescode(i,obs,n,rs,dts,vare,svh,nav,x,opt,v,H,var,azel,vsat,resp,
                    &ns);
         
         if (nv<NX) {
@@ -505,7 +498,7 @@ static int raim_fde(const obsd_t *obs, int n, const double *rs,
             svh_e[k++]=svh[j];
         }
         /* estimate receiver position without a satellite */
-        if (!estpos(obs_e,n-1,rs_e,dts_e,vare_e,svh_e,nav,opt,ssat,&sol_e,azel_e,
+        if (!estpos(obs_e,n-1,rs_e,dts_e,vare_e,svh_e,nav,opt,&sol_e,azel_e,
                     vsat_e,resp_e,msg_e)) {
             trace(3,"raim_fde: exsat=%2d (%s)\n",obs[i].sat,msg);
             continue;
@@ -690,7 +683,7 @@ extern int pntpos(const obsd_t *obs, int n, const nav_t *nav,
     satposs(sol->time,obs,n,nav,opt_.sateph,rs,dts,var,svh);
     
     /* estimate receiver position and time with pseudorange */
-    stat=estpos(obs,n,rs,dts,var,svh,nav,&opt_,ssat,sol,azel_,vsat,resp,msg);
+    stat=estpos(obs,n,rs,dts,var,svh,nav,&opt_,sol,azel_,vsat,resp,msg);
     
     /* RAIM FDE */
     if (!stat&&n>=6&&opt->posopt[4]) {

--- a/src/postpos.c
+++ b/src/postpos.c
@@ -1092,10 +1092,8 @@ static int execses(gtime_t ts, gtime_t te, double ti, const prcopt_t *popt,
 
     /* read dcb parameters from DCB, BIA, BSX files */
     dcb_ok = 0;
-    for (i=0;i<MAX_CODE_BIASES;i++) for (k=0;k<MAX_CODE_BIAS_FREQS;k++) {
-        /* FIXME: cbias later initialized with 0 in readdcb()!  */
-        for (j=0;j<MAXSAT;j++) navs.cbias[j][k][i]=-1;
-        for (j=0;j<MAXRCV;j++) navs.rbias[j][k][i]=0;
+    for (i=0;i<MAX_CODE_BIASES;i++) for (k=0;k<NFREQ;k++) {
+        for (j=0;j<MAXSAT;j++) navs.cbias[j][k][i]=0;
         }
     for (i=0;i<n;i++) {  /* first check infiles for .BIA or .BSX files */
         if ((dcb_ok=readdcb(infile[i],&navs,stas))) break;

--- a/src/ppp.c
+++ b/src/ppp.c
@@ -412,7 +412,7 @@ static void corr_meas(const obsd_t *obs, const nav_t *nav, const double *azel,
                       double *Lc, double *Pc)
 {
     double freq[NFREQ]={0},C1,C2;
-    int i,ix=0,frq,frq2,bias_ix,sys=satsys(obs->sat,NULL);
+    int i,ix=0,frq2,sys=satsys(obs->sat,NULL);
 
     for (i=0;i<opt->nf;i++) {
         L[i]=P[i]=0.0;
@@ -424,7 +424,7 @@ static void corr_meas(const obsd_t *obs, const nav_t *nav, const double *azel,
         /* antenna phase center and phase windup correction */
         L[i]=obs->L[i]*CLIGHT/freq[i]-dants[i]-dantr[i]-phw*CLIGHT/freq[i];
         P[i]=obs->P[i]               -dants[i]-dantr[i];
-
+        double P_nobias = P[i];
         if (opt->sateph==EPHOPT_SSRAPC||opt->sateph==EPHOPT_SSRCOM) {
             /* select SSR code correction based on code */
             if (sys==SYS_GPS)
@@ -437,18 +437,13 @@ static void corr_meas(const obsd_t *obs, const nav_t *nav, const double *azel,
             P[i]+=(nav->ssr[obs->sat-1].cbias[obs->code[i]-1]-nav->ssr[obs->sat-1].cbias[ix]);
         }
         else {   /* apply code bias corrections from file */
-            if (sys==SYS_GAL&&(i==1||i==2)) frq=3-i;  /* GAL biases are L1/L5 */
-            else frq=i;  /* other biases are L1/L2 */
-            if (frq>=MAX_CODE_BIAS_FREQS) continue;  /* only 2 freqs per system supported in code bias table */
-            bias_ix=code2bias_ix(sys,obs->code[i]); /* look up bias index in table */
-            if (bias_ix>0) {  /*  0=ref code */
-                P[i]+=nav->cbias[obs->sat-1][frq][bias_ix-1]; /* code bias */
-            }
+            P[i]-=code2bias(nav,sys,obs->sat,obs->code[i],0); /* differential bias*/
         }
+        trace(4,"sys=%d sat=%d frq=%d, P: %.3f->%.3f, dt=%.3f\n",sys,obs->sat,i,P_nobias,P[i],(P[i]-P_nobias)/(1E-9*CLIGHT));
     }
     /* choose freqs for iono-free LC */
     *Lc=*Pc=0.0;
-    frq2=L[1]==0?2:1;  /* if L[1]==0, try L[2] */
+    frq2=seliflc(opt->nf,satsys(obs->sat,NULL));
     if (freq[0]==0.0||freq[frq2]==0.0) return;
     C1= SQR(freq[0])/(SQR(freq[0])-SQR(freq[frq2]));
     C2=-SQR(freq[frq2])/(SQR(freq[0])-SQR(freq[frq2]));

--- a/src/preceph.c
+++ b/src/preceph.c
@@ -57,10 +57,9 @@
 #define MAXDTE      900.0           /* max time difference to ephem time (s) */
 #define EXTERR_CLK  1E-3            /* extrapolation error for clock (m/s) */
 #define EXTERR_EPH  5E-7            /* extrapolation error for ephem (m/s^2) */
-#define MAX_BIAS_SYS 4              /* # of constellations supported */
 
 /* table to translate code to code bias table index  */
-static int8_t code_bias_ix[MAX_BIAS_SYS][MAXCODE];
+static int8_t code_bias_ix[NSYS][MAXCODE];
 /* initialize code bias lookup table -------------------------------------------
 *       -1 = code not supported
 *        0 = reference code (0 bias)
@@ -69,7 +68,7 @@ static int8_t code_bias_ix[MAX_BIAS_SYS][MAXCODE];
 static void init_bias_ix(void) {
     int i,j;
 
-    for (i=0;i<MAX_BIAS_SYS;i++) for (j=0;j<MAXCODE;j++)
+    for (i=0;i<NSYS;i++) for (j=0;j<MAXCODE;j++)
         code_bias_ix[i][j]=-1;
 
     /* GPS */
@@ -92,6 +91,9 @@ static void init_bias_ix(void) {
     code_bias_ix[2][CODE_L5Q]=0;
     code_bias_ix[2][CODE_L5I]=1;
     code_bias_ix[2][CODE_L5X]=2;
+    code_bias_ix[2][CODE_L7Q]=0;
+    code_bias_ix[2][CODE_L7I]=1;
+    code_bias_ix[2][CODE_L7X]=2;
     /* Beidou */
     code_bias_ix[3][CODE_L2I]=0;
     code_bias_ix[3][CODE_L6I]=0;
@@ -374,14 +376,14 @@ extern int readsap(const char *file, const gtime_t time, nav_t *nav) {
   return 1;
 }
 /* read DCB parameters from DCB file -------------------------------------------
-*    - supports satellite and receiver biases
+*    - supports satellite biases
 *-----------------------------------------------------------------------------*/
 static int readdcbf(const char *file, nav_t *nav, const sta_t *sta)
 {
     FILE *fp;
     double cbias;
     char buff[256],str1[32],str2[32]="";
-    int i,j,sat,type=0;
+    int sat,type=0;
 
     trace(3,"readdcbf: file=%s\n",file);
 
@@ -400,16 +402,17 @@ static int readdcbf(const char *file, nav_t *nav, const sta_t *sta)
         if ((cbias=str2num(buff,26,9))==0.0) continue;
 
         if (sta&&(!strcmp(str1,"G")||!strcmp(str1,"R"))) { /* receiver DCB */
-            for (i=0;i<MAXRCV;i++) {
-                if (!strcmp(sta[i].name,str2)) break;
-            }
-            if (i<MAXRCV) {
-                j=!strcmp(str1,"G")?0:1;
-                nav->rbias[i][j][type-1]=cbias*1E-9*CLIGHT; /* ns -> m */
-            }
+/* receiver DCBs never used in RTKLIB so remove support */
+//            for (i=0;i<MAXRCV;i++) {
+//                if (!strcmp(sta[i].name,str2)) break;
+//            }
+//            if (i<MAXRCV) {
+//                j=!strcmp(str1,"G")?0:1;
+//                nav->rbias[i][j][type-1]=cbias*1E-9*CLIGHT; /* ns -> m */
+//            }
         }
         else if ((sat=satid2no(str1))) { /* satellite dcb */
-            nav->cbias[sat-1][type-1][0]=cbias*1E-9*CLIGHT; /* ns -> m */
+            nav->cbias[sat-1][type-1][0]=-cbias*1E-9*CLIGHT; /* ns -> m */
         }
     }
     fclose(fp);
@@ -430,19 +433,24 @@ static int sys2ix(int sys)
     }
     return 0;
 }
-/* translate satellite system and code to code bias table index ----------------
-*       -1 = code not supported
-*        0 = reference code (0 bias)
-*        1-3 = table index for code
+/* lookup code bias from table ----------------
+*       return 0 if not found
+*       mode:  0=DCB or pseudo-DCB
+*              1=OSB or pseudo-OSB
 * ----------------------------------------------------------------------------*/
-extern int code2bias_ix(int sys, int code) {
-    int sys_ix;
+extern double code2bias(const nav_t *nav, int sys, int sat, int code, int mode) {
+    int sys_ix,frq_ix,code_ix;
+    double bias=0;
 
     sys_ix=sys2ix(sys);
-    if (sys_ix<MAX_BIAS_SYS)
-        return code_bias_ix[sys_ix][code];
-    else
-        return 0;
+    frq_ix=code2idx(sys,code);
+    if (frq_ix>=0&&sat<=MAXSAT) {
+        code_ix = code_bias_ix[sys_ix][code];
+        bias=nav->cbias[sat-1][frq_ix][code_ix];  // absolute bias
+        if (mode==0)
+            bias-=nav->cbias[sat-1][frq_ix][0];  // difference with reference
+    }
+    return bias;
 }
 /* read DCB parameters from BIA or BSX file ------------------------------------
 *    - supports satellite code biases only
@@ -452,12 +460,12 @@ static int readbiaf(const char *file, nav_t *nav)
     FILE *fp;
     double cbias;
     char buff[256],bias[6]="",svn[6]="",prn[6]="",obs1[6]="",obs2[6];
-    int i,sat,freq,code1,code2,bias_ix1,bias_ix2,sys;
+    int sat,sys_ix,frq_ix,code1,code2,bias_ix1,bias_ix2,sys;
 
     trace(3,"readbiaf: file=%s\n",file);
 
     if (!(fp=fopen(file,"r"))) {
-        trace(2,"dcb parameters file open error: %s\n",file);
+        trace(2,"BIA/BSX parameters file open error: %s\n",file);
         return 0;
     }
     while (fgets(buff,sizeof(buff),fp)) {
@@ -466,34 +474,22 @@ static int readbiaf(const char *file, nav_t *nav)
         if ((cbias=str2num(buff,70,21))==0.0) continue;
         sat=satid2no(prn);
         sys=satsys(sat,NULL);
-        /* other code biases are L1/L2, Galileo is L1/L5 */
-        if (obs1[1]=='1')
-            freq=0;
-        else if ((sys!=SYS_GAL&&obs1[1]=='2')||(sys==SYS_GAL&&obs1[1]=='5'))
-            freq=1;
-        else continue;
-        
+        sys_ix=sys2ix(sys);
         if (!(code1=obs2code(&obs1[1]))) continue; /* skip if code not valid */
-        bias_ix1=code2bias_ix(sys,code1);
+        if ((frq_ix=code2idx(sys,code1))<0) continue;
+        if ((bias_ix1=code_bias_ix[sys_ix][code1])<0) continue;
         if (strcmp(bias,"OSB")==0) {
-            /* observed signal bias */
-            if (bias_ix1==0) { /* this is ref code */
-                for (i=0;i<MAX_CODE_BIASES;i++)
-                    /* adjust all other codes by ref code bias */
-                    nav->cbias[sat-1][freq][i]+=cbias*1E-9*CLIGHT; /* ns -> m */
-            } else {
-                nav->cbias[sat-1][freq][bias_ix1-1]-=cbias*1E-9*CLIGHT; /* ns -> m */
-            }
+            nav->cbias[sat-1][frq_ix][bias_ix1]=cbias*1E-9*CLIGHT; /* ns -> m */
         }
         else if (strcmp(bias,"DSB")==0) {
             /* differential signal bias */
             if (obs1[1]!=obs2[1]) continue; /* skip biases between freqs for now */
             if (!(code2=obs2code(&obs2[1]))) continue; /* skip if code not valid */
-            bias_ix2=code2bias_ix(sys,code2);
+            if ((bias_ix2=code_bias_ix[sys_ix][code2])<0) continue;
             if (bias_ix1==0) /* this is ref code */
-                nav->cbias[sat-1][freq][bias_ix2-1]=cbias*1E-9*CLIGHT; /* ns -> m */
+                nav->cbias[sat-1][frq_ix][bias_ix2]=-cbias*1E-9*CLIGHT; /* ns -> m */
             else if (bias_ix2==0) /* this is ref code */
-                nav->cbias[sat-1][freq][bias_ix1-1]=-cbias*1E-9*CLIGHT; /* ns -> m */
+                nav->cbias[sat-1][frq_ix][bias_ix1]=cbias*1E-9*CLIGHT; /* ns -> m */
         }
 
     }
@@ -521,7 +517,7 @@ extern int readdcb(const char *file, nav_t *nav, const sta_t *sta)
 
     init_bias_ix(); /* init translation table from code to table column */
 
-    for (i=0;i<MAXSAT;i++) for (j=0;j<MAX_CODE_BIAS_FREQS;j++) for (k=0;k<MAX_CODE_BIASES;k++) {
+    for (i=0;i<MAXSAT;i++) for (j=0;j<NFREQ;j++) for (k=0;k<MAX_CODE_BIASES;k++) {
         nav->cbias[i][j][k]=0.0;
     }
     for (i=0;i<MAXEXFILE;i++) {

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -293,8 +293,7 @@ extern "C" {
 #define MAXLEAPS    64                  /* max number of leap seconds table */
 #define MAXGISLAYER 32                  /* max number of GIS data layers */
 #define MAXRCVCMD   4096                /* max length of receiver commands */
-#define MAX_CODE_BIASES 3               /* max # of different code biases per freq */
-#define MAX_CODE_BIAS_FREQS 2           /* max # of freqs supported for code biases  */
+#define MAX_CODE_BIASES 4               /* max # of different code biases per freq */
 
 #define RNX2VER     2.10                /* RINEX ver.2 default output version */
 #define RNX3VER     3.00                /* RINEX ver.3 default output version */
@@ -872,8 +871,7 @@ typedef struct {        /* navigation data type */
     double ion_cmp[8];  /* BeiDou iono model parameters {a0,a1,a2,a3,b0,b1,b2,b3} */
     double ion_irn[8];  /* IRNSS iono model parameters {a0,a1,a2,a3,b0,b1,b2,b3} */
     int glo_fcn[32];    /* GLONASS FCN + 8 */
-    double cbias[MAXSAT][MAX_CODE_BIAS_FREQS][MAX_CODE_BIASES]; /* satellite DCB [0:P1-C1,1:P2-C2][code] (m) */
-    double rbias[MAXRCV][MAX_CODE_BIAS_FREQS][MAX_CODE_BIASES]; /* receiver DCB (0:P1-P2,1:P1-C1,2:P2-C2) (m) */
+    double cbias[MAXSAT][NFREQ][MAX_CODE_BIASES]; /* satellite code biases] (m) */
     pcv_t pcvs[MAXSAT]; /* satellite antenna pcv */
     sbssat_t sbssat;    /* SBAS satellite corrections */
     sbsion_t sbsion[MAXBAND+1]; /* SBAS ionosphere corrections */
@@ -1656,7 +1654,7 @@ EXPORT int  getseleph(int sys);
 EXPORT void readsp3(const char *file, nav_t *nav, int opt);
 EXPORT int  readsap(const char *file, gtime_t time, nav_t *nav);
 EXPORT int  readdcb(const char *file, nav_t *nav, const sta_t *sta);
-EXPORT int code2bias_ix(const int sys,const int code);
+EXPORT double code2bias(const nav_t *nav, int sys, int sat, int code, int mode);
 /*EXPORT int  readfcb(const char *file, nav_t *nav);*/
 EXPORT void alm2pos(gtime_t time, const alm_t *alm, double *rs, double *dts);
 


### PR DESCRIPTION
     * Fix bug during OSB load from file that corrupts nav data when no broadcast ephemeris file specified
     * Store OSBs directly in table instead of computing DCBs first for greater future flexibility and expand to all freqs
     * No change to solutions except for bug fix
- Remove unused references to ssat in pntpos.c
- Remove receiver bias tables, previously populated but never used