### PR TITLE
rtknavi: save ephemeris as unsigned long

### DIFF
--- a/app/qtapp/rtknavi_qt/navimain.cpp
+++ b/app/qtapp/rtknavi_qt/navimain.cpp
@@ -2351,7 +2351,7 @@ void MainWindow::loadNavigation(nav_t *nav)
     QString str;
     eph_t eph0;
     char buff[2049], *p;
-    long toe_time,toc_time,ttr_time;
+    long unsigned toe_time,toc_time,ttr_time;
     int i;
 
     trace(3, "loadNavigation\n");
@@ -2359,13 +2359,13 @@ void MainWindow::loadNavigation(nav_t *nav)
     memset(&eph0, 0, sizeof(eph_t));
 
     for (i = 0; i < 2 * MAXSAT; i++) {
-        if ((str = settings.value(QString("navi/eph_%1").arg(i, 2)).toString()).isEmpty()) continue;
+        if ((str = settings.value(QString("navi/eph_%1").arg(i, 3, 10, QChar('0'))).toString()).isEmpty()) continue;
         nav->eph[i] = eph0;
         strncpy(buff, qPrintable(str), 2047);
         if (!(p = strchr(buff, ','))) continue;
         *p = '\0';
         if (!(nav->eph[i].sat = satid2no(buff))) continue;
-        sscanf(p + 1, "%d,%d,%d,%d,%ld,%ld,%ld,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%d,%d,%lf",
+        sscanf(p + 1, "%d,%d,%d,%d,%lu,%lu,%lu,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%d,%d,%lf",
                &nav->eph[i].iode,
                &nav->eph[i].iodc,
                &nav->eph[i].sva,
@@ -2434,9 +2434,9 @@ void MainWindow::saveNavigation(nav_t *nav)
         str = str + QString("%1,").arg(nav->eph[i].iodc);
         str = str + QString("%1,").arg(nav->eph[i].sva);
         str = str + QString("%1,").arg(nav->eph[i].svh);
-        str = str + QString("%1,").arg(static_cast<int>(nav->eph[i].toe.time));
-        str = str + QString("%1,").arg(static_cast<int>(nav->eph[i].toc.time));
-        str = str + QString("%1,").arg(static_cast<int>(nav->eph[i].ttr.time));
+        str = str + QString("%1,").arg(static_cast<long unsigned>(nav->eph[i].toe.time));
+        str = str + QString("%1,").arg(static_cast<long unsigned>(nav->eph[i].toc.time));
+        str = str + QString("%1,").arg(static_cast<long unsigned>(nav->eph[i].ttr.time));
         str = str + QString("%1,").arg(nav->eph[i].A, 0, 'E', 14);
         str = str + QString("%1,").arg(nav->eph[i].e, 0, 'E', 14);
         str = str + QString("%1,").arg(nav->eph[i].i0, 0, 'E', 14);
@@ -2461,7 +2461,7 @@ void MainWindow::saveNavigation(nav_t *nav)
         str = str + QString("%1,").arg(nav->eph[i].code);
         str = str + QString("%1,").arg(nav->eph[i].flag);
         str = str + QString("%1,").arg(nav->eph[i].tgd[1],0,'E',14);
-        settings.setValue(QString("navi/eph_%1").arg(i, 2), str);
+        settings.setValue(QString("navi/eph_%1").arg(i, 3, 10, QChar('0')), str);
     }
     str = "";
     for (i = 0; i < 8; i++) str = str + QString("%1,").arg(nav->ion_gps[i], 0, 'E', 14);

--- a/app/winapp/rtknavi/navimain.cpp
+++ b/app/winapp/rtknavi/navimain.cpp
@@ -2323,19 +2323,19 @@ void __fastcall TMainForm::LoadNav(nav_t *nav)
     AnsiString str,s;
     eph_t eph0={0};
     char buff[2049],id[32],*p;
-    long toe_time,toc_time,ttr_time;
+    long unsigned toe_time,toc_time,ttr_time;
     int i;
     
     trace(3,"LoadNav\n");
     
     for (i=0;i<MAXSAT*2;i++) {
-        if ((str=ini->ReadString("navi",s.sprintf("eph_%02d",i),""))=="") continue;
+        if ((str=ini->ReadString("navi",s.sprintf("eph_%03d",i),""))=="") continue;
         nav->eph[i]=eph0;
         strcpy(buff,str.c_str());
         if (!(p=strchr(buff,','))) continue;
         *p='\0';
         if (!(nav->eph[i].sat=satid2no(buff))) continue;
-        sscanf(p+1,"%d,%d,%d,%d,%ld,%ld,%ld,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%d,%d,%lf",
+        sscanf(p+1,"%d,%d,%d,%d,%lu,%lu,%lu,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%d,%d,%lf",
                &nav->eph[i].iode,
                &nav->eph[i].iodc,
                &nav->eph[i].sva ,
@@ -2404,9 +2404,9 @@ void __fastcall TMainForm::SaveNav(nav_t *nav)
         str=str+s.sprintf("%d,",nav->eph[i].iodc);
         str=str+s.sprintf("%d,",nav->eph[i].sva);
         str=str+s.sprintf("%d,",nav->eph[i].svh);
-        str=str+s.sprintf("%d,",(int)nav->eph[i].toe.time);
-        str=str+s.sprintf("%d,",(int)nav->eph[i].toc.time);
-        str=str+s.sprintf("%d,",(int)nav->eph[i].ttr.time);
+        str=str+s.sprintf("%lu,",(long unsigned)nav->eph[i].toe.time);
+        str=str+s.sprintf("%lu,",(long unsigned)nav->eph[i].toc.time);
+        str=str+s.sprintf("%lu,",(long unsigned)nav->eph[i].ttr.time);
         str=str+s.sprintf("%.14E,",nav->eph[i].A);
         str=str+s.sprintf("%.14E,",nav->eph[i].e);
         str=str+s.sprintf("%.14E,",nav->eph[i].i0);
@@ -2431,7 +2431,7 @@ void __fastcall TMainForm::SaveNav(nav_t *nav)
         str=str+s.sprintf("%d,",nav->eph[i].code);
         str=str+s.sprintf("%d,",nav->eph[i].flag);
         str=str+s.sprintf("%.14E,",nav->eph[i].tgd[1]);
-        ini->WriteString("navi",s.sprintf("eph_%02d",i),str);
+        ini->WriteString("navi",s.sprintf("eph_%03d",i),str);
     }
     str="";
     for (i=0;i<8;i++) str=str+s.sprintf("%.14E,",nav->ion_gps[i]);

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -3136,7 +3136,7 @@ extern int readnav(const char *file, nav_t *nav)
     eph_t eph0={0};
     geph_t geph0={0};
     char buff[4096],*p;
-    long toe_time,tof_time,toc_time,ttr_time;
+    long unsigned toe_time,tof_time,toc_time,ttr_time;
     int i,sat,prn;
 
     trace(3,"loadnav: file=%s\n",file);
@@ -3160,7 +3160,7 @@ extern int readnav(const char *file, nav_t *nav)
             nav->geph[prn-1]=geph0;
             nav->geph[prn-1].sat=sat;
             toe_time=tof_time=0;
-            (void)sscanf(p+1,"%d,%d,%d,%d,%d,%d,%ld,%ld,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,"
+            (void)sscanf(p+1,"%d,%d,%d,%d,%d,%d,%lu,%lu,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,"
                         "%lf,%lf,%lf,%lf",
                    &nav->geph[prn-1].iode,&nav->geph[prn-1].frq,&nav->geph[prn-1].svh,
                    &nav->geph[prn-1].flags,&nav->geph[prn-1].sva,&nav->geph[prn-1].age,
@@ -3176,7 +3176,7 @@ extern int readnav(const char *file, nav_t *nav)
             nav->eph[sat-1]=eph0;
             nav->eph[sat-1].sat=sat;
             toe_time=toc_time=ttr_time=0;
-            (void)sscanf(p+1,"%d,%d,%d,%d,%ld,%ld,%ld,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,"
+            (void)sscanf(p+1,"%d,%d,%d,%d,%lu,%lu,%lu,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,"
                         "%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%d,%d",
                    &nav->eph[sat-1].iode,&nav->eph[sat-1].iodc,&nav->eph[sat-1].sva ,
                    &nav->eph[sat-1].svh ,
@@ -3210,12 +3210,12 @@ extern int savenav(const char *file, const nav_t *nav)
     for (i=0;i<MAXSAT;i++) {
         if (nav->eph[i].ttr.time==0) continue;
         satno2id(nav->eph[i].sat,id);
-        fprintf(fp,"%s,%d,%d,%d,%d,%d,%d,%d,%.14E,%.14E,%.14E,%.14E,%.14E,%.14E,"
+        fprintf(fp,"%s,%d,%d,%d,%d,%lu,%lu,%lu,%.14E,%.14E,%.14E,%.14E,%.14E,%.14E,"
                    "%.14E,%.14E,%.14E,%.14E,%.14E,%.14E,%.14E,%.14E,%.14E,%.14E,"
                    "%.14E,%.14E,%.14E,%.14E,%.14E,%d,%d\n",
                 id,nav->eph[i].iode,nav->eph[i].iodc,nav->eph[i].sva ,
-                nav->eph[i].svh ,(int)nav->eph[i].toe.time,
-                (int)nav->eph[i].toc.time,(int)nav->eph[i].ttr.time,
+                nav->eph[i].svh ,(long unsigned)nav->eph[i].toe.time,
+                (long unsigned)nav->eph[i].toc.time,(long unsigned)nav->eph[i].ttr.time,
                 nav->eph[i].A   ,nav->eph[i].e  ,nav->eph[i].i0  ,nav->eph[i].OMG0,
                 nav->eph[i].omg ,nav->eph[i].M0 ,nav->eph[i].deln,nav->eph[i].OMGd,
                 nav->eph[i].idot,nav->eph[i].crc,nav->eph[i].crs ,nav->eph[i].cuc ,
@@ -3226,12 +3226,12 @@ extern int savenav(const char *file, const nav_t *nav)
     for (i=0;i<MAXPRNGLO;i++) {
         if (nav->geph[i].tof.time==0) continue;
         satno2id(nav->geph[i].sat,id);
-        fprintf(fp,"%s,%d,%d,%d,%d,%d,%d,%d,%d,%.14E,%.14E,%.14E,%.14E,%.14E,%.14E,"
+        fprintf(fp,"%s,%d,%d,%d,%d,%d,%d,%lu,%lu,%.14E,%.14E,%.14E,%.14E,%.14E,%.14E,"
                    "%.14E,%.14E,%.14E,%.14E,%.14E,%.14E\n",
                 id,nav->geph[i].iode,nav->geph[i].frq,nav->geph[i].svh,
                 nav->geph[i].flags,
-                nav->geph[i].sva,nav->geph[i].age,(int)nav->geph[i].toe.time,
-                (int)nav->geph[i].tof.time,
+                nav->geph[i].sva,nav->geph[i].age,(long unsigned)nav->geph[i].toe.time,
+                (long unsigned)nav->geph[i].tof.time,
                 nav->geph[i].pos[0],nav->geph[i].pos[1],nav->geph[i].pos[2],
                 nav->geph[i].vel[0],nav->geph[i].vel[1],nav->geph[i].vel[2],
                 nav->geph[i].acc[0],nav->geph[i].acc[1],nav->geph[i].acc[2],


### PR DESCRIPTION
The use of the long type here was not consistent so clean that up, and while here use the unsigned type as these times are not negative.

For rtknavi_qt the key used to save the ephemeris could include a space that was then escaped. Change this to fill the numerical suffix with zeros rather than spaces.

Use a fixed three digit numerical suffix for the ephemeris keys, rather than two digits, as these can be over 99 and this keeps the key a consistent width.