### PR TITLE
rtksvr rtcm ssr: defer using ssr without a matching iode

### DIFF
--- a/src/rtcm.c
+++ b/src/rtcm.c
@@ -87,6 +87,7 @@ extern int init_rtcm(rtcm_t *rtcm)
     rtcm->dgps=NULL;
     for (i=0;i<MAXSAT;i++) {
         rtcm->ssr[i]=ssr0;
+        rtcm->ssr[i].iode= -1;
     }
     rtcm->msg[0]=rtcm->msgtype[0]=rtcm->opt[0]='\0';
     for (i=0;i<6;i++) rtcm->msmtype[i][0]='\0';

--- a/src/rtksvr.c
+++ b/src/rtksvr.c
@@ -318,6 +318,35 @@ static void update_ssr(rtksvr_t *svr, int index)
       if (svr->rtcm[index].ssr[i].iod[0] != svr->rtcm[index].ssr[i].iod[1])
         continue;
 
+      // Check consistency of iode between ssr and broadcast.
+      int ssr_iode = svr->rtcm[index].ssr[i].iode, iode = -1;
+      if (ssr_iode < 0) continue;
+      int sys = satsys(i + 1, NULL);
+      if (sys != SYS_GLO) {
+        for (int j = 0; j < svr->nav.n; j++) {
+          if (svr->nav.eph[j].sat == i + 1 && ssr_iode == svr->nav.eph[j].iode) {
+            // Galileo SSR is wrt the I/NAV broadcast clock, skip F/NAV.
+            if (sys == SYS_GAL && (svr->nav.eph[j].code & (1 << 8)) != 0) {
+              trace(4, "update_ssr skipping F/NAV sat=%d\n", i + 1);
+              continue;
+            }
+            iode = svr->nav.eph[j].iode;
+            break;
+          }
+        }
+      } else {
+        for (int j = 0; j < svr->nav.ng; j++) {
+          if (svr->nav.geph[j].sat == i + 1 && ssr_iode == svr->nav.geph[j].iode) {
+            iode = svr->nav.geph[j].iode;
+            break;
+          }
+        }
+      }
+      if (iode == -1) {
+        trace(4, "update_ssr deferred sat=%d ssr_iode=%d\n", i + 1, ssr_iode);
+        continue;
+      }
+
       svr->nav.ssr[i] = svr->rtcm[index].ssr[i];
       svr->rtcm[index].ssr[i].update = 0;
     }
@@ -820,10 +849,11 @@ extern int rtksvrinit(rtksvr_t *svr)
     }
     for (i=0;i<MAXSTRRTK;i++) strinit(svr->stream+i);
 
-    for (i=0;i<MAXSAT;i++) for (j=0;j<6;j++) {
-        svr->nav.ssr[i].t0[j]=time0;
+    for (int i = 0; i < MAXSAT; i++) {
+      for (int j = 0; j < 6; j++) svr->nav.ssr[i].t0[j] = time0;
+      svr->nav.ssr[i].iode = -1;
     }
-    
+
     for (i=0;i<3;i++) *svr->cmds_periodic[i]='\0';
     *svr->cmd_reset='\0';
     svr->bl_reset=10.0;


### PR DESCRIPTION
Noted satellites not being used when using SSR corrections, and this tries to address one of the issues noted, a mismatch with the ephemeris IOD. Not certain that this is the correction solution, perhaps it's at least an improvement so putting it out there for consideration, and perhaps it could help people exploring SSR corrections if they not similar issues. If your ephemeris are being updated ahead of the SSR corrections then this should not be an issue.

If the SSR corrections for a particular satellite are updated with a new IOD before the dependent broadcast ephemeris then the correction becomes invalid and the satellite is dropped from the solution. This can happen across a block of satellites, dropping them all, and frustrates solutions using SSR corrections.

RTKLIB already maintains a current and previous ephemeris so can often fill gaps if the ephemeris is updated with a new IOD before the SSR corrections.

To avoid breaking a current matching SSR and IODE pair, defer adopting the SSR corrections for a particular satellite if there is not a matching broadcast ephemeris. The update is retried and will proceed after the ephemeris catches up.

Initialize the ssr iode to -1 rather than 0, to avoid an unexpected match as 0 is a valid iod.