### PR TITLE
gui tide correction options

### DIFF
--- a/app/qtapp/appcmn_qt/navi_post_opt.cpp
+++ b/app/qtapp/appcmn_qt/navi_post_opt.cpp
@@ -67,7 +67,12 @@ OptDialog::OptDialog(QWidget *parent, int opts)
 
     ui->cBTideCorrection->setItemData(0, tr("Not apply earth tides correction"), Qt::ToolTipRole);
     ui->cBTideCorrection->setItemData(1, tr("Apply solid earth tides correction"), Qt::ToolTipRole);
-    ui->cBTideCorrection->setItemData(2, tr("Apply solid earth tides, OTL (ocean tide loading) and pole tide corrections"), Qt::ToolTipRole);
+    ui->cBTideCorrection->setItemData(2, tr("Apply OTL (ocean tide loading)"), Qt::ToolTipRole);
+    ui->cBTideCorrection->setItemData(3, tr("Apply solid earth tides and OTL (ocean tide loading)"), Qt::ToolTipRole);
+    ui->cBTideCorrection->setItemData(4, tr("Apply pole tide corrections"), Qt::ToolTipRole);
+    ui->cBTideCorrection->setItemData(5, tr("Apply solid earth tides and pole tide corrections"), Qt::ToolTipRole);
+    ui->cBTideCorrection->setItemData(6, tr("Apply OTL (ocean tide loading) and pole tide corrections"), Qt::ToolTipRole);
+    ui->cBTideCorrection->setItemData(7, tr("Apply solid earth tides, OTL (ocean tide loading) and pole tide corrections"), Qt::ToolTipRole);
 
     ui->cBIonosphereOption->setItemData(IONOOPT_OFF, tr("Not apply ionospheric correction"), Qt::ToolTipRole);
     ui->cBIonosphereOption->setItemData(IONOOPT_BRDC, tr("Apply broadcast ionospheric model"), Qt::ToolTipRole);
@@ -705,8 +710,7 @@ void OptDialog::updateOptions()
     processingOptions.ionoopt = ui->cBIonosphereOption->currentIndex();
     processingOptions.tropopt = ui->cBTroposphereOption->currentIndex();
     processingOptions.dynamics = ui->cBDynamicModel->currentIndex();
-    processingOptions.tidecorr = ui->cBTideCorrection->currentIndex();
-    if (processingOptions.tidecorr > 1) processingOptions.tidecorr = 7;
+    processingOptions.tidecorr = ui->cBTideCorrection->currentIndex() & 7;
     processingOptions.niter = ui->sBNumIteration->value();
     // codesmooth
     processingOptions.intpref = ui->cBIntputReferenceObservation->currentIndex();
