### PR TITLE
cmake include GNUInstallDirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ message("RTKLIB version: ${VERSION}-${PATCH_LEVEL}")
 
 project(rtklib LANGUAGES C CXX VERSION 2.4.3)
 
+include(GNUInstallDirs)
 include(CTest)
 
 option(IERS_MODEL "Use Earth models from IERS" OFF)


### PR DESCRIPTION
The solution in https://github.com/rtklibexplorer/RTKLIB/issues/839 worked here on linux, and see reports the GNUInstallDirs works on Windows too, thanks.