### PR TITLE
Export decode_msm7 to support rust FFI bindings

### DIFF
--- a/src/rtcm3.c
+++ b/src/rtcm3.c
@@ -2430,7 +2430,7 @@ static int decode_msm6(rtcm_t *rtcm, int sys)
     return sync?0:1;
 }
 /* decode MSM 7: full pseudorange, phaserange, phaserangerate and CNR (h-res) */
-static int decode_msm7(rtcm_t *rtcm, int sys)
+extern int decode_msm7(rtcm_t *rtcm, int sys)
 {
     msm_h_t h={0};
     double r[64],rr[64],pr[64],cp[64],rrf[64],cnr[64];

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1737,6 +1737,7 @@ EXPORT int input_rtcm2f(rtcm_t *rtcm, FILE *fp);
 EXPORT int input_rtcm3f(rtcm_t *rtcm, FILE *fp);
 EXPORT int gen_rtcm2   (rtcm_t *rtcm, int type, int sync);
 EXPORT int gen_rtcm3   (rtcm_t *rtcm, int type, int subtype, int sync);
+EXPORT int decode_msm7 (rtcm_t *rtcm, int sys);
 
 /* solution functions --------------------------------------------------------*/
 EXPORT void initsolbuf(solbuf_t *solbuf, int cyclic, int nmax);


### PR DESCRIPTION
Small tweak to upstream the relevant changes in existing https://github.com/kpwebb/rtklib-ffi, which I am currently expanding. If the export is deemed acceptable, it can potentially be expanded to expose more functions in `rtcm3.c`.