@@ -933,7 +937,7 @@ void OptDialog::updateUi(const prcopt_t &prcopt, const solopt_t &solopt, const f
     ui->cBIonosphereOption->setCurrentIndex(prcopt.ionoopt);
     ui->cBTroposphereOption->setCurrentIndex(prcopt.tropopt);
     ui->cBDynamicModel->setCurrentIndex(prcopt.dynamics);
-    ui->cBTideCorrection->setCurrentIndex(prcopt.tidecorr > 1 ? 2 : prcopt.tidecorr);
+    ui->cBTideCorrection->setCurrentIndex(prcopt.tidecorr & 7);
     ui->sBNumIteration->setValue(prcopt.niter);
     //prcopt.codesmooth
     if (options == PostOptions) {
@@ -1132,8 +1136,7 @@ void OptDialog::save(const QString &file)
     procOpts.ionoopt = ui->cBIonosphereOption->currentIndex();
     procOpts.tropopt = ui->cBTroposphereOption->currentIndex();
     procOpts.dynamics = ui->cBDynamicModel->currentIndex();
-    procOpts.tidecorr = ui->cBTideCorrection->currentIndex();
-    if (procOpts.tidecorr > 1) procOpts.tidecorr = 7;
+    procOpts.tidecorr = ui->cBTideCorrection->currentIndex() & 7;
     procOpts.niter = ui->sBNumIteration->value();
     // procOpts.codesmooth
     procOpts.intpref = ui->cBIntputReferenceObservation->currentIndex();
@@ -1312,7 +1315,7 @@ void OptDialog::saveOptions(QSettings &settings)
     settings.setValue("prcopt/ionoopt", ui->cBIonosphereOption->currentIndex());
     settings.setValue("prcopt/tropopt", ui->cBTroposphereOption->currentIndex());
     settings.setValue("prcopt/dynamics", ui->cBDynamicModel->currentIndex());
-    settings.setValue("prcopt/tidecorr", ui->cBTideCorrection->currentIndex());
+    settings.setValue("prcopt/tidecorr", ui->cBTideCorrection->currentIndex() & 7);
     settings.setValue("prcopt/niter", ui->sBNumIteration->value());
     // settings.setValue("prcopt/codesmooth", processingOptions.codesmooth);
     settings.setValue("prcopt/intpref", ui->cBIntputReferenceObservation->currentIndex());
@@ -1511,7 +1514,7 @@ void OptDialog::loadOptions(QSettings &settings)
     ui->cBIonosphereOption->setCurrentIndex(settings.value("prcopt/ionoopt", IONOOPT_BRDC).toInt());
     ui->cBTroposphereOption->setCurrentIndex(settings.value("prcopt/tropopt", TROPOPT_SAAS).toInt());
     ui->cBDynamicModel->setCurrentIndex(settings.value("prcopt/dynamics", 0).toInt());
-    ui->cBTideCorrection->setCurrentIndex(settings.value("prcopt/tidecorr", 0).toInt());
+    ui->cBTideCorrection->setCurrentIndex(settings.value("prcopt/tidecorr", 0).toInt() & 7);
     ui->sBNumIteration->setValue(settings.value("prcopt/niter", 1).toInt());
     // processingOptions.codesmooth = settings.value("prcopt/codesmooth", 0).toInt();
     if (options == PostOptions) {

--- a/app/qtapp/appcmn_qt/navi_post_opt.ui
+++ b/app/qtapp/appcmn_qt/navi_post_opt.ui
@@ -192,7 +192,32 @@
          </item>
          <item>
           <property name="text">
+           <string>OTL</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
            <string>Solid/OTL</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>S.Pole</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Solid/S.Pole</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>OTL/S.Pole</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Solid/OTL/S.Pole</string>
           </property>
          </item>
         </widget>

--- a/app/qtapp/rtknavi_qt/mondlg.cpp
+++ b/app/qtapp/rtknavi_qt/mondlg.cpp
@@ -393,7 +393,7 @@ void MonitorDialog::setRtk()
     int width[] = {500, 500};
 
     ui->tWConsole->setColumnCount(2);
-    ui->tWConsole->setRowCount(52 + NFREQ*2);
+    ui->tWConsole->setRowCount(53 + NFREQ*2);
     ui->tWConsole->setHorizontalHeaderLabels(header);
 
     for (int i = 0; (i < ui->tWConsole->columnCount()) && (i < 2); i++)
@@ -486,7 +486,7 @@ void MonitorDialog::showRtk()
     if (rtk->opt.navsys & SYS_IRN) navsys = navsys + tr("NavIC ");
     if (rtk->opt.navsys & SYS_SBS) navsys = navsys + tr("SBAS ");
 
-    if (ui->tWConsole->rowCount() < 55) {
+    if (ui->tWConsole->rowCount() < 53 + NFREQ * 2) {
       free(rtk);
       return;
     }
@@ -532,8 +532,14 @@ void MonitorDialog::showRtk()
                               .arg(rtk->opt.snrmask.mask[2][3], 0).arg(rtk->opt.snrmask.mask[2][4], 0).arg(rtk->opt.snrmask.mask[2][5], 0)
                               .arg(rtk->opt.snrmask.mask[2][6], 0).arg(rtk->opt.snrmask.mask[2][7], 0).arg(rtk->opt.snrmask.mask[2][8], 0));
 
-    ui->tWConsole->item(row,   0)->setText(tr("Rec Dynamic/Earth Tides Correction"));
-    ui->tWConsole->item(row++, 1)->setText(QStringLiteral("%1, %2").arg(rtk->opt.dynamics ? tr("ON") : tr("OFF"), rtk->opt.tidecorr ? tr("ON") : tr("OFF")));
+    ui->tWConsole->item(row,   0)->setText(tr("Rec Dynamics"));
+    ui->tWConsole->item(row++, 1)->setText(QStringLiteral("%1").arg(rtk->opt.dynamics ? tr("ON") : tr("OFF")));
+
+    ui->tWConsole->item(row,   0)->setText(tr("Earth Tides Correction"));
+    const char *tideopts[]={"OFF","Solid Earth","Ocean Loading","Solid Earth + Ocean Loading",
+      "Solid Pole","Solid Earth + Solid Pole","Ocean Loading + Sold Pole",
+      "Solid Earth + Ocean Loading + Solid Pole"};
+    ui->tWConsole->item(row++, 1)->setText(QStringLiteral("%1").arg(tideopts[rtk->opt.tidecorr & 7]));
 
     ui->tWConsole->item(row,   0)->setText(tr("Ionosphere/Troposphere Model"));
     ui->tWConsole->item(row++, 1)->setText(QStringLiteral("%1, %2").arg(ionoopt[rtk->opt.ionoopt < 0 || rtk->opt.ionoopt > 6 ? 0 : rtk->opt.ionoopt],

--- a/app/winapp/rtknavi/mondlg.cpp
+++ b/app/winapp/rtknavi/mondlg.cpp
@@ -484,8 +484,14 @@ void __fastcall TMonitorDialog::ShowRtk(void)
 				  rtk->opt.snrmask.mask[3][0],rtk->opt.snrmask.mask[3][1],rtk->opt.snrmask.mask[3][2],
 				  rtk->opt.snrmask.mask[3][3],rtk->opt.snrmask.mask[3][4],rtk->opt.snrmask.mask[3][5],
 				  rtk->opt.snrmask.mask[3][6],rtk->opt.snrmask.mask[3][7],rtk->opt.snrmask.mask[3][8]);
-	Tbl->Cells[0][i  ]="Rec Dynamic/Earth Tides Correction";
-	Tbl->Cells[1][i++]=s.sprintf("%s, %s",rtk->opt.dynamics?"ON":"OFF",rtk->opt.tidecorr?"ON":"OFF");
+
+	Tbl->Cells[0][i  ]="Rec Dynamics";
+	Tbl->Cells[1][i++]=s.sprintf("%s",rtk->opt.dynamics?"ON":"OFF");
+
+	Tbl->Cells[0][i  ]="Earth Tides Correction";
+        const char *tideopts[]={"OFF","Solid Earth","Ocean Loading","Solid Earth + Ocean Loading","Solid Pole",
+          "Solid Earth + Solid Pole","Ocean Loading + Sold Pole","Solid Earth + Ocean Loading + Solid Pole"};
+        Tbl->Cells[1][i++]=s.sprintf("%s", tideopts[rtk->opt.tidecorr & 7]);
 	
 	Tbl->Cells[0][i  ]="Ionosphere/Troposphere Model";
 	Tbl->Cells[1][i++]=s.sprintf("%s, %s",ionoopt[rtk->opt.ionoopt],tropopt[rtk->opt.tropopt]);

--- a/app/winapp/rtknavi/naviopt.cpp
+++ b/app/winapp/rtknavi/naviopt.cpp
@@ -421,7 +421,7 @@ void __fastcall TOptDialog::GetOpt(void)
 	Freq		 ->ItemIndex=PrcOpt.nf-1>NFREQ-1?NFREQ-1:PrcOpt.nf-1;
 	ElMask		 ->Text     =s.sprintf("%.0f",PrcOpt.elmin*R2D);
 	DynamicModel ->ItemIndex=PrcOpt.dynamics;
-	TideCorr	 ->ItemIndex=PrcOpt.tidecorr > 1 ? 2 : PrcOpt.tidecorr;
+	TideCorr	 ->ItemIndex=PrcOpt.tidecorr & 7;
 	IonoOpt		 ->ItemIndex=PrcOpt.ionoopt;
 	TropOpt		 ->ItemIndex=PrcOpt.tropopt;
 	SatEphem	 ->ItemIndex=PrcOpt.sateph;
@@ -565,8 +565,7 @@ void __fastcall TOptDialog::SetOpt(void)
 	PrcOpt.nf        =Freq        ->ItemIndex+1;
 	PrcOpt.elmin     =str2dbl(ElMask ->Text)*D2R;
 	PrcOpt.dynamics  =DynamicModel->ItemIndex;
-	PrcOpt.tidecorr  =TideCorr    ->ItemIndex;
-	if (PrcOpt.tidecorr > 1) PrcOpt.tidecorr = 7;
+	PrcOpt.tidecorr  =TideCorr    ->ItemIndex & 7;
 	PrcOpt.ionoopt   =IonoOpt     ->ItemIndex;
 	PrcOpt.tropopt   =TropOpt     ->ItemIndex;
 	PrcOpt.sateph    =SatEphem    ->ItemIndex;
@@ -752,7 +751,7 @@ void __fastcall TOptDialog::LoadOpt(AnsiString file)
 	ElMask		 ->Text			=s.sprintf("%.0f",prcopt.elmin*R2D);
     PrcOpt.snrmask              =prcopt.snrmask;
 	DynamicModel ->ItemIndex	=prcopt.dynamics;
-	TideCorr	 ->ItemIndex	=prcopt.tidecorr > 1 ? 2 : prcopt.tidecorr;
+	TideCorr	 ->ItemIndex	=prcopt.tidecorr & 7;
 	IonoOpt		 ->ItemIndex	=prcopt.ionoopt;
 	TropOpt		 ->ItemIndex	=prcopt.tropopt;
 	SatEphem	 ->ItemIndex	=prcopt.sateph;
@@ -994,8 +993,7 @@ void __fastcall TOptDialog::SaveOpt(AnsiString file)
 	prcopt.elmin	=str2dbl(ElMask	->Text)*D2R;
     prcopt.snrmask	=PrcOpt.snrmask;
 	prcopt.dynamics	=DynamicModel->ItemIndex;
-	prcopt.tidecorr	=TideCorr	 ->ItemIndex;
-	if (prcopt.tidecorr > 1) prcopt.tidecorr = 7;
+	prcopt.tidecorr	=TideCorr	 ->ItemIndex & 7;
 	prcopt.ionoopt	=IonoOpt	 ->ItemIndex;
 	prcopt.tropopt	=TropOpt	 ->ItemIndex;
 	prcopt.sateph	=SatEphem	 ->ItemIndex;

--- a/app/winapp/rtknavi/naviopt.dfm
+++ b/app/winapp/rtknavi/naviopt.dfm
@@ -199,7 +199,7 @@ object OptDialog: TOptDialog
       object DynamicModel: TComboBox
         Left = 248
         Top = 136
-        Width = 75
+        Width = 45
         Height = 21
         Style = csDropDownList
         ItemIndex = 0
@@ -210,9 +210,9 @@ object OptDialog: TOptDialog
           'ON')
       end
       object TideCorr: TComboBox
-        Left = 325
+        Left = 295
         Top = 136
-        Width = 75
+        Width = 105
         Height = 21
         Style = csDropDownList
         ItemIndex = 0
@@ -220,7 +220,13 @@ object OptDialog: TOptDialog
         Text = 'OFF'
         Items.Strings = (
           'OFF'
-          'Solid')
+          'Solid Earth Tide'
+          'Ocean Tide Loading'
+          'Solid Earth + OTL'
+          'Solid Pole'
+          'Solid Earth + Pole'
+          'OTL + Solid Pole'
+          'Solid + OTL + Pole')
       end
       object IonoOpt: TComboBox
         Left = 248

--- a/app/winapp/rtkpost/postmain.cpp
+++ b/app/winapp/rtkpost/postmain.cpp
@@ -1000,8 +1000,7 @@ int __fastcall TMainForm::GetOption(prcopt_t &prcopt, solopt_t &solopt,
     prcopt.posopt[4]=PosOpt[4];
     prcopt.posopt[5]=PosOpt[5];
     prcopt.dynamics =DynamicModel;
-    prcopt.tidecorr =TideCorr;
-    if (prcopt.tidecorr > 1) prcopt.tidecorr = 7;
+    prcopt.tidecorr =TideCorr & 7;
     prcopt.armaxiter=ARIter;
     prcopt.niter    =NumIter;
     prcopt.minfixsats=MinFixSats;

--- a/app/winapp/rtkpost/postopt.cpp
+++ b/app/winapp/rtkpost/postopt.cpp
@@ -636,7 +636,7 @@ void __fastcall TOptDialog::LoadOpt(AnsiString file)
 	ElMask		 ->Text			=s.sprintf("%.0f",prcopt.elmin*R2D);
 	SnrMask						=prcopt.snrmask;
 	DynamicModel ->ItemIndex	=prcopt.dynamics;
-	TideCorr	 ->ItemIndex	=prcopt.tidecorr > 1 ? 2 : prcopt.tidecorr;
+	TideCorr	 ->ItemIndex	=prcopt.tidecorr & 7;
 	IonoOpt		 ->ItemIndex	=prcopt.ionoopt;
 	TropOpt		 ->ItemIndex	=prcopt.tropopt;
 	SatEphem	 ->ItemIndex	=prcopt.sateph;
@@ -797,8 +797,7 @@ int ppp=PosMode->ItemIndex>=PMODE_PPP_KINEMA;
 	prcopt.elmin	=str2dbl(ElMask	->Text)*D2R;
 	prcopt.snrmask	=SnrMask;
 	prcopt.dynamics	=DynamicModel->ItemIndex;
-	prcopt.tidecorr	=TideCorr	 ->ItemIndex;
-	if (prcopt.tidecorr > 1) prcopt.tidecorr = 7;
+	prcopt.tidecorr	=TideCorr	 ->ItemIndex & 7;
 	prcopt.ionoopt	=IonoOpt	 ->ItemIndex;
 	prcopt.tropopt	=TropOpt	 ->ItemIndex;
 	prcopt.sateph	=SatEphem	 ->ItemIndex;

--- a/app/winapp/rtkpost/postopt.dfm
+++ b/app/winapp/rtkpost/postopt.dfm
@@ -216,7 +216,7 @@ object OptDialog: TOptDialog
       object DynamicModel: TComboBox
         Left = 248
         Top = 92
-        Width = 75
+        Width = 45
         Height = 21
         Style = csDropDownList
         ItemIndex = 0
@@ -228,9 +228,9 @@ object OptDialog: TOptDialog
           'ON')
       end
       object TideCorr: TComboBox
-        Left = 325
+        Left = 295
         Top = 92
-        Width = 75
+        Width = 105
         Height = 21
         Style = csDropDownList
         ItemIndex = 0
@@ -238,8 +238,13 @@ object OptDialog: TOptDialog
         Text = 'OFF'
         Items.Strings = (
           'OFF'
-          'Solid'
-          'Solid/OTL')
+          'Solid Earth Tide'
+          'Ocean Tide Loading'
+          'Solid Earth + OTL'
+          'Solid Pole'
+          'Solid Earth + Pole'
+          'OTL + Solid Pole'
+          'Solid + OTL + Pole')
       end
       object IonoOpt: TComboBox
         Left = 248


### PR DESCRIPTION
The tide correction options were extended some time ago but the GUI changes were left todo, and since there have been no other suggestions then this is a minimal change suggestion.

Expand the tide corrections options exposed in the gui apps. This just adds a list entry for each combination. An alternative would be to replace the pull down list with three check boxes.