### PR TITLE
rtkrcv show ssr: support rtcm streams as a source

### DIFF
--- a/app/consapp/rtkrcv/rtkrcv.c
+++ b/app/consapp/rtkrcv/rtkrcv.c
@@ -152,7 +152,7 @@ static const char *helptxt[]={
     "observ [-n] [cycle]   : show observation data",
     "navidata [cycle]      : show navigation data",
     "stream [cycle]        : show stream status",
-    "ssr [-c] [-p] [cycle] : show ssr corrections",
+    "ssr [-[1,2,3]] [-c] [-p] [cycle] : show ssr corrections",
     "error                 : show error/warning messages",
     "option [opt]          : show option(s)",
     "set opt [val]         : set option",
@@ -1042,7 +1042,7 @@ static void prstream(vt_t *vt)
     }
 }
 /* print ssr correction ------------------------------------------------------*/
-static void prssr(vt_t *vt, int cbias, int pbias)
+static void prssr(vt_t *vt, int ri, int cbias, int pbias)
 {
     static char buff[128*MAXSAT];
     gtime_t time;
@@ -1053,7 +1053,10 @@ static void prssr(vt_t *vt, int cbias, int pbias)
     rtksvrlock(&svr);
     time=svr.rtk.sol.time;
     for (i=0;i<MAXSAT;i++) {
-        ssr[i]=svr.nav.ssr[i];
+      if (ri <= 0 || ri > 3)
+        ssr[i] = svr.nav.ssr[i];
+      else
+        ssr[i] = svr.rtcm[ri - 1].ssr[i];
     }
     rtksvrunlock(&svr);
     
@@ -1242,8 +1245,9 @@ static void cmd_ssr(char **args, int narg, vt_t *vt)
     trace(3,"cmd_ssr:\n");
     
     int cycle = 0;
-    int cbias = 0, pbias = 0;
+    int ri = 0, cbias = 0, pbias = 0;
     for (int i = 1; i < narg; i++) {
+      if (sscanf(args[i], "-%d", &ri) == 1) continue;
       if (strcmp(args[i], "-c") == 0) {
         cbias = 1;
         continue;
@@ -1257,7 +1261,7 @@ static void cmd_ssr(char **args, int narg, vt_t *vt)
 
     while (!vt_chkbrk(vt)) {
         if (cycle>0) vt_printf(vt,ESC_CLEAR);
-        prssr(vt, cbias, pbias);
+        prssr(vt, ri, cbias, pbias);
         if (cycle>0) sleepms(cycle); else return;
     }
     vt_printf(vt,"\n");
@@ -1793,10 +1797,11 @@ static void deamonise(void)
 *     stream [cycle]
 *       Show stream status. Use option cycle for cyclic display.
 *
-*     ssr [-c] [-p] [cycle]
-*       Show the RTCM SSR state, with option -c to include code biases and
-*       with option -p to include phase biases. Use option cycle for cyclic
-*       display.
+*     ssr [-[1,2,3]] [-c] [-p] [cycle]
+*       Show the RTCM SSR state. Option -1 -2 or -3 selects the respective
+*       input, output, or correction RTCM stream index otherwise the combined
+*       ssr state is used. Option -c includes code biases and option -p
+*       includes phase biases. Use option cycle for cyclic display.
 *
 *     error
 *       Show error/warning messages. To stop messages, send break (ctr-C).


### PR DESCRIPTION
helps compare the ssr data available vs that copied over.