### PR TITLE
rtksvr: don't clear ephemeris times when initialising

### DIFF
--- a/src/rtksvr.c
+++ b/src/rtksvr.c
@@ -904,7 +904,7 @@ extern int rtksvrstart(rtksvr_t *svr, int cycle, int buffsize, int *strs,
                        int nmeareq, const double *nmeapos, prcopt_t *prcopt,
                        solopt_t *solopt, stream_t *moni, char *errmsg)
 {
-    gtime_t time,time0={0};
+    gtime_t time;
     int i,j,rw;
     
     tracet(3,"rtksvrstart: cycle=%d buffsize=%d navsel=%d nmeacycle=%d nmeareq=%d\n",
@@ -972,10 +972,13 @@ extern int rtksvrstart(rtksvr_t *svr, int cycle, int buffsize, int *strs,
             svr->rtk.rb[i]=i<3?prcopt->rb[i]:0.0;
         }
     }
+#ifdef RTKLIB_DISABLED
     /* update navigation data */
+    gtime_t time0 = {0};
     for (i=0;i<MAXSAT*4 ;i++) svr->nav.eph [i].ttr=time0;
     for (i=0;i<MAXPRNGLO*2;i++) svr->nav.geph[i].tof=time0;
     for (i=0;i<NSATSBS*2;i++) svr->nav.seph[i].tof=time0;
+#endif
     
     /* set monitor stream */
     svr->moni=moni;


### PR DESCRIPTION
The ephemeris data can be pre-loaded by rtkrcv and rtknavi, and clearing the times when initialising invalidates these.

Frustrating that rtkrcv loses nav data and then takes time to acquire it again. It was loading the nav data and then initializing rtksvr which cleared the ephemeris times which stops them being saved unless new nav data is acquired, so quickly starting and stopping rtkrcv would lose the nav data. This patch works around this. Not sure why this clearing of the times was needed, and the users of the data should be checking the times anyway, but might there be a reason for this? 