### PR TITLE
rtcm init: initialize glo_fcn

### DIFF
--- a/src/rtcm.c
+++ b/src/rtcm.c
@@ -129,6 +129,7 @@ extern int init_rtcm(rtcm_t *rtcm)
       for (int i = 0; i < MAXPRNGLO; i++) rtcm->nav.geph[i] = geph0;
     }
     rtcm->nav.ng = rtcm->nav.ngmax = MAXPRNGLO;
+    for (int i = 0; i < 32; i++) rtcm->nav.glo_fcn[i] = 0;
 
     return 1;
 }


### PR DESCRIPTION
Saw an issue with this state being used uninitialized.