### PR TITLE
rtkpost_qt, rtknavi_qt: fix for incorrect target install in CMakeLists.txt

### DIFF
--- a/app/qtapp/rtklaunch_qt/CMakeLists.txt
+++ b/app/qtapp/rtklaunch_qt/CMakeLists.txt
@@ -26,7 +26,7 @@ set_target_properties(rtklaunch_qt PROPERTIES
     WIN32_EXECUTABLE ON
     MACOSX_BUNDLE ON
 )
-install(TARGETS rtkget_qt RUNTIME DESTINATION bin BUNDLE DESTINATION bin)
+install(TARGETS rtklaunch_qt RUNTIME DESTINATION bin BUNDLE DESTINATION bin)
 if (UNIX)
    install(FILES rtklaunch_qt.desktop DESTINATION ${XDG_APPS_INSTALL_DIR})
    install(FILES ../icon/rtklaunch.png DESTINATION ${XDG_APPS_PIXMAPS_DIR})

--- a/app/qtapp/rtknavi_qt/CMakeLists.txt
+++ b/app/qtapp/rtknavi_qt/CMakeLists.txt
@@ -81,7 +81,7 @@ set_target_properties(rtknavi_qt PROPERTIES
     WIN32_EXECUTABLE ON
     MACOSX_BUNDLE ON
 )
-install(TARGETS rtkget_qt RUNTIME DESTINATION bin BUNDLE DESTINATION bin)
+install(TARGETS rtknavi_qt RUNTIME DESTINATION bin BUNDLE DESTINATION bin)
 if (UNIX)
    install(FILES rtknavi_qt.desktop DESTINATION ${XDG_APPS_INSTALL_DIR})
    install(FILES ../icon/rtknavi.png DESTINATION ${XDG_APPS_PIXMAPS_DIR})

--- a/app/qtapp/rtkplot_qt/CMakeLists.txt
+++ b/app/qtapp/rtkplot_qt/CMakeLists.txt
@@ -90,7 +90,7 @@ set_target_properties(rtkplot_qt PROPERTIES
     WIN32_EXECUTABLE ON
     MACOSX_BUNDLE ON
 )
-install(TARGETS rtkget_qt RUNTIME DESTINATION bin BUNDLE DESTINATION bin)
+install(TARGETS rtkplot_qt RUNTIME DESTINATION bin BUNDLE DESTINATION bin)
 if (UNIX)
    install(FILES rtkplot_qt.desktop DESTINATION ${XDG_APPS_INSTALL_DIR})
    install(FILES ../icon/rtkplot.png DESTINATION ${XDG_APPS_PIXMAPS_DIR})

--- a/app/qtapp/rtkpost_qt/CMakeLists.txt
+++ b/app/qtapp/rtkpost_qt/CMakeLists.txt
@@ -51,7 +51,7 @@ set_target_properties(rtkpost_qt PROPERTIES
     WIN32_EXECUTABLE ON
     MACOSX_BUNDLE ON
 )
-install(TARGETS rtkget_qt RUNTIME DESTINATION bin BUNDLE DESTINATION bin)
+install(TARGETS rtkpost_qt RUNTIME DESTINATION bin BUNDLE DESTINATION bin)
 if (UNIX)
    install(FILES rtkpost_qt.desktop DESTINATION ${XDG_APPS_INSTALL_DIR})
    install(FILES ../icon/rtkpost.png DESTINATION ${XDG_APPS_PIXMAPS_DIR})

--- a/app/qtapp/srctblbrows_qt/CMakeLists.txt
+++ b/app/qtapp/srctblbrows_qt/CMakeLists.txt
@@ -51,7 +51,7 @@ set_target_properties(srctblbrows_qt PROPERTIES
     WIN32_EXECUTABLE ON
     MACOSX_BUNDLE ON
 )
-install(TARGETS rtkget_qt RUNTIME DESTINATION bin BUNDLE DESTINATION bin)
+install(TARGETS srctblbrows_qt RUNTIME DESTINATION bin BUNDLE DESTINATION bin)
 if (UNIX)
    install(FILES srctblbrows_qt.desktop DESTINATION ${XDG_APPS_INSTALL_DIR})
    install(FILES ../icon/srctblbrows.png DESTINATION ${XDG_APPS_PIXMAPS_DIR})

--- a/app/qtapp/strsvr_qt/CMakeLists.txt
+++ b/app/qtapp/strsvr_qt/CMakeLists.txt
@@ -53,7 +53,7 @@ set_target_properties(strsvr_qt PROPERTIES
     WIN32_EXECUTABLE ON
     MACOSX_BUNDLE ON
 )
-install(TARGETS rtkget_qt RUNTIME DESTINATION bin BUNDLE DESTINATION bin)
+install(TARGETS strsvr_qt RUNTIME DESTINATION bin BUNDLE DESTINATION bin)
 if (UNIX)
    install(FILES strsvr_qt.desktop DESTINATION ${XDG_APPS_INSTALL_DIR})
    install(FILES ../icon/strsvr.png DESTINATION ${XDG_APPS_PIXMAPS_DIR})


### PR DESCRIPTION
When installing on Ubuntu 24 from source, some Qt applications install as `rtkget_qt` due to incorrect install targets in multiple CMakeLists.txt files. The list of affected files is:

app/qtapp/rtknavi_qt/CMakeLists.txt
app/qtapp/rtklaunch_qt/CMakeLists.txt
app/qtapp/rtkplot_qt/CMakeLists.txt
app/qtapp/rtkpost_qt/CMakeLists.txt
app/qtapp/srctblbrows_qt/CMakeLists.txt
app/qtapp/strsvr_qt/CMakeLists.txt

This causes:
- Binaries to overwrite each other during `make install`
- Missing QT apps on /ust/local/bin/
