### PR TITLE
rtkplot: avoid interger overflow in intermediate calcs

### DIFF
--- a/app/qtapp/rtkplot_qt/plotmain.cpp
+++ b/app/qtapp/rtkplot_qt/plotmain.cpp
@@ -1532,12 +1532,11 @@ void Plot::mouseDownSolution(int x, int y)
         graphTriple[0]->getLimits(xl, yl);
         graphTriple[0]->toPoint(x_pos, yl[1], pnt);
 
-        if ((x - pnt.x()) * (x - pnt.x()) + (y - pnt.y()) * (y - pnt.y()) < 5*5) {
+        double dx = x - pnt.x(), dy = y - pnt.y();
+        if (dx * dx + dy * dy < 5 * 5) {
             setCursor(Qt::SizeHorCursor);
-
             dragState = 20;
             refresh();
-
             return;
         }
     }
@@ -1582,7 +1581,8 @@ void Plot::mouseDownObservation(int x, int y)
         graphSingle->getLimits(xl, yl);
         graphSingle->toPoint(x_pos, yl[1], pnt);
 
-        if ((x - pnt.x()) * (x - pnt.x()) + (y - pnt.y()) * (y - pnt.y()) < 5*5) {
+        double dx = x - pnt.x(), dy = y - pnt.y();
+        if (dx * dx + dy * dy < 5 * 5) {
             setCursor(Qt::SizeHorCursor);
             dragState = 20;
             refresh();

--- a/app/winapp/rtkplot/plotmain.cpp
+++ b/app/winapp/rtkplot/plotmain.cpp
@@ -1519,8 +1519,9 @@ void __fastcall TPlot::MouseDownSol(int X, int Y)
         
         GraphG[0]->GetLim(xl,yl);
         GraphG[0]->ToPoint(x,yl[1],pnt);
-        
-        if ((X-pnt.x)*(X-pnt.x)+(Y-pnt.y)*(Y-pnt.y)<25) {
+
+        double dx = X - pnt.x, dy = Y - pnt.y;
+        if (dx * dx + dy * dy < 5 * 5) {
             Screen->Cursor=crSizeWE;
             Drag=20;
             Refresh();
@@ -1568,7 +1569,8 @@ void __fastcall TPlot::MouseDownObs(int X, int Y)
         GraphR->GetLim(xl,yl);
         GraphR->ToPoint(x,yl[1],pnt);
         
-        if ((X-pnt.x)*(X-pnt.x)+(Y-pnt.y)*(Y-pnt.y)<25) {
+        double dx = X - pnt.x, dy = Y - pnt.y;
+        if (dx * dx + dy * dy < 5 * 5) {
             Screen->Cursor=crSizeWE;
             Drag=20;
             Refresh();


### PR DESCRIPTION
Saw these 32 bit integer calculations overflow so use doubles.