### PR TITLE
rtknavi_qt: initialize the refpos

### DIFF
--- a/app/qtapp/appcmn_qt/navi_post_opt.cpp
+++ b/app/qtapp/appcmn_qt/navi_post_opt.cpp
@@ -651,7 +651,7 @@ void OptDialog::selectSolutionFont()
 //---------------------------------------------------------------------------
 void OptDialog::updateOptions()
 {
-    double rovPos[3], refPos[3];
+    double rovPos[3] = {0}, refPos[3] = {0};
     QLineEdit *editu[] = {ui->lERoverPosition1, ui->lERoverPosition2, ui->lERoverPosition3 };
     QLineEdit *editr[] = {ui->lEReferencePosition1, ui->lEReferencePosition2, ui->lEReferencePosition3 };
     pcvs_t pcvr;
@@ -1274,7 +1274,7 @@ void OptDialog::save(const QString &file)
 //---------------------------------------------------------------------------
 void OptDialog::saveOptions(QSettings &settings)
 {
-    double rovPos[3], refPos[3];
+    double rovPos[3] = {0}, refPos[3] = {0};
     QLineEdit *editu[] = {ui->lERoverPosition1, ui->lERoverPosition2, ui->lERoverPosition3};
     QLineEdit *editr[] = {ui->lEReferencePosition1, ui->lEReferencePosition2, ui->lEReferencePosition3};
 


### PR DESCRIPTION
These might have been sources of garbage causing issues initialising in a prior patch that used the base position to initialise early, shall keep exploring that but separately.

Otherwise uninitialized values can be passed through.