### PR TITLE
rtknavi, rtkrcv: consider all valid signals frequency indices

### DIFF
--- a/app/consapp/rtkrcv/rtkrcv.c
+++ b/app/consapp/rtkrcv/rtkrcv.c
@@ -724,8 +724,14 @@ static void prstatus(vt_t *vt)
     rtksvrunlock(&svr);
     
     for (i=n=0;i<MAXSAT;i++) {
-        if (rtk->opt.mode==PMODE_SINGLE&&!rtk->ssat[i].vs) continue;
-        if (rtk->opt.mode!=PMODE_SINGLE&&!rtk->ssat[i].vsat[0]) continue;
+        if (rtk->opt.mode == PMODE_SINGLE) {
+          if (!rtk->ssat[i].vs) continue;
+        } else {
+          int any = 0;
+          for (int fi = 0; fi < NFREQ; fi++)
+            if (rtk->ssat[i].vsat[fi]) { any = 1; break; }
+          if (!any) continue;
+        }
         azel[  n*2]=rtk->ssat[i].azel[0];
         azel[1+n*2]=rtk->ssat[i].azel[1];
         n++;
@@ -842,7 +848,7 @@ static void prsatellite(vt_t *vt, int nf)
     *rtk=svr.rtk;
     rtksvrunlock(&svr);
     if (nf<=0||nf>NFREQ) nf=NFREQ;
-    vt_printf(vt,"\n%s%3s %2s %5s %4s",ESC_BOLD,"SAT","C1","Az","El");
+    vt_printf(vt,"\n%s%3s %2s %5s %4s",ESC_BOLD,"SAT","V","Az","El");
     for (j=0;j<nf;j++) vt_printf(vt," L%d"    ,frq[j]);
     for (j=0;j<nf;j++) vt_printf(vt,"  Fix%d" ,frq[j]);
     for (j=0;j<nf;j++) vt_printf(vt,"  P%dRes",frq[j]);
@@ -855,7 +861,14 @@ static void prsatellite(vt_t *vt, int nf)
     for (i=0;i<MAXSAT;i++) {
         if (rtk->ssat[i].azel[1]<=0.0) continue;
         satno2id(i+1,id);
-        vt_printf(vt,"%3s %2s",id,rtk->ssat[i].vs?"OK":"-");
+        int vsat = 0;
+        if (rtk->opt.mode == PMODE_SINGLE) {
+          vsat = rtk->ssat[i].vs;
+        } else {
+          for (int fi = 0; fi < NFREQ; fi++)
+            if (rtk->ssat[i].vsat[fi]) { vsat = 1; break; }
+        }
+        vt_printf(vt,"%3s %2s",id,vsat?"OK":"-");
         az=rtk->ssat[i].azel[0]*R2D; if (az<0.0) az+=360.0;
         el=rtk->ssat[i].azel[1]*R2D;
         vt_printf(vt," %5.1f %4.1f",az,el);

--- a/app/qtapp/rtknavi_qt/mondlg.cpp
+++ b/app/qtapp/rtknavi_qt/mondlg.cpp
@@ -464,8 +464,14 @@ void MonitorDialog::showRtk()
     rtksvrunlock(rtksvr); // unlock
 
     for (j = k = 0; j < MAXSAT; j++) {
-        if (rtk->opt.mode == PMODE_SINGLE && !rtk->ssat[j].vs) continue;
-        if (rtk->opt.mode != PMODE_SINGLE && !rtk->ssat[j].vsat[0]) continue;
+        if (rtk->opt.mode == PMODE_SINGLE) {
+          if (!rtk->ssat[j].vs) continue;
+        } else {
+          int any = 0;
+          for (int fi = 0; fi < NFREQ; fi++)
+            if (rtk->ssat[j].vsat[fi]) { any = 1; break; }
+          if (!any) continue;
+        }
         azel[k * 2] = rtk->ssat[j].azel[0];
         azel[k * 2 + 1] = rtk->ssat[j].azel[1];
 		k++;
@@ -792,8 +798,13 @@ void MonitorDialog::showSat()
     rtksvrunlock(rtksvr);
 
     for (i = 0; i < MAXSAT; i++) {
-        ssat = rtk->ssat + i;
-        vsat[i] = ssat->vs;
+        if (rtk->opt.mode == PMODE_SINGLE) {
+          vsat[i] = rtk->ssat[i].vs;
+        } else {
+          vsat[i] = 0;
+          for (int fi = 0; fi < NFREQ; fi++)
+            if (rtk->ssat[i].vsat[fi]) { vsat[i] = 1; break; }
+        }
     }
 
     for (i = 0, nsat = 0; i < MAXSAT; i++) {
@@ -821,7 +832,7 @@ void MonitorDialog::showSat()
         if (ui->cBSelectSatellites->currentIndex() == 1 && !vsat[i]) continue;
         satno2id(i + 1, id);
         ui->tWConsole->item(n, j++)->setText(id);
-        ui->tWConsole->item(n, j++)->setText(ssat->vs ? tr("OK") : tr("-"));
+        ui->tWConsole->item(n, j++)->setText(vsat[i] ? tr("OK") : tr("-"));
         az = ssat->azel[0] * R2D; if (az < 0.0) az += 360.0;
         el = ssat->azel[1] * R2D;
         ui->tWConsole->item(n, j++)->setText(QString::number(az, 'f', 1));

--- a/app/qtapp/rtknavi_qt/navimain.cpp
+++ b/app/qtapp/rtknavi_qt/navimain.cpp
@@ -138,10 +138,12 @@ MainWindow::MainWindow(QWidget *parent)
 
     for (int i = 0; i < 2; i++)
         for (int j = 0; j < MAXSAT; j++) {
-            satellites[i][j] = validSatellites[i][j] = 0;
+            satellites[i][j] = 0;
             satellitesAzimuth[i][j] = satellitesElevation[i][j] = 0.0;
-            for (int k = 0; k < NFREQ; k++)
+            for (int k = 0; k < NFREQ; k++) {
+                validSatellites[i][j][k] = 0;
                 satellitesSNR[i][j][k] = 0;
+            }
         }
 
     static opt_t rcvopts[] = {
@@ -1662,8 +1664,8 @@ void MainWindow::drawSolutionPlot(QLabel *plot, int type, int freq)
 
     int w = buffer.size().width() - 2;
     int h = buffer.height() - 2;
-    int i, j, x, sat[2][MAXSAT], ns[2], snr[2][MAXSAT][NFREQ], vsat[2][MAXSAT];
-    int *snr0[MAXSAT], *snr1[MAXSAT], topMargin = QFontMetrics(optDialog->panelFont).height()*3/2;
+    int i, j, x, sat[2][MAXSAT], ns[2], snr[2][MAXSAT][NFREQ], vsat[2][MAXSAT][NFREQ];
+    int topMargin = QFontMetrics(optDialog->panelFont).height()*3/2;
     double az[2][MAXSAT], el[2][MAXSAT], rr[3], pos[3];
 
     trace(4, "drawSolutionPlot\n");
@@ -1672,12 +1674,8 @@ void MainWindow::drawSolutionPlot(QLabel *plot, int type, int freq)
         fstr[i + 1] = QStringLiteral("L%1").arg(i + 1);
     fstr[i + 1] = " SYS";
 
-    for (i = 0; i < MAXSAT; i++) {
-        snr0[i] = snr[0][i];
-        snr1[i] = snr[1][i];
-    }
-    ns[0] = rtksvrostat(rtksvr, 0, &time, sat[0], az[0], el[0], snr0, vsat[0]);
-    ns[1] = rtksvrostat(rtksvr, 1, &time, sat[1], az[1], el[1], snr1, vsat[1]);
+    ns[0] = rtksvrostat(rtksvr, 0, &time, sat[0], az[0], el[0], snr[0], vsat[0]);
+    ns[1] = rtksvrostat(rtksvr, 1, &time, sat[1], az[1], el[1], snr[1], vsat[1]);
 
     rtksvrlock(rtksvr);
     matcpy(rr, rtksvr->rtk.sol.rr, 3, 1);
@@ -1691,15 +1689,17 @@ void MainWindow::drawSolutionPlot(QLabel *plot, int type, int freq)
                 satellites[i][j] = sat[i][j];
                 satellitesAzimuth[i][j] = az[i][j];
                 satellitesElevation[i][j] = el[i][j];
-                for (int k = 0; k < NFREQ; k++)
+                for (int k = 0; k < NFREQ; k++) {
+                    validSatellites[i][j][k] = vsat[i][j][k];
                     satellitesSNR[i][j][k] = snr[i][j][k];
-                validSatellites[i][j] = vsat[i][j];
+                }
             }
         } else {
             for (j = 0; j < numSatellites[i]; j++) {
-                validSatellites[i][j] = 0;
-                for (int k = 0; k < NFREQ; k++)
+                for (int k = 0; k < NFREQ; k++) {
+                    validSatellites[i][j][k] = 0;
                     satellitesSNR[i][j][k] = 0;
+                }
             }
         }
     }
@@ -1861,7 +1861,10 @@ void MainWindow::drawSnr(QPainter &c, int w, int h, int x0, int y0,
             QRect r1(x1, y1, barWidth, -height);
             if (j == 0) {  // filled bar
                 c.setBrush(QBrush(freq < NFREQ + 1 ? snrColor(snr[snrIdx]) : color_sys[sysIdx], Qt::SolidPattern));
-                if (!validSatellites[index][i])
+                int any = 0;
+                for (int fi = 0; fi < NFREQ; fi++)
+                  if (validSatellites[index][i][fi]) { any = 1; break; }
+                if (!any)
                     c.setBrush(QBrush(QColor(QColorConstants::LightGray), Qt::SolidPattern));
             } else {  // outline only
                 c.setPen(j < NFREQ + 1 ? QColor(QColorConstants::LightGray) : Qt::darkGray);
@@ -1909,7 +1912,10 @@ void MainWindow::drawSatellites(QPainter &c, int w, int h, int x0, int y0,
                 snr[0] = snr[j + 1]; // max snr
             }
         }
-        if (validSatellites[index][k] && (freq > NFREQ || snr[freq] > 0)) {
+        int anyValidSatFreq = 0;
+        for (int fi = 0; fi < NFREQ; fi++)
+          if (validSatellites[index][k][fi]) { anyValidSatFreq = 1; break; }
+        if (anyValidSatFreq && (freq > NFREQ || snr[freq] > 0)) {
             azel[nsats * 2] = satellitesAzimuth[index][k];
             azel[nsats * 2 + 1] = satellitesElevation[index][k];
             nsats++;
@@ -1920,7 +1926,7 @@ void MainWindow::drawSatellites(QPainter &c, int w, int h, int x0, int y0,
         y[i] = static_cast<int>(p.y() - r * (90 - satellitesElevation[index][k] * R2D) / 90 * cos(satellitesAzimuth[index][k])) + y0;
         radius = QFontMetrics(optDialog->panelFont).height();
 
-        c.setBrush(!validSatellites[index][k] ? Color::Silver :
+        c.setBrush(!anyValidSatFreq ? Color::Silver :
                         (freq < NFREQ + 1 ? snrColor(snr[freq]) : color_sys[sysIdx]));
         c.setPen(Qt::darkGray);
         color_text = Qt::white;

--- a/app/qtapp/rtknavi_qt/navimain.h
+++ b/app/qtapp/rtknavi_qt/navimain.h
@@ -160,7 +160,7 @@ public:
     int monitorPortOpen;
 
     int solutionsCurrent, solutionsStart, solutionsEnd, numSatellites[2], solutionCurrentStatus;
-    int satellites[2][MAXSAT], satellitesSNR[2][MAXSAT][NFREQ], validSatellites[2][MAXSAT];
+    int satellites[2][MAXSAT], satellitesSNR[2][MAXSAT][NFREQ], validSatellites[2][MAXSAT][NFREQ];
     double satellitesAzimuth[2][MAXSAT], satellitesElevation[2][MAXSAT];
     gtime_t *timeStamps;
     int *solutionStatus, *numValidSatellites;

--- a/app/winapp/rtknavi/mondlg.cpp
+++ b/app/winapp/rtknavi/mondlg.cpp
@@ -410,8 +410,14 @@ void __fastcall TMonitorDialog::ShowRtk(void)
 	rtksvrunlock(&rtksvr); // unlock
 	
 	for (j=k=0;j<MAXSAT;j++) {
-		if (rtk->opt.mode==PMODE_SINGLE&&!rtk->ssat[j].vs) continue;
-		if (rtk->opt.mode!=PMODE_SINGLE&&!rtk->ssat[j].vsat[0]) continue;
+		if (rtk->opt.mode == PMODE_SINGLE) {
+                  if (!rtk->ssat[j].vs) continue;
+                } else {
+                  int any = 0;
+                  for (int fi = 0; fi < NFREQ; fi++)
+                    if (rtk->ssat[j].vsat[fi]) { any = 1; break; }
+                  if (!any) continue;
+                }
 		azel[  k*2]=rtk->ssat[j].azel[0];
 		azel[1+k*2]=rtk->ssat[j].azel[1];
 		k++;
@@ -740,8 +746,13 @@ void __fastcall TMonitorDialog::ShowSat(void)
 	Label->Caption="";
 	
 	for (i=0;i<MAXSAT;i++) {
-		ssat=rtk->ssat+i;
-		vsat[i]=ssat->vs;
+                if (rtk->opt.mode == PMODE_SINGLE) {
+                  vsat[i] = rtk->ssat[i].vs;
+                } else {
+                  vsat[i] = 0;
+                  for (int fi = 0; fi < NFREQ; fi++)
+                    if (rtk->ssat[i].vsat[fi]) { vsat[i] = 1; break; }
+                }
 	}
 	for (i=0,n=1;i<MAXSAT;i++) {
 		if (!(satsys(i+1,NULL)&sys)) continue;
@@ -764,7 +775,7 @@ void __fastcall TMonitorDialog::ShowSat(void)
 		if (SelSat->ItemIndex==1&&!vsat[i]) continue;
 		satno2id(i+1,id);
 		Tbl->Cells[j++][n]=id;
-		Tbl->Cells[j++][n]=ssat->vs?"OK":"-";
+		Tbl->Cells[j++][n]=vsat[i]?"OK":"-";
 		az=ssat->azel[0]*R2D; if (az<0.0) az+=360.0;
 		el=ssat->azel[1]*R2D;
 		Tbl->Cells[j++][n]=s.sprintf("%.1f",az);

--- a/app/winapp/rtknavi/navimain.cpp
+++ b/app/winapp/rtknavi/navimain.cpp
@@ -138,9 +138,12 @@ __fastcall TMainForm::TMainForm(TComponent* Owner)
     SolCurrentStat=0;
     SolRov=SolRef=Qr=VelRov=Age=Ratio=NULL;
     for (int i=0;i<2;i++) for (int j=0;j<MAXSAT;j++) {
-        Sat[i][j]=Vsat[i][j]=0;
+        Sat[i][j]=0;
         Az[i][j]=El[i][j]=0.0;
-        for (int k=0;k<NFREQ;k++) Snr[i][j][k]=0;
+        for (int k=0;k<NFREQ;k++) {
+          Snr[i][j][k]=0;
+          Vsat[i][j][k]=0;
+        }
     }
     PrcOpt=prcopt_default;
     SolOpt=solopt_default;
@@ -1666,8 +1669,8 @@ void __fastcall TMainForm::DrawPlot(TImage *plot, int type, int freq)
     TCanvas *c=plot->Canvas;
     TLabel *label[]={Plabel1,Plabel2,Plabel3,Pos1,Pos2,Pos3};
     int w=plot->Parent->Width-2,h=plot->Parent->Height-2;
-    int i,j,x,sat[2][MAXSAT],ns[2],snr[2][MAXSAT][NFREQ],vsat[2][MAXSAT];
-    int *snr0[MAXSAT],*snr1[MAXSAT],tm=PanelFont->Size*3/2;
+    int i,j,x,sat[2][MAXSAT],ns[2],snr[2][MAXSAT][NFREQ],vsat[2][MAXSAT][NFREQ];
+    int tm=PanelFont->Size*3/2;
     char name[16];
     double az[2][MAXSAT],el[2][MAXSAT],rr[3],rs[6],e[3],pos[3],azel[2];
     
@@ -1678,12 +1681,8 @@ void __fastcall TMainForm::DrawPlot(TImage *plot, int type, int freq)
     }
     fstr[i+1]=" SYS";
     
-    for (i=0;i<MAXSAT;i++) {
-        snr0[i]=snr[0][i];
-        snr1[i]=snr[1][i];
-    }
-    ns[0]=rtksvrostat(&rtksvr,0,&time,sat[0],az[0],el[0],snr0,vsat[0]);
-    ns[1]=rtksvrostat(&rtksvr,1,&time,sat[1],az[1],el[1],snr1,vsat[1]);
+    ns[0]=rtksvrostat(&rtksvr,0,&time,sat[0],az[0],el[0],snr[0],vsat[0]);
+    ns[1]=rtksvrostat(&rtksvr,1,&time,sat[1],az[1],el[1],snr[1],vsat[1]);
     
     rtksvrlock(&rtksvr);
     matcpy(rr,rtksvr.rtk.sol.rr,3,1);
@@ -1698,15 +1697,15 @@ void __fastcall TMainForm::DrawPlot(TImage *plot, int type, int freq)
                 Az  [i][j]=az  [i][j];
                 El  [i][j]=el  [i][j];
                 for (int k=0;k<NFREQ;k++) {
+                    Vsat[i][j][k]=vsat[i][j][k];
                     Snr[i][j][k]=snr[i][j][k];
                 }
-                Vsat[i][j]=vsat[i][j];
             }
         }
         else {
             for (j=0;j<Nsat[i];j++) {
-                Vsat[i][j]=0;
                 for (int k=0;k<NFREQ;k++) {
+                    Vsat[i][j][k]=0;
                     Snr[i][j][k]=0;
                 }
             }
@@ -1884,7 +1883,10 @@ void __fastcall TMainForm::DrawSnr(TCanvas *c, int w, int h, int x0, int y0,
             if (j==0) {
                 c->Brush->Style=bsSolid;
                 c->Brush->Color=freq<NFREQ+1?SnrColor(snr[k]):color_sys[l];
-                if (!Vsat[index][i]) c->Brush->Color=clSilver;
+                int any = 0;
+                for (int fi = 0; fi < NFREQ; fi++)
+                  if (Vsat[index][i][fi]) { any = 1; break; }
+                if (!any) c->Brush->Color=clSilver;
                 c->Rectangle(r1);
             }
             else {
@@ -1929,7 +1931,10 @@ void __fastcall TMainForm::DrawSat(TCanvas *c, int w, int h, int x0, int y0,
                 snr[0]=snr[j+1]; // max snr
             }
         }
-        if (Vsat[index][k]&&(freq>NFREQ||snr[freq]>0)) {
+        int anyvsatf = 0;
+        for (int fi = 0; fi < NFREQ; fi++)
+          if (Vsat[index][k][fi]) { anyvsatf = 1; break; }
+        if (anyvsatf && (freq > NFREQ || snr[freq] > 0)) {
             azel[ns*2]=Az[index][k]; azel[1+ns*2]=El[index][k];
             ns++;
         }
@@ -1938,7 +1943,7 @@ void __fastcall TMainForm::DrawSat(TCanvas *c, int w, int h, int x0, int y0,
         x[i]=(int)(p.x+r*(90-El[index][k]*R2D)/90*sin(Az[index][k]))+x0;
         y[i]=(int)(p.y-r*(90-El[index][k]*R2D)/90*cos(Az[index][k]))+y0;
         d=PanelFont->Size*3/2;
-        c->Brush->Color=!Vsat[index][k]?clSilver:
+        c->Brush->Color=!anyvsatf?clSilver:
                         (freq<NFREQ+1?SnrColor(snr[freq]):color_sys[l]);
         c->Brush->Style=bsSolid;
         c->Pen->Color=clGray;

--- a/app/winapp/rtknavi/navimain.h
+++ b/app/winapp/rtknavi/navimain.h
@@ -254,7 +254,7 @@ public:
 	int MoniPort,OpenPort,AutoRun;
 	
 	int PSol,PSolS,PSolE,Nsat[2],SolCurrentStat;
-	int Sat[2][MAXSAT],Snr[2][MAXSAT][NFREQ],Vsat[2][MAXSAT];
+	int Sat[2][MAXSAT],Snr[2][MAXSAT][NFREQ],Vsat[2][MAXSAT][NFREQ];
 	double Az[2][MAXSAT],El[2][MAXSAT];
 	gtime_t *Time;
 	int *SolStat,*Nvsat;

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1896,8 +1896,8 @@ EXPORT int  rtksvropenstr(rtksvr_t *svr, int index, int str, const char *path,
 EXPORT void rtksvrclosestr(rtksvr_t *svr, int index);
 EXPORT void rtksvrlock  (rtksvr_t *svr);
 EXPORT void rtksvrunlock(rtksvr_t *svr);
-EXPORT int  rtksvrostat (rtksvr_t *svr, int type, gtime_t *time, int *sat,
-                         double *az, double *el, int **snr, int *vsat);
+EXPORT int  rtksvrostat (rtksvr_t *svr, int type, gtime_t *time, int sat[MAXSAT],
+                         double *az, double *el, int snr[MAXSAT][NFREQ], int vsat[MAXSAT][NFREQ]);
 EXPORT void rtksvrsstat (rtksvr_t *svr, int *sstat, char *msg);
 EXPORT int  rtksvrmark(rtksvr_t *svr, const char *name, const char *comment);
 

--- a/src/rtksvr.c
+++ b/src/rtksvr.c
@@ -1124,31 +1124,27 @@ extern void rtksvrclosestr(rtksvr_t *svr, int index)
 *          int     *vsat    O  valid satellite flag
 * return : number of satellites
 *-----------------------------------------------------------------------------*/
-extern int rtksvrostat(rtksvr_t *svr, int rcv, gtime_t *time, int *sat,
-                       double *az, double *el, int **snr, int *vsat)
+extern int rtksvrostat(rtksvr_t *svr, int rcv, gtime_t *time, int sat[MAXSAT],
+                       double *az, double *el, int snr[MAXSAT][NFREQ], int vsat[MAXSAT][NFREQ])
 {
-    int i,j,ns;
-    
     tracet(4,"rtksvrostat: rcv=%d\n",rcv);
     
     if (!svr->state) return 0;
     rtksvrlock(svr);
-    ns=svr->obs[rcv][0].n;
+    int ns=svr->obs[rcv][0].n;
     if (ns>0) {
         *time=svr->obs[rcv][0].data[0].time;
     }
-    for (i=0;i<ns;i++) {
+    for (int i=0;i<ns;i++) {
         sat [i]=svr->obs[rcv][0].data[i].sat;
         az  [i]=svr->rtk.ssat[sat[i]-1].azel[0];
         el  [i]=svr->rtk.ssat[sat[i]-1].azel[1];
-        for (j=0;j<NFREQ;j++) {
-            snr[i][j]=(int)(svr->obs[rcv][0].data[i].SNR[j]);
-        }
-        if (svr->rtk.sol.stat==SOLQ_NONE||svr->rtk.sol.stat==SOLQ_SINGLE) {
-            vsat[i]=svr->rtk.ssat[sat[i]-1].vs;
-        }
-        else {
-            vsat[i]=svr->rtk.ssat[sat[i]-1].vsat[0];
+        for (int j=0;j<NFREQ;j++) {
+            snr[i][j] = (int)(svr->obs[rcv][0].data[i].SNR[j] + 0.5);
+            if (svr->rtk.sol.stat == SOLQ_NONE || svr->rtk.sol.stat == SOLQ_SINGLE)
+              vsat[i][j] = svr->rtk.ssat[sat[i] - 1].vs;
+            else
+              vsat[i][j] = svr->rtk.ssat[sat[i] - 1].vsat[j];
         }
     }
     rtksvrunlock(svr);


### PR DESCRIPTION
Have rtksvrostat() return the vsat array for all signal frequency indices, rather than using only the first signal index.

For rtknavi have the sky plot and snr plot report a satellite as valid if the appropriate frequency index is valid. It was considering just the first index and would grey out a satellite that was used in the solution if it did not have a valid first signal frequency index.

For the rtknavi monitor satellite table show all valid satellites used in the solution even if they do not have a valid first signal frequency index. Similarly for the DOP report consider all the satellites used in the solution.

Respective changes for rtkrcv.