### PR TITLE
rtknavi rtcm: avoid a static allocation

### DIFF
--- a/app/qtapp/rtknavi_qt/mondlg.cpp
+++ b/app/qtapp/rtknavi_qt/mondlg.cpp
@@ -1948,37 +1948,39 @@ void MonitorDialog::setRtcm()
 //---------------------------------------------------------------------------
 void MonitorDialog::showRtcm()
 {
-    static rtcm_t rtcm;
     int i = 0, j, format;
     QString mstr1, mstr2;
     char tstr[40] = "-";
 
     int effectiveStream = (inputStream < 0 || inputStream > 2) ? 0 : inputStream;
 
+    rtcm_t *rtcm = (rtcm_t *)malloc(sizeof(rtcm_t));
+    if (rtcm == NULL) return;
+
     rtksvrlock(rtksvr);
     format = rtksvr->format[effectiveStream];
-    rtcm = rtksvr->rtcm[effectiveStream];
+    *rtcm = rtksvr->rtcm[effectiveStream];
     rtksvrunlock(rtksvr);
 
-    if (rtcm.time.time) time2str(rtcm.time, tstr, 3);
+    if (rtcm->time.time) time2str(rtcm->time, tstr, 3);
 
     for (j = 1; j < 100; j++) {
-        if (rtcm.nmsg2[j] == 0) continue;
-        mstr1 += QString("%1%2 (%3)").arg(mstr1.isEmpty() ? "" : ",").arg(j).arg(rtcm.nmsg2[j]);
+        if (rtcm->nmsg2[j] == 0) continue;
+        mstr1 += QString("%1%2 (%3)").arg(mstr1.isEmpty() ? "" : ",").arg(j).arg(rtcm->nmsg2[j]);
 	}
-    if (rtcm.nmsg2[0] > 0) {
-        mstr1 += QString("%1other (%2)").arg(mstr1.isEmpty() ? "" : ",").arg(rtcm.nmsg2[0]);
+    if (rtcm->nmsg2[0] > 0) {
+        mstr1 += QString("%1other (%2)").arg(mstr1.isEmpty() ? "" : ",").arg(rtcm->nmsg2[0]);
     }
     for (j = 1; j < 300; j++) {
-        if (rtcm.nmsg3[j] == 0) continue;
-        mstr2 += QString("%1%2(%3)").arg(mstr2.isEmpty() ? "" : ",").arg(j + 1000).arg(rtcm.nmsg3[j]);
+        if (rtcm->nmsg3[j] == 0) continue;
+        mstr2 += QString("%1%2(%3)").arg(mstr2.isEmpty() ? "" : ",").arg(j + 1000).arg(rtcm->nmsg3[j]);
 	}
     for (j = 300; j < 399; j++) {
-        if (rtcm.nmsg3[j] == 0) continue;
-        mstr2+=QString("%1%2(%3)").arg(mstr2.isEmpty()?"":",").arg(j+3770).arg(rtcm.nmsg3[j]);
+        if (rtcm->nmsg3[j] == 0) continue;
+        mstr2+=QString("%1%2(%3)").arg(mstr2.isEmpty()?"":",").arg(j+3770).arg(rtcm->nmsg3[j]);
     }
-    if (rtcm.nmsg3[0] > 0)
-        mstr2 += QString("%1other(%2)").arg(mstr2.isEmpty() ? "" : ",").arg(rtcm.nmsg3[0]);
+    if (rtcm->nmsg3[0] > 0)
+        mstr2 += QString("%1other(%2)").arg(mstr2.isEmpty() ? "" : ",").arg(rtcm->nmsg3[0]);
 
     ui->tWConsole->item(i,   0)->setText(tr("Format"));
     ui->tWConsole->item(i++, 1)->setText(format == STRFMT_RTCM2 ? tr("RTCM 2") : tr("RTCM 3"));
@@ -1987,43 +1989,45 @@ void MonitorDialog::showRtcm()
     ui->tWConsole->item(i++, 1)->setText(tstr);
 
     ui->tWConsole->item(i,   0)->setText(tr("Station ID"));
-    ui->tWConsole->item(i++, 1)->setText(QString::number(rtcm.staid));
+    ui->tWConsole->item(i++, 1)->setText(QString::number(rtcm->staid));
 
     ui->tWConsole->item(i,   0)->setText(tr("Station Health"));
-    ui->tWConsole->item(i++, 1)->setText(QString::number(rtcm.stah));
+    ui->tWConsole->item(i++, 1)->setText(QString::number(rtcm->stah));
 
     ui->tWConsole->item(i,   0)->setText(tr("Sequence No"));
-    ui->tWConsole->item(i++, 1)->setText(QString::number(rtcm.seqno));
+    ui->tWConsole->item(i++, 1)->setText(QString::number(rtcm->seqno));
 
     ui->tWConsole->item(i,   0)->setText(tr("RTCM Special Message"));
-    ui->tWConsole->item(i++, 1)->setText(rtcm.msg);
+    ui->tWConsole->item(i++, 1)->setText(rtcm->msg);
 
     ui->tWConsole->item(i,   0)->setText(tr("Last Message"));
-    ui->tWConsole->item(i++, 1)->setText(rtcm.msgtype);
+    ui->tWConsole->item(i++, 1)->setText(rtcm->msgtype);
 
     ui->tWConsole->item(i,   0)->setText(tr("# of RTCM Messages"));
     ui->tWConsole->item(i++, 1)->setText(format == STRFMT_RTCM2 ? mstr1 : mstr2);
 
     ui->tWConsole->item(i,   0)->setText(tr("MSM Signals for GPS"));
-    ui->tWConsole->item(i++, 1)->setText(rtcm.msmtype[0]);
+    ui->tWConsole->item(i++, 1)->setText(rtcm->msmtype[0]);
 
     ui->tWConsole->item(i,   0)->setText(tr("MSM Signals for GLONASS"));
-    ui->tWConsole->item(i++, 1)->setText(rtcm.msmtype[1]);
+    ui->tWConsole->item(i++, 1)->setText(rtcm->msmtype[1]);
 
     ui->tWConsole->item(i,   0)->setText(tr("MSM Signals for Galileo"));
-    ui->tWConsole->item(i++, 1)->setText(rtcm.msmtype[2]);
+    ui->tWConsole->item(i++, 1)->setText(rtcm->msmtype[2]);
 
     ui->tWConsole->item(i,   0)->setText(tr("MSM Signals for QZSS"));
-    ui->tWConsole->item(i++, 1)->setText(rtcm.msmtype[3]);
+    ui->tWConsole->item(i++, 1)->setText(rtcm->msmtype[3]);
 
     ui->tWConsole->item(i,   0)->setText(tr("MSM Signals for SBAS"));
-    ui->tWConsole->item(i++, 1)->setText(rtcm.msmtype[4]);
+    ui->tWConsole->item(i++, 1)->setText(rtcm->msmtype[4]);
 
     ui->tWConsole->item(i,   0)->setText(tr("MSM Signals for BDS"));
-    ui->tWConsole->item(i++, 1)->setText(rtcm.msmtype[5]);
+    ui->tWConsole->item(i++, 1)->setText(rtcm->msmtype[5]);
 
     ui->tWConsole->item(i,   0)->setText(tr("MSM Signals for NavIC"));
-    ui->tWConsole->item(i++, 1)->setText(rtcm.msmtype[6]);
+    ui->tWConsole->item(i++, 1)->setText(rtcm->msmtype[6]);
+
+    free(rtcm);
 }
 //---------------------------------------------------------------------------
 void MonitorDialog::setRtcmDgps()

--- a/app/winapp/rtknavi/mondlg.cpp
+++ b/app/winapp/rtknavi/mondlg.cpp
@@ -1799,35 +1799,37 @@ void __fastcall TMonitorDialog::SetRtcm(void)
 void __fastcall TMonitorDialog::ShowRtcm(void)
 {
 	AnsiString s;
-	static rtcm_t rtcm;
 	double pos[3]={0};
 	int i=1,j,format;
 	char tstr[40]="-",mstr1[1024]="",mstr2[1024]="",*p1=mstr1,*p2=mstr2;
 	
+	rtcm_t *rtcm = (rtcm_t *)malloc(sizeof(rtcm_t));
+    if (rtcm == NULL) return;
+
 	rtksvrlock(&rtksvr);
 	format=rtksvr.format[Str1];
-	rtcm=rtksvr.rtcm[Str1];
+	*rtcm=rtksvr.rtcm[Str1];
 	rtksvrunlock(&rtksvr);
 	
-	if (rtcm.time.time) time2str(rtcm.time,tstr,3);
+	if (rtcm->time.time) time2str(rtcm->time,tstr,3);
 	
 	for (j=1;j<100;j++) {
-		if (rtcm.nmsg2[j]==0) continue;
-        p1+=sprintf(p1,"%s%d (%d)",p1>mstr1?",":"",j,rtcm.nmsg2[j]);
+		if (rtcm->nmsg2[j]==0) continue;
+        p1+=sprintf(p1,"%s%d (%d)",p1>mstr1?",":"",j,rtcm->nmsg2[j]);
 	}
-	if (rtcm.nmsg2[0]>0) {
-		sprintf(p1,"%sother (%d)",p1>mstr1?",":"",rtcm.nmsg2[0]);
+	if (rtcm->nmsg2[0]>0) {
+		sprintf(p1,"%sother (%d)",p1>mstr1?",":"",rtcm->nmsg2[0]);
 	}
 	for (j=1;j<300;j++) {
-		if (rtcm.nmsg3[j]==0) continue;
-        p2+=sprintf(p2,"%s%d(%d)",p2>mstr2?",":"",j+1000,rtcm.nmsg3[j]);
+		if (rtcm->nmsg3[j]==0) continue;
+        p2+=sprintf(p2,"%s%d(%d)",p2>mstr2?",":"",j+1000,rtcm->nmsg3[j]);
 	}
 	for (j=300;j<399;j++) {
-		if (rtcm.nmsg3[j]==0) continue;
-        p2+=sprintf(p2,"%s%d(%d)",p2>mstr2?",":"",j+3770,rtcm.nmsg3[j]);
+		if (rtcm->nmsg3[j]==0) continue;
+        p2+=sprintf(p2,"%s%d(%d)",p2>mstr2?",":"",j+3770,rtcm->nmsg3[j]);
 	}
-	if (rtcm.nmsg3[0]>0) {
-		sprintf(p2,"%sother(%d)",p2>mstr2?",":"",rtcm.nmsg3[0]);
+	if (rtcm->nmsg3[0]>0) {
+		sprintf(p2,"%sother(%d)",p2>mstr2?",":"",rtcm->nmsg3[0]);
 	}
 	Label->Caption="";
 	
@@ -1840,43 +1842,45 @@ void __fastcall TMonitorDialog::ShowRtcm(void)
 	Tbl->Cells[1][i++]=tstr;
 	
 	Tbl->Cells[0][i  ]="Station ID";
-	Tbl->Cells[1][i++]=s.sprintf("%d",rtcm.staid);
+	Tbl->Cells[1][i++]=s.sprintf("%d",rtcm->staid);
 	
 	Tbl->Cells[0][i  ]="Station Health";
-	Tbl->Cells[1][i++]=s.sprintf("%d",rtcm.stah);
+	Tbl->Cells[1][i++]=s.sprintf("%d",rtcm->stah);
 	
 	Tbl->Cells[0][i  ]="Sequence No";
-	Tbl->Cells[1][i++]=s.sprintf("%d",rtcm.seqno);
+	Tbl->Cells[1][i++]=s.sprintf("%d",rtcm->seqno);
 	
 	Tbl->Cells[0][i  ]="RTCM Special Message";
-	Tbl->Cells[1][i++]=rtcm.msg;
+	Tbl->Cells[1][i++]=rtcm->msg;
 	
 	Tbl->Cells[0][i  ]="Last Message";
-	Tbl->Cells[1][i++]=rtcm.msgtype;
+	Tbl->Cells[1][i++]=rtcm->msgtype;
 	
 	Tbl->Cells[0][i  ]="# of RTCM Messages";
 	Tbl->Cells[1][i++]=format==STRFMT_RTCM2?mstr1:mstr2;
 	
 	Tbl->Cells[0][i  ]="MSM Signals for GPS";
-	Tbl->Cells[1][i++]=rtcm.msmtype[0];
+	Tbl->Cells[1][i++]=rtcm->msmtype[0];
 	
 	Tbl->Cells[0][i  ]="MSM Signals for GLONASS";
-	Tbl->Cells[1][i++]=rtcm.msmtype[1];
+	Tbl->Cells[1][i++]=rtcm->msmtype[1];
 	
 	Tbl->Cells[0][i  ]="MSM Signals for Galileo";
-	Tbl->Cells[1][i++]=rtcm.msmtype[2];
+	Tbl->Cells[1][i++]=rtcm->msmtype[2];
 	
 	Tbl->Cells[0][i  ]="MSM Signals for QZSS";
-	Tbl->Cells[1][i++]=rtcm.msmtype[3];
+	Tbl->Cells[1][i++]=rtcm->msmtype[3];
 	
 	Tbl->Cells[0][i  ]="MSM Signals for SBAS";
-	Tbl->Cells[1][i++]=rtcm.msmtype[4];
+	Tbl->Cells[1][i++]=rtcm->msmtype[4];
 	
 	Tbl->Cells[0][i  ]="MSM Signals for BDS";
-	Tbl->Cells[1][i++]=rtcm.msmtype[5];
+	Tbl->Cells[1][i++]=rtcm->msmtype[5];
 	
 	Tbl->Cells[0][i  ]="MSM Signals for NavIC";
-	Tbl->Cells[1][i++]=rtcm.msmtype[6];
+	Tbl->Cells[1][i++]=rtcm->msmtype[6];
+
+    free(rtcm);
 }
 //---------------------------------------------------------------------------
 void __fastcall TMonitorDialog::SetRtcmDgps(void)


### PR DESCRIPTION
This code appears to have used a static allocation to work around the large size of the rtcm_t structure.  The data is temporary and local to this function and thread so perhaps it's cleaner to just allocate it on the heap.

This was likely a hack to work around the large size of the rtcm_t structure, and the data is local to this function and need not be statically allocated.