### PR TITLE
rtknavi: guard freq and freqtype index read from settings

### DIFF
--- a/app/qtapp/rtknavi_qt/navimain.cpp
+++ b/app/qtapp/rtknavi_qt/navimain.cpp
@@ -2550,6 +2550,7 @@ void MainWindow::loadOptions()
     frequencyType[1] = settings.value("setting/freqtype2", 0).toInt();
     frequencyType[2] = settings.value("setting/freqtype3", 0).toInt();
     frequencyType[3] = settings.value("setting/freqtype4", 0).toInt();
+    for (int i = 0; i < 4; i++) if (frequencyType[i] > NFREQ + 1) frequencyType[i] = 0;
     baselineMode[0] = settings.value("setting/blmode1", 0).toInt();
     baselineMode[1] = settings.value("setting/blmode2", 0).toInt();
     baselineMode[2] = settings.value("setting/blmode3", 0).toInt();

--- a/app/winapp/rtknavi/navimain.cpp
+++ b/app/winapp/rtknavi/navimain.cpp
@@ -2494,6 +2494,7 @@ void __fastcall TMainForm::LoadOpt(void)
     }
     PrcOpt.mode     =ini->ReadInteger("prcopt", "mode",            2);
     PrcOpt.nf       =ini->ReadInteger("prcopt", "nf",          NFREQ);
+    if (PrcOpt.nf > NFREQ) PrcOpt.nf = NFREQ;
     PrcOpt.elmin    =ini->ReadFloat  ("prcopt", "elmin",    15.0*D2R);
     PrcOpt.snrmask.ena[0]=ini->ReadInteger("prcopt","snrmask_ena1",0);
     PrcOpt.snrmask.ena[1]=ini->ReadInteger("prcopt","snrmask_ena2",0);
@@ -2653,6 +2654,10 @@ void __fastcall TMainForm::LoadOpt(void)
     FreqType2       =ini->ReadInteger("setting","freqtype2",       0);
     FreqType3       =ini->ReadInteger("setting","freqtype3",       0);
     FreqType4       =ini->ReadInteger("setting","freqtype4",       0);
+    if (FreqType1 > NFREQ + 1) FreqType1 = 0;
+    if (FreqType2 > NFREQ + 1) FreqType2 = 0;
+    if (FreqType3 > NFREQ + 1) FreqType3 = 0;
+    if (FreqType4 > NFREQ + 1) FreqType4 = 0;
     BLMode1         =ini->ReadInteger("setting","blmode1",         0);
     BLMode2         =ini->ReadInteger("setting","blmode2",         0);
     BLMode3         =ini->ReadInteger("setting","blmode3",         0);

--- a/app/winapp/rtkpost/postmain.cpp
+++ b/app/winapp/rtkpost/postmain.cpp
@@ -1356,6 +1356,7 @@ void __fastcall TMainForm::LoadOpt(void)
     
     PosMode            =ini->ReadInteger("opt","posmode",        2);
     Freq               =ini->ReadInteger("opt","freq",     NFREQ-1);
+    if (Freq > NFREQ - 1) Freq = NFREQ - 1;
     Solution           =ini->ReadInteger("opt","solution",       0);
     ElMask             =ini->ReadFloat  ("opt","elmask",      15.0);
     SnrMask.ena[0]     =ini->ReadInteger("opt","snrmask_ena1",   0);


### PR DESCRIPTION
Noticed oob crashes switching between builds with differing NFREQ.

Reading an initializing file from a build with more frequency indices can otherwise result in an oob index being passed along.