### PR TITLE
Fix uses of SYS_BDS to be SYS_CMP

### DIFF
--- a/app/consapp/rnx2rtkp/rnx2rtkp.c
+++ b/app/consapp/rnx2rtkp/rnx2rtkp.c
@@ -193,7 +193,7 @@ int main(int argc, char **argv)
         else if (n<MAXFILE) infile[n++]=argv[i];
     }
     if (!prcopt.navsys) {
-        prcopt.navsys=SYS_GPS|SYS_GLO|SYS_GAL|SYS_BDS;
+        prcopt.navsys=SYS_GPS|SYS_GLO|SYS_GAL|SYS_CMP;
     }
     if (n<=0) {
         showmsg("error : no input file");

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -203,7 +203,7 @@ const double chisqr[100]={      /* chi-sqr(n) (alpha=0.001) */
 };
 const prcopt_t prcopt_default={ /* defaults processing options */
     PMODE_KINEMA,SOLTYPE_FORWARD, /* mode,soltype */
-    2,SYS_GPS|SYS_GLO|SYS_GAL|SYS_BDS,  /* nf, navsys */
+    2,SYS_GPS|SYS_GLO|SYS_GAL|SYS_CMP,  /* nf, navsys */
     15.0*D2R,{{0,0}},           /* elmin,snrmask */
     0,3,3,1,0,1,                /* sateph,modear,glomodear,gpsmodear,bdsmodear,arfilter */
     20,0,4,5,10,20,             /* maxout,minlock,minfixsats,minholdsats,mindropsats,minfix */


### PR DESCRIPTION
Fix prior patches that used SYS_BDS and should have used SYS_CMP, sorry.

Use SYS_BDS in local branch after splitting BDS-2 and BDS-3, and got this out of order.