### PR TITLE
qtapp: avoid input unit suffix

### DIFF
--- a/app/qtapp/appcmn_qt/fileoptdlg.ui
+++ b/app/qtapp/appcmn_qt/fileoptdlg.ui
@@ -142,10 +142,7 @@
      <item>
       <widget class="QDoubleSpinBox" name="sBTimeStart">
        <property name="toolTip">
-        <string>Start time</string>
-       </property>
-       <property name="suffix">
-        <string> s</string>
+        <string>Start time (s)</string>
        </property>
        <property name="maximum">
         <double>10000.000000000000000</double>

--- a/app/qtapp/appcmn_qt/ftpoptdlg.ui
+++ b/app/qtapp/appcmn_qt/ftpoptdlg.ui
@@ -280,10 +280,7 @@
       <item row="3" column="1">
        <widget class="QSpinBox" name="sBRetryInterval">
         <property name="toolTip">
-         <string>Time between retries if download fails.</string>
-        </property>
-        <property name="suffix">
-         <string> s</string>
+         <string>Time (s) between retries if download fails.</string>
         </property>
         <property name="maximum">
          <number>10000</number>

--- a/app/qtapp/appcmn_qt/maskoptdlg.ui
+++ b/app/qtapp/appcmn_qt/maskoptdlg.ui
@@ -19,12 +19,6 @@
      <property name="toolTip">
       <string/>
      </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
-     </property>
      <property name="maximum">
       <double>90.000000000000000</double>
      </property>
@@ -48,12 +42,6 @@
      <property name="toolTip">
       <string/>
      </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
-     </property>
      <property name="maximum">
       <double>90.000000000000000</double>
      </property>
@@ -63,12 +51,6 @@
     <widget class="QDoubleSpinBox" name="sBMask_1_1">
      <property name="toolTip">
       <string>Apply mask to base station</string>
-     </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
      </property>
      <property name="maximum">
       <double>90.000000000000000</double>
@@ -80,12 +62,6 @@
      <property name="toolTip">
       <string/>
      </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
-     </property>
      <property name="maximum">
       <double>90.000000000000000</double>
      </property>
@@ -95,12 +71,6 @@
     <widget class="QDoubleSpinBox" name="sBMask_2_3">
      <property name="toolTip">
       <string/>
-     </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
      </property>
      <property name="maximum">
       <double>90.000000000000000</double>
@@ -125,12 +95,6 @@
      <property name="toolTip">
       <string/>
      </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
-     </property>
      <property name="maximum">
       <double>90.000000000000000</double>
      </property>
@@ -140,12 +104,6 @@
     <widget class="QDoubleSpinBox" name="sBMask_3_4">
      <property name="toolTip">
       <string/>
-     </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
      </property>
      <property name="maximum">
       <double>90.000000000000000</double>
@@ -170,12 +128,6 @@
      <property name="toolTip">
       <string/>
      </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
-     </property>
      <property name="maximum">
       <double>90.000000000000000</double>
      </property>
@@ -185,12 +137,6 @@
     <widget class="QDoubleSpinBox" name="sBMask_3_6">
      <property name="toolTip">
       <string/>
-     </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
      </property>
      <property name="maximum">
       <double>90.000000000000000</double>
@@ -202,12 +148,6 @@
      <property name="toolTip">
       <string/>
      </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
-     </property>
      <property name="maximum">
       <double>90.000000000000000</double>
      </property>
@@ -217,12 +157,6 @@
     <widget class="QDoubleSpinBox" name="sBMask_1_4">
      <property name="toolTip">
       <string/>
-     </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
      </property>
      <property name="maximum">
       <double>90.000000000000000</double>
@@ -234,12 +168,6 @@
      <property name="toolTip">
       <string/>
      </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
-     </property>
      <property name="maximum">
       <double>90.000000000000000</double>
      </property>
@@ -250,12 +178,6 @@
      <property name="toolTip">
       <string/>
      </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
-     </property>
      <property name="maximum">
       <double>90.000000000000000</double>
      </property>
@@ -265,12 +187,6 @@
     <widget class="QDoubleSpinBox" name="sBMask_1_2">
      <property name="toolTip">
       <string/>
-     </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
      </property>
      <property name="maximum">
       <double>90.000000000000000</double>
@@ -295,12 +211,6 @@
      <property name="toolTip">
       <string/>
      </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
-     </property>
      <property name="maximum">
       <double>90.000000000000000</double>
      </property>
@@ -310,12 +220,6 @@
     <widget class="QDoubleSpinBox" name="sBMask_2_4">
      <property name="toolTip">
       <string/>
-     </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
      </property>
      <property name="maximum">
       <double>90.000000000000000</double>
@@ -327,12 +231,6 @@
      <property name="toolTip">
       <string/>
      </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
-     </property>
      <property name="maximum">
       <double>90.000000000000000</double>
      </property>
@@ -342,12 +240,6 @@
     <widget class="QDoubleSpinBox" name="sBMask_3_3">
      <property name="toolTip">
       <string/>
-     </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
      </property>
      <property name="maximum">
       <double>90.000000000000000</double>
@@ -401,12 +293,6 @@
      <property name="toolTip">
       <string/>
      </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
-     </property>
      <property name="maximum">
       <double>90.000000000000000</double>
      </property>
@@ -416,12 +302,6 @@
     <widget class="QDoubleSpinBox" name="sBMask_1_3">
      <property name="toolTip">
       <string/>
-     </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
      </property>
      <property name="maximum">
       <double>90.000000000000000</double>
@@ -459,12 +339,6 @@
      <property name="toolTip">
       <string/>
      </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
-     </property>
      <property name="maximum">
       <double>90.000000000000000</double>
      </property>
@@ -474,12 +348,6 @@
     <widget class="QDoubleSpinBox" name="sBMask_3_7">
      <property name="toolTip">
       <string/>
-     </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
      </property>
      <property name="maximum">
       <double>90.000000000000000</double>
@@ -491,12 +359,6 @@
      <property name="toolTip">
       <string/>
      </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
-     </property>
      <property name="maximum">
       <double>90.000000000000000</double>
      </property>
@@ -507,12 +369,6 @@
      <property name="toolTip">
       <string/>
      </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
-     </property>
      <property name="maximum">
       <double>90.000000000000000</double>
      </property>
@@ -522,12 +378,6 @@
     <widget class="QDoubleSpinBox" name="sBMask_2_9">
      <property name="toolTip">
       <string/>
-     </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
      </property>
      <property name="maximum">
       <double>90.000000000000000</double>
@@ -606,12 +456,6 @@
      <property name="toolTip">
       <string/>
      </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
-     </property>
      <property name="maximum">
       <double>90.000000000000000</double>
      </property>
@@ -637,12 +481,6 @@
     <widget class="QDoubleSpinBox" name="sBMask_3_1">
      <property name="toolTip">
       <string/>
-     </property>
-     <property name="text" stdset="0">
-      <string>0,00 dBHz</string>
-     </property>
-     <property name="suffix">
-      <string> dBHz</string>
      </property>
      <property name="maximum">
       <double>90.000000000000000</double>

--- a/app/qtapp/appcmn_qt/navi_post_opt.cpp
+++ b/app/qtapp/appcmn_qt/navi_post_opt.cpp
@@ -1934,22 +1934,22 @@ void OptDialog::setPosition(int type, QLineEdit **edit, const double *pos)
         edit[2]->setText(QStringLiteral("%1 m").arg(QLocale().toString(p[2], 'f', 4)));
 
     } else if (type == 2) { /* x/y/z-ecef */
-        edit[0]->setValidator(new DoubleUnitValidator(-INFINITY, INFINITY, -1, " m", this));
-        edit[1]->setValidator(new DoubleUnitValidator(-INFINITY, INFINITY, -1, " m", this));
-        edit[2]->setValidator(new DoubleUnitValidator(-INFINITY, INFINITY, -1, " m", this));
+        edit[0]->setValidator(new DoubleUnitValidator(-INFINITY, INFINITY, -1, "", this));
+        edit[1]->setValidator(new DoubleUnitValidator(-INFINITY, INFINITY, -1, "", this));
+        edit[2]->setValidator(new DoubleUnitValidator(-INFINITY, INFINITY, -1, "", this));
 
-        edit[0]->setText(QStringLiteral("%1 m").arg(QLocale().toString(pos[0], 'f', 4)));
-        edit[1]->setText(QStringLiteral("%1 m").arg(QLocale().toString(pos[1], 'f', 4)));
-        edit[2]->setText(QStringLiteral("%1 m").arg(QLocale().toString(pos[2], 'f', 4)));
+        edit[0]->setText(QStringLiteral("%1").arg(QLocale().toString(pos[0], 'f', 4)));
+        edit[1]->setText(QStringLiteral("%1").arg(QLocale().toString(pos[1], 'f', 4)));
+        edit[2]->setText(QStringLiteral("%1").arg(QLocale().toString(pos[2], 'f', 4)));
     } else {   /* lat/lon/hight decimal */
-        edit[0]->setValidator(new DoubleUnitValidator(-90, 90, -1, "°", this));
-        edit[1]->setValidator(new DoubleUnitValidator(-180, 180, -1, "°", this));
-        edit[2]->setValidator(new DoubleUnitValidator(-100, 10000, -1, " m", this));
+        edit[0]->setValidator(new DoubleUnitValidator(-90, 90, -1, "", this));
+        edit[1]->setValidator(new DoubleUnitValidator(-180, 180, -1, "", this));
+        edit[2]->setValidator(new DoubleUnitValidator(-100, 10000, -1, "", this));
 
         ecef2pos(pos, p);
-        edit[0]->setText(QStringLiteral("%1°").arg(QLocale().toString(p[0] * R2D, 'f', 9)));
-        edit[1]->setText(QStringLiteral("%1°").arg(QLocale().toString(p[1] * R2D, 'f', 9)));
-        edit[2]->setText(QStringLiteral("%1 m").arg(QLocale().toString(p[2], 'f', 4)));
+        edit[0]->setText(QStringLiteral("%1").arg(QLocale().toString(p[0] * R2D, 'f', 14)));
+        edit[1]->setText(QStringLiteral("%1").arg(QLocale().toString(p[1] * R2D, 'f', 14)));
+        edit[2]->setText(QStringLiteral("%1").arg(QLocale().toString(p[2], 'f', 4)));
     }
 }
 //---------------------------------------------------------------------------

--- a/app/qtapp/appcmn_qt/navi_post_opt.ui
+++ b/app/qtapp/appcmn_qt/navi_post_opt.ui
@@ -703,7 +703,7 @@
           <number>3</number>
          </property>
          <property name="value">
-          <double>3.000000000000000</double>
+          <double>3.000</double>
          </property>
         </widget>
        </item>
@@ -737,16 +737,13 @@
        <item row="16" column="3" colspan="2">
         <widget class="QDoubleSpinBox" name="sBBaselineSig">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Define the standard deviation of the baseline length constraint in moving‐base mode (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-basesig).&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="suffix">
-          <string> m</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Define the standard deviation (m) of the baseline length constraint in moving‐base mode (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-basesig).&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="decimals">
-          <number>3</number>
+          <number>4</number>
          </property>
          <property name="maximum">
-          <double>1000000.000000000000000</double>
+          <double>1000000.0000</double>
          </property>
         </widget>
        </item>
@@ -763,16 +760,13 @@
        <item row="18" column="1" colspan="2">
         <widget class="QDoubleSpinBox" name="sBMaxPositionVarAR">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Maximum position variance for ambiguity resolution (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-arthres1&lt;/span&gt;).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="suffix">
-          <string> m</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Maximum position variance (m^2) for ambiguity resolution (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-arthres1&lt;/span&gt;).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="decimals">
           <number>4</number>
          </property>
          <property name="value">
-          <double>0.004000000000000</double>
+          <double>0.0040</double>
          </property>
         </widget>
        </item>
@@ -789,10 +783,7 @@
        <item row="5" column="1" colspan="2">
         <widget class="QSpinBox" name="sBLockCountFixAmbiguity">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Define the minimum lock count to fix integer ambiguity. If the lock count is less than the value, the ambiguity is excluded from the fixed integer vector (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-arlockcnt&lt;/span&gt;).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="suffix">
-          <string> s</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Define the minimum lock count to fix integer ambiguity (s). If the lock count is less than the value, the ambiguity is excluded from the fixed integer vector (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-arlockcnt&lt;/span&gt;).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="maximum">
           <number>3600</number>
@@ -822,16 +813,13 @@
        <item row="16" column="1">
         <widget class="QDoubleSpinBox" name="sBBaselineLen">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Define the constraint of the baseline length in moving‐base mode (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-baselen).&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="suffix">
-          <string> m</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Define the constraint of the baseline length (m) in moving‐base mode (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-baselen).&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="decimals">
-          <number>3</number>
+          <number>4</number>
          </property>
          <property name="maximum">
-          <double>1000000.000000000000000</double>
+          <double>1000000.0000</double>
          </property>
         </widget>
        </item>
@@ -855,16 +843,13 @@
        <item row="9" column="3" colspan="2">
         <widget class="QDoubleSpinBox" name="sBSlipThreshold">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Define the cycle‐slip threshold of geometry‐free LC carrier‐phase difference between epochs (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-slipthres&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="suffix">
-          <string> m</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Define the cycle‐slip threshold of geometry‐free LC carrier‐phase difference (m) between epochs (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-slipthres&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="decimals">
-          <number>3</number>
+          <number>4</number>
          </property>
          <property name="value">
-          <double>0.050000000000000</double>
+          <double>0.0500</double>
          </property>
         </widget>
        </item>
@@ -894,35 +879,29 @@
        <item row="11" column="1" colspan="2">
         <widget class="QDoubleSpinBox" name="sBMaxAgeDifferences">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Define the maximum value of age of differential between the rover and the base station (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-maxage&lt;/span&gt;) &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="suffix">
-          <string> s</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Define the maximum value of age of differential (s) between the rover and the base station (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-maxage&lt;/span&gt;) &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="decimals">
           <number>1</number>
          </property>
          <property name="maximum">
-          <double>3600.000000000000000</double>
+          <double>3600.0</double>
          </property>
          <property name="value">
-          <double>30.000000000000000</double>
+          <double>30.0</double>
          </property>
         </widget>
        </item>
        <item row="5" column="3" colspan="2">
         <widget class="QDoubleSpinBox" name="sBElevationMaskAR">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Define the minimum elevation angle to fix integer ambiguity. If the elevation angle is less than the value, the ambiguity is excluded from the fixed integer vector (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-arelmask&lt;/span&gt;).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="suffix">
-          <string>°</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Define the minimum elevation angle (deg) to fix integer ambiguity. If the elevation angle is less than the value, the ambiguity is excluded from the fixed integer vector (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-arelmask&lt;/span&gt;).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="decimals">
           <number>0</number>
          </property>
          <property name="maximum">
-          <double>90.000000000000000</double>
+          <double>90</double>
          </property>
         </widget>
        </item>
@@ -958,9 +937,6 @@
          <property name="toolTip">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the cycle-slip threshold (Hz) of difference between doppler and carrier phase difference between epochs, 0 = disabled (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-dopthres).&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
-         <property name="suffix">
-          <string> Hz</string>
-         </property>
          <property name="decimals">
           <number>3</number>
          </property>
@@ -971,30 +947,24 @@
          <property name="toolTip">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set relative GLONASS hardware bias in meters per frequency slot. Used only when pos2-gloarmode is&lt;/p&gt;&lt;p&gt;set to “autocal” and is used to specify the interchannel bias between two different receiver manufacturers  (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-arthres2&lt;/span&gt;).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
-         <property name="suffix">
-          <string> m</string>
-         </property>
          <property name="decimals">
-          <number>3</number>
+          <number>4</number>
          </property>
         </widget>
        </item>
        <item row="13" column="1" colspan="2">
         <widget class="QDoubleSpinBox" name="sBRejectCode">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the reject threshold of GDOP (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-rejgdop&lt;/span&gt;). &lt;/p&gt;&lt;p&gt;If the GDOP is over the value, the observable is excluded for the estimation process as an outlier.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="suffix">
-          <string> m</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the reject threshold (m) of GDOP (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-rejgdop&lt;/span&gt;). &lt;/p&gt;&lt;p&gt;If the GDOP is over the value, the observable is excluded for the estimation process as an outlier.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="decimals">
           <number>2</number>
          </property>
          <property name="maximum">
-          <double>1000.000000000000000</double>
+          <double>1000.00</double>
          </property>
          <property name="value">
-          <double>30.000000000000000</double>
+          <double>30.00</double>
          </property>
         </widget>
        </item>
@@ -1088,19 +1058,16 @@
        <item row="7" column="3" colspan="2">
         <widget class="QDoubleSpinBox" name="sBElevationMaskHold">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Define the minimum elevation angle to hold ambiguity in ʺFix and Holdʺ integer ambiguity resolution mode (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-elmaskhold&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="suffix">
-          <string>°</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Define the minimum elevation angle (deg) to hold ambiguity in ʺFix and Holdʺ integer ambiguity resolution mode (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-elmaskhold&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="decimals">
           <number>0</number>
          </property>
          <property name="maximum">
-          <double>90.000000000000000</double>
+          <double>90</double>
          </property>
          <property name="value">
-          <double>10.000000000000000</double>
+          <double>10</double>
          </property>
         </widget>
        </item>
@@ -1120,17 +1087,14 @@
           <number>3</number>
          </property>
          <property name="value">
-          <double>3.000000000000000</double>
+          <double>3.000</double>
          </property>
         </widget>
        </item>
        <item row="7" column="1" colspan="2">
         <widget class="QSpinBox" name="sBFixCountHoldAmbiguity">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Define the minimum fix count to hold ambiguity in &amp;quot;Fix and Hold&amp;quot; integer ambiguity resolution mode (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-arminfix&lt;/span&gt;).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="suffix">
-          <string> s</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Define the minimum (s) fix count to hold ambiguity in &amp;quot;Fix and Hold&amp;quot; integer ambiguity resolution mode (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-arminfix&lt;/span&gt;).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="maximum">
           <number>1000</number>
@@ -1143,19 +1107,16 @@
        <item row="13" column="3" colspan="2">
         <widget class="QDoubleSpinBox" name="sBRejectPhase">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the reject threshold of the kalman filter innovations (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-rejionn&lt;/span&gt;). &lt;/p&gt;&lt;p&gt;If the carrier phase innovation is over the value, the observable is excluded for the estimation process as an outlier. The innovation threshold is multiplied by the carrier phase/pseudorange error ratio to generate the threshold for pseudorange innovations.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="suffix">
-          <string> m</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the reject threshold (m) of the kalman filter innovations (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-rejionn&lt;/span&gt;). &lt;/p&gt;&lt;p&gt;If the carrier phase innovation is over the value, the observable is excluded for the estimation process as an outlier. The innovation threshold is multiplied by the carrier phase/pseudorange error ratio to generate the threshold for pseudorange innovations.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="decimals">
           <number>2</number>
          </property>
          <property name="maximum">
-          <double>1000.000000000000000</double>
+          <double>1000.00</double>
          </property>
          <property name="value">
-          <double>30.000000000000000</double>
+          <double>30.00</double>
          </property>
         </widget>
        </item>
@@ -1178,7 +1139,7 @@
           <number>3</number>
          </property>
          <property name="value">
-          <double>3.000000000000000</double>
+          <double>3.000</double>
          </property>
         </widget>
        </item>
@@ -1205,10 +1166,7 @@
        <item row="11" column="3" colspan="2">
         <widget class="QSpinBox" name="sBOutageCountResetAmbiguity">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the outage count to reset ambiguity. If the data outage count is over the value, the estimated ambiguity is reset to the initial value (option &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-aroutcnt).&lt;/span&gt;&lt;span style=&quot; font-family:'monospace';&quot;&gt;&lt;br/&gt;&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="suffix">
-          <string> epochs</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the outage count (epochs) to reset ambiguity. If the data outage count is over the value, the estimated ambiguity is reset to the initial value (option &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-aroutcnt).&lt;/span&gt;&lt;span style=&quot; font-family:'monospace';&quot;&gt;&lt;br/&gt;&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </widget>
        </item>
@@ -1232,10 +1190,7 @@
        <item row="20" column="1" colspan="2">
         <widget class="QDoubleSpinBox" name="sBVarHoldAmb">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set variance for ambiguity hold feedback. Acts asinverse ambiguity tracking gain (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-varholdamb&lt;/span&gt;).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="suffix">
-          <string> m</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set variance (m^2) for ambiguity hold feedback. Acts asinverse ambiguity tracking gain (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-varholdamb&lt;/span&gt;).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="decimals">
           <number>4</number>
@@ -1291,8 +1246,8 @@
        </item>
        <item row="7" column="3">
         <widget class="QDoubleSpinBox" name="sBMaxSolutionStd">
-         <property name="suffix">
-          <string> m</string>
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(m);&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </widget>
        </item>
@@ -1442,10 +1397,7 @@
        <item row="12" column="1" colspan="2">
         <widget class="QDoubleSpinBox" name="sBNmeaInterval1">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify the output interval of NMEA GPRMC, GPGGA messages (option: &lt;span style=&quot; font-style:italic;&quot;&gt;out-nmeaintv1&lt;/span&gt;) &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="suffix">
-          <string> s</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify the output interval (s) of NMEA GPRMC, GPGGA messages (option: &lt;span style=&quot; font-style:italic;&quot;&gt;out-nmeaintv1&lt;/span&gt;) &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </widget>
        </item>
@@ -1571,10 +1523,7 @@
        <item row="12" column="3">
         <widget class="QDoubleSpinBox" name="sBNmeaInterval2">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify the output interval of NMEA GPGSA, GLGSA,GAGSA, GPGSV, GLGSV, GAGSV messages (option: &lt;span style=&quot; font-style:italic;&quot;&gt;out-nmeaintv2&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="suffix">
-          <string> s</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify the output interval (s) of NMEA GPGSA, GLGSA,GAGSA, GPGSV, GLGSV, GAGSV messages (option: &lt;span style=&quot; font-style:italic;&quot;&gt;out-nmeaintv2&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="value">
           <double>1.000000000000000</double>
@@ -1752,10 +1701,7 @@
           <item row="0" column="1">
            <widget class="ScientificSpinBox" name="sBSatelliteClockStability">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the satellite clock stability (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-clkstab&lt;/span&gt;) &lt;/p&gt;&lt;p&gt;The value is used for interpolation of base-station observables.&lt;/p&gt;&lt;p&gt;Unit: s/s&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="suffix">
-             <string> s/s</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the satellite clock stability (s/s) (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-clkstab&lt;/span&gt;) &lt;/p&gt;&lt;p&gt;The value is used for interpolation of base-station observables.&lt;/p&gt;&lt;p&gt;Unit: s/s&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="minimum">
              <double>-1.000000000000000</double>
@@ -1817,10 +1763,7 @@
           <item row="0" column="1">
            <widget class="ScientificSpinBox" name="sBProcessNoise4">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the process noise standard deviation of the receiver acceleration as the horizontal component (&lt;span style=&quot; font-style:italic;&quot;&gt;stats-prnaccelh&lt;/span&gt;).&lt;/p&gt;&lt;p&gt;If receiver dynamics is set to OFF, they are not used.&lt;/p&gt;&lt;p&gt;Unit: m/s2/sqrt(s)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="suffix">
-             <string> m/s²</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the process noise standard deviation (m/s²) of the receiver acceleration as the horizontal component (&lt;span style=&quot; font-style:italic;&quot;&gt;stats-prnaccelh&lt;/span&gt;).&lt;/p&gt;&lt;p&gt;If receiver dynamics is set to OFF, they are not used.&lt;/p&gt;&lt;p&gt;Unit: m/s2/sqrt(s)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="maximum">
              <double>100.000000000000000</double>
@@ -1830,10 +1773,7 @@
           <item row="0" column="2">
            <widget class="ScientificSpinBox" name="sBProcessNoise5">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the process noise standard deviation of the receiver acceleration as the vertical component (&lt;span style=&quot; font-style:italic;&quot;&gt;stats-prnaccelv&lt;/span&gt;).&lt;/p&gt;&lt;p&gt;If receiver dynamics is set to OFF, they are not used.&lt;/p&gt;&lt;p&gt;Unit: m/s2/sqrt(s)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="suffix">
-             <string> m/s²</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the process noise standard deviation (m/s²) of the receiver acceleration as the vertical component (&lt;span style=&quot; font-style:italic;&quot;&gt;stats-prnaccelv&lt;/span&gt;).&lt;/p&gt;&lt;p&gt;If receiver dynamics is set to OFF, they are not used.&lt;/p&gt;&lt;p&gt;Unit: m/s2/sqrt(s)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="maximum">
              <double>100.000000000000000</double>
@@ -1843,10 +1783,7 @@
           <item row="1" column="1" colspan="2">
            <widget class="ScientificSpinBox" name="sBProcessNoise1">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the process noise standard deviation of carrier-phase bias/ambiguity (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-prnbias&lt;/span&gt;)&lt;/p&gt;&lt;p&gt;Unit: cycle/sqrt(s).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="suffix">
-             <string> cycles</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the process noise standard deviation (cycles) of carrier-phase bias/ambiguity (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-prnbias&lt;/span&gt;)&lt;/p&gt;&lt;p&gt;Unit: cycle/sqrt(s).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="minimum">
              <double>-100.000000000000000</double>
@@ -1859,10 +1796,7 @@
           <item row="2" column="1" colspan="2">
            <widget class="ScientificSpinBox" name="sBProcessNoise2">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the process noise standard deviation of vertical ionospheric delay per 10 km baseline (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-prniono&lt;/span&gt;)&lt;/p&gt;&lt;p&gt;Unit: m/sqrt(s).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="suffix">
-             <string> m/10km</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the process noise standard deviation (m/10km) of vertical ionospheric delay per 10 km baseline (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-prniono&lt;/span&gt;)&lt;/p&gt;&lt;p&gt;Unit: m/sqrt(s).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="minimum">
              <double>-10000.000000000000000</double>
@@ -1875,10 +1809,7 @@
           <item row="3" column="1" colspan="2">
            <widget class="ScientificSpinBox" name="sBProcessNoise3">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the process noise standard deviation of zenith tropospheric delay (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-prntrop&lt;/span&gt;)&lt;/p&gt;&lt;p&gt;Unit: m/sqrt(s).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="suffix">
-             <string> m</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the process noise standard deviation (m) of zenith tropospheric delay (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-prntrop&lt;/span&gt;)&lt;/p&gt;&lt;p&gt;Unit: m/sqrt(s).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="minimum">
              <double>-1000.000000000000000</double>
@@ -1900,10 +1831,7 @@
           <item row="8" column="1" colspan="2">
            <widget class="QDoubleSpinBox" name="sBMeasurementError5">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the standard deviation of Doppler errors (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-errdoppler)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="suffix">
-             <string> Hz</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the standard deviation (Hz) of Doppler errors (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-errdoppler)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="minimum">
              <double>-10000.000000000000000</double>
@@ -1925,10 +1853,10 @@
              <number>1</number>
             </property>
             <property name="maximum">
-             <double>10000.000000000000000</double>
+             <double>10000.0</double>
             </property>
             <property name="value">
-             <double>100.000000000000000</double>
+             <double>100.0</double>
             </property>
            </widget>
           </item>
@@ -1993,35 +1921,29 @@
           <item row="5" column="1" colspan="4">
            <widget class="QDoubleSpinBox" name="sBMeasurementError4">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the baseline-length dependent term of carrier-phase error standard deviation (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-errphasebl&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="suffix">
-             <string> m/10km</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the baseline-length dependent term (m/10km) of carrier-phase error standard deviation (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-errphasebl&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="decimals">
-             <number>3</number>
+             <number>4</number>
             </property>
            </widget>
           </item>
           <item row="3" column="3" colspan="2">
            <widget class="QDoubleSpinBox" name="sBMeasurementError3">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the elevation dependent term of carrier-phase error standard deviation (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-errphaseel&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="suffix">
-             <string> m</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the elevation dependent term of carrier-phase error standard deviation (m) (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-errphaseel&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="decimals">
              <number>3</number>
             </property>
             <property name="maximum">
-             <double>100.000000000000000</double>
+             <double>100.000</double>
             </property>
             <property name="singleStep">
-             <double>0.001000000000000</double>
+             <double>0.001</double>
             </property>
             <property name="value">
-             <double>0.003000000000000</double>
+             <double>0.003</double>
             </property>
            </widget>
           </item>
@@ -2038,22 +1960,19 @@
           <item row="3" column="1" colspan="2">
            <widget class="QDoubleSpinBox" name="sBMeasurementError2">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the base term of carrier-phase error standard deviation (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-errphase&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="suffix">
-             <string> m</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the base term of carrier-phase error standard deviation (m) (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-errphase&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="decimals">
              <number>3</number>
             </property>
             <property name="maximum">
-             <double>100.000000000000000</double>
+             <double>100.000</double>
             </property>
             <property name="singleStep">
-             <double>0.001000000000000</double>
+             <double>0.001</double>
             </property>
             <property name="value">
-             <double>0.003000000000000</double>
+             <double>0.003</double>
             </property>
            </widget>
           </item>
@@ -2110,10 +2029,7 @@
           <item row="6" column="3" colspan="2">
            <widget class="QDoubleSpinBox" name="sBMeasurementErrorSNR_Max">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the max component of the SNR dependent terms of carrier-phase error standard deviation (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-snrmax&lt;/span&gt;)&lt;/p&gt;&lt;p&gt;e * 10^(0.1*(SNR_MAX - snr))&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="suffix">
-             <string> dB</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the max component of the SNR (dB) dependent terms of carrier-phase error standard deviation (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-snrmax&lt;/span&gt;)&lt;/p&gt;&lt;p&gt;e * 10^(0.1*(SNR_MAX - snr))&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </widget>
           </item>
@@ -2168,19 +2084,16 @@
           <item row="5" column="6">
            <widget class="QDoubleSpinBox" name="sBReferenceAntennaU">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the delta position in up direction of the rover antenna as offsets of ARP (antenna reference point) position with refer to the marker (option: &lt;span style=&quot; font-style:italic;&quot;&gt;ant2-antdelu&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="suffix">
-             <string> m</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the delta position (m) in up direction of the rover antenna as offsets of ARP (antenna reference point) position with refer to the marker (option: &lt;span style=&quot; font-style:italic;&quot;&gt;ant2-antdelu&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="decimals">
              <number>4</number>
             </property>
             <property name="minimum">
-             <double>-10000.000000000000000</double>
+             <double>-10000.0000</double>
             </property>
             <property name="maximum">
-             <double>10000.000000000000000</double>
+             <double>10000.0000</double>
             </property>
            </widget>
           </item>
@@ -2217,19 +2130,16 @@
           <item row="5" column="4">
            <widget class="QDoubleSpinBox" name="sBReferenceAntennaE">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the delta position in east direction of the rover antenna as offsets of ARP (antenna reference point) position with refer to the marker (option: &lt;span style=&quot; font-style:italic;&quot;&gt;ant2-antdele&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="suffix">
-             <string> m</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the delta position (m) in east direction of the rover antenna as offsets of ARP (antenna reference point) position with refer to the marker (option: &lt;span style=&quot; font-style:italic;&quot;&gt;ant2-antdele&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="decimals">
              <number>4</number>
             </property>
             <property name="minimum">
-             <double>-100000.000000000000000</double>
+             <double>-100000.0000</double>
             </property>
             <property name="maximum">
-             <double>1000000.000000000000000</double>
+             <double>1000000.0000</double>
             </property>
            </widget>
           </item>
@@ -2278,19 +2188,16 @@
           <item row="5" column="5">
            <widget class="QDoubleSpinBox" name="sBReferenceAntennaN">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the delta position in north direction of the rover antenna as offsets of ARP (antenna reference point) position with refer to the marker (option: &lt;span style=&quot; font-style:italic;&quot;&gt;ant2-antdeln&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="suffix">
-             <string> m</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the delta position (m) in north direction of the rover antenna as offsets of ARP (antenna reference point) position with refer to the marker (option: &lt;span style=&quot; font-style:italic;&quot;&gt;ant2-antdeln&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="decimals">
              <number>4</number>
             </property>
             <property name="minimum">
-             <double>-100000.000000000000000</double>
+             <double>-100000.0000</double>
             </property>
             <property name="maximum">
-             <double>1000000.000000000000000</double>
+             <double>1000000.0000</double>
             </property>
            </widget>
           </item>
@@ -2308,9 +2215,6 @@
            <widget class="QSpinBox" name="sBMaxAveEp">
             <property name="toolTip">
              <string>Maximum averaging epochs</string>
-            </property>
-            <property name="suffix">
-             <string> epochs</string>
             </property>
             <property name="maximum">
              <number>10000</number>
@@ -2497,57 +2401,48 @@
           <item row="5" column="2">
            <widget class="QDoubleSpinBox" name="sBRoverAntennaE">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the delta position in east direction of the rover antenna as offsets of ARP (antenna reference point) position with refer to the marker (option: &lt;span style=&quot; font-style:italic;&quot;&gt;ant1-antdele&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="suffix">
-             <string> m</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the delta position (m) in east direction of the rover antenna as offsets of ARP (antenna reference point) position with refer to the marker (option: &lt;span style=&quot; font-style:italic;&quot;&gt;ant1-antdele&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="decimals">
              <number>4</number>
             </property>
             <property name="minimum">
-             <double>-1000000.000000000000000</double>
+             <double>-1000000.0000</double>
             </property>
             <property name="maximum">
-             <double>1000000.000000000000000</double>
+             <double>1000000.0000</double>
             </property>
            </widget>
           </item>
           <item row="5" column="5">
            <widget class="QDoubleSpinBox" name="sBRoverAntennaU">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the delta position in up direction of the rover antenna as offsets of ARP (antenna reference point) position with refer to the marker (option: &lt;span style=&quot; font-style:italic;&quot;&gt;ant1-antdelu&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="suffix">
-             <string> m</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the delta position (m) in up direction of the rover antenna as offsets of ARP (antenna reference point) position with refer to the marker (option: &lt;span style=&quot; font-style:italic;&quot;&gt;ant1-antdelu&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="decimals">
              <number>4</number>
             </property>
             <property name="minimum">
-             <double>-10000.000000000000000</double>
+             <double>-10000.0000</double>
             </property>
             <property name="maximum">
-             <double>10000.000000000000000</double>
+             <double>10000.0000</double>
             </property>
            </widget>
           </item>
           <item row="5" column="3" colspan="2">
            <widget class="QDoubleSpinBox" name="sBRoverAntennaN">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the delta position in north direction of the rover antenna as offsets of ARP (antenna reference point) position with refer to the marker (option: &lt;span style=&quot; font-style:italic;&quot;&gt;ant1-antdeln&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="suffix">
-             <string> m</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the delta position (m) in north direction of the rover antenna as offsets of ARP (antenna reference point) position with refer to the marker (option: &lt;span style=&quot; font-style:italic;&quot;&gt;ant1-antdeln&lt;/span&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="decimals">
              <number>4</number>
             </property>
             <property name="minimum">
-             <double>-100000.000000000000000</double>
+             <double>-100000.0000</double>
             </property>
             <property name="maximum">
-             <double>1000000.000000000000000</double>
+             <double>1000000.0000</double>
             </property>
            </widget>
           </item>
@@ -2732,9 +2627,6 @@
          <property name="toolTip">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the input message buffer size in bytes (option: &lt;span style=&quot; font-style:italic;&quot;&gt;misc-svrcycle&lt;/span&gt;).&lt;/p&gt;&lt;p&gt;Usually set it to 32768 or more.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
-         <property name="suffix">
-          <string> bytes</string>
-         </property>
          <property name="maximum">
           <number>10000000</number>
          </property>
@@ -2746,10 +2638,7 @@
        <item row="7" column="5">
         <widget class="QSpinBox" name="sBSavedSolution">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the internal log buffer size.  &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="suffix">
-          <string> epochs</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the internal log buffer size (epochs).  &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="maximum">
           <number>1000000</number>
@@ -2764,9 +2653,6 @@
          <property name="toolTip">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the processing cycle time of in ms (option: &lt;span style=&quot; font-style:italic;&quot;&gt;misc-svrcycle&lt;/span&gt;). &lt;/p&gt;&lt;p&gt;Usually set 100 ms or less value.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
-         <property name="suffix">
-          <string> ms</string>
-         </property>
          <property name="maximum">
           <number>10000</number>
          </property>
@@ -2778,10 +2664,7 @@
        <item row="5" column="4">
         <widget class="QSpinBox" name="sBNmeaCycle">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the NMEA GPGGA transmission cycle to NRTK server (option &lt;span style=&quot; font-style:italic;&quot;&gt;misc-nmeacycle&lt;/span&gt;).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="suffix">
-          <string> ms</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the NMEA GPGGA transmission cycle (ms) to NRTK server (option &lt;span style=&quot; font-style:italic;&quot;&gt;misc-nmeacycle&lt;/span&gt;).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="minimum">
           <number>1000</number>
@@ -2807,10 +2690,7 @@
        <item row="7" column="4">
         <widget class="QSpinBox" name="sBSolutionBufferSize">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the internal solution buffer size (option &lt;span style=&quot; font-style:italic;&quot;&gt;misc-buffersize&lt;/span&gt;).  &lt;/p&gt;&lt;p&gt;To increase the length of the receiver trajectory on &amp;quot;RTK Map&amp;quot;, increase the solution buffer size.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="suffix">
-          <string> epochs</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the internal solution buffer size (epochs) (option &lt;span style=&quot; font-style:italic;&quot;&gt;misc-buffersize&lt;/span&gt;).  &lt;/p&gt;&lt;p&gt;To increase the length of the receiver trajectory on &amp;quot;RTK Map&amp;quot;, increase the solution buffer size.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="maximum">
           <number>1000000</number>
@@ -2823,10 +2703,7 @@
        <item row="3" column="5">
         <widget class="QSpinBox" name="sBReconnectTime">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the re-connect interval for TCP client and NTRIP client connections (option &lt;span style=&quot; font-style:italic;&quot;&gt;misc-reconnect&lt;/span&gt;). &lt;/p&gt;&lt;p&gt;If the timeout time expired without sever response, RTKNAVI retries to connect to server after waiting for the re-connect interval.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="suffix">
-          <string> ms</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the re-connect interval (ms) for TCP client and NTRIP client connections (option &lt;span style=&quot; font-style:italic;&quot;&gt;misc-reconnect&lt;/span&gt;). &lt;/p&gt;&lt;p&gt;If the timeout time expired without sever response, RTKNAVI retries to connect to server after waiting for the re-connect interval.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="maximum">
           <number>1000000</number>
@@ -2839,10 +2716,7 @@
        <item row="5" column="5">
         <widget class="QSpinBox" name="sBFileSwapMargin">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If output or log file swap enabled, set the overlapped periods between the previous and the new output files. If you set it to 0, the periods of these files are not overlapped. &lt;/p&gt;&lt;p&gt;This feature is to avoid the missing of transient data by the output file swapping.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="suffix">
-          <string> s</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If output or log file swap enabled, set the overlapped periods (s) between the previous and the new output files. If you set it to 0, the periods of these files are not overlapped. &lt;/p&gt;&lt;p&gt;This feature is to avoid the missing of transient data by the output file swapping.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="maximum">
           <number>10000</number>
@@ -2949,10 +2823,7 @@
        <item row="3" column="4">
         <widget class="QSpinBox" name="sBTimeoutTime">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the timeout interval for TCP client and NTRIP client connections (option &lt;span style=&quot; font-style:italic;&quot;&gt;misc-timeout&lt;/span&gt;).&lt;/p&gt;&lt;p&gt;If the timeout time expired without sever response, RTKNAVI retries to connect to server after waiting for the reconnect interval.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="suffix">
-          <string> ms</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the timeout (ms) interval for TCP client and NTRIP client connections (option &lt;span style=&quot; font-style:italic;&quot;&gt;misc-timeout&lt;/span&gt;).&lt;/p&gt;&lt;p&gt;If the timeout time expired without sever response, RTKNAVI retries to connect to server after waiting for the reconnect interval.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="maximum">
           <number>1000000</number>

--- a/app/qtapp/appcmn_qt/tspandlg.ui
+++ b/app/qtapp/appcmn_qt/tspandlg.ui
@@ -67,9 +67,6 @@
    </item>
    <item row="3" column="1">
     <widget class="QDoubleSpinBox" name="sBTimeInterval">
-     <property name="suffix">
-      <string> s</string>
-     </property>
      <property name="maximum">
       <double>3600.000000000000000</double>
      </property>

--- a/app/qtapp/rtkconv_qt/convmain.ui
+++ b/app/qtapp/rtkconv_qt/convmain.ui
@@ -242,9 +242,6 @@
        </item>
        <item row="1" column="8">
         <widget class="QDoubleSpinBox" name="sBTimeUnit">
-         <property name="suffix">
-          <string> h</string>
-         </property>
          <property name="maximum">
           <double>168.000000000000000</double>
          </property>

--- a/app/qtapp/rtkconv_qt/convopt.ui
+++ b/app/qtapp/rtkconv_qt/convopt.ui
@@ -152,19 +152,16 @@
       <item>
        <widget class="QDoubleSpinBox" name="sBTimeTolerance">
         <property name="toolTip">
-         <string>Time tolerance for start and stop time</string>
-        </property>
-        <property name="suffix">
-         <string> s</string>
+         <string>Time tolerance for start and stop time (s)</string>
         </property>
         <property name="decimals">
          <number>4</number>
         </property>
         <property name="singleStep">
-         <double>0.001000000000000</double>
+         <double>0.0010</double>
         </property>
         <property name="value">
-         <double>0.005000000000000</double>
+         <double>0.0050</double>
         </property>
        </widget>
       </item>
@@ -227,16 +224,13 @@
       <item row="8" column="3">
        <widget class="QDoubleSpinBox" name="sBAntennaDelta1">
         <property name="toolTip">
-         <string>East</string>
-        </property>
-        <property name="suffix">
-         <string> m</string>
+         <string>East (m)</string>
         </property>
         <property name="decimals">
          <number>4</number>
         </property>
         <property name="minimum">
-         <double>-99.000000000000000</double>
+         <double>-99.0000</double>
         </property>
        </widget>
       </item>
@@ -301,38 +295,32 @@
       <item row="7" column="3">
        <widget class="QDoubleSpinBox" name="sBApproxPosition1">
         <property name="toolTip">
-         <string>Y</string>
-        </property>
-        <property name="suffix">
-         <string> m</string>
+         <string>Y (m)</string>
         </property>
         <property name="decimals">
          <number>4</number>
         </property>
         <property name="maximum">
-         <double>10000000.000000000000000</double>
+         <double>10000000.0000</double>
         </property>
         <property name="minimum">
-         <double>-10000000.000000000000000</double>
+         <double>-10000000.0000</double>
         </property>
        </widget>
       </item>
       <item row="7" column="2">
        <widget class="QDoubleSpinBox" name="sBApproxPosition0">
         <property name="toolTip">
-         <string>X</string>
-        </property>
-        <property name="suffix">
-         <string> m</string>
+         <string>X (m)</string>
         </property>
         <property name="decimals">
          <number>4</number>
         </property>
         <property name="maximum">
-         <double>10000000.000000000000000</double>
+         <double>10000000.0000</double>
         </property>
         <property name="minimum">
-         <double>-10000000.000000000000000</double>
+         <double>-10000000.0000</double>
         </property>
        </widget>
       </item>
@@ -346,16 +334,13 @@
       <item row="8" column="2">
        <widget class="QDoubleSpinBox" name="sBAntennaDelta0">
         <property name="toolTip">
-         <string>Height</string>
-        </property>
-        <property name="suffix">
-         <string> m</string>
+         <string>Height (m)</string>
         </property>
         <property name="decimals">
          <number>4</number>
         </property>
         <property name="minimum">
-         <double>-99.000000000000000</double>
+         <double>-99.0000</double>
         </property>
        </widget>
       </item>
@@ -396,16 +381,13 @@
       <item row="8" column="4">
        <widget class="QDoubleSpinBox" name="sBAntennaDelta2">
         <property name="toolTip">
-         <string>North</string>
-        </property>
-        <property name="suffix">
-         <string> m</string>
+         <string>North (m)</string>
         </property>
         <property name="decimals">
          <number>4</number>
         </property>
         <property name="minimum">
-         <double>-99.000000000000000</double>
+         <double>-99.0000</double>
         </property>
        </widget>
       </item>
@@ -433,19 +415,16 @@
       <item row="7" column="4">
        <widget class="QDoubleSpinBox" name="sBApproxPosition2">
         <property name="toolTip">
-         <string>Z</string>
-        </property>
-        <property name="suffix">
-         <string> m</string>
+         <string>Z (m)</string>
         </property>
         <property name="decimals">
          <number>4</number>
         </property>
         <property name="maximum">
-         <double>10000000.000000000000000</double>
+         <double>10000000.0000</double>
         </property>
         <property name="minimum">
-         <double>-10000000.000000000000000</double>
+         <double>-10000000.0000</double>
         </property>
        </widget>
       </item>

--- a/app/qtapp/rtknavi_qt/instrdlg.ui
+++ b/app/qtapp/rtknavi_qt/instrdlg.ui
@@ -88,9 +88,6 @@
       </item>
       <item row="0" column="3">
        <widget class="QDoubleSpinBox" name="sBTimeStart">
-        <property name="suffix">
-         <string> s</string>
-        </property>
         <property name="maximum">
          <double>3600.000000000000000</double>
         </property>
@@ -242,57 +239,48 @@
          <item row="0" column="3">
           <widget class="QDoubleSpinBox" name="sBNmeaPosition3">
            <property name="toolTip">
-            <string>Height to send to base station</string>
-           </property>
-           <property name="suffix">
-            <string> m</string>
+            <string>Height to send to base station (m)</string>
            </property>
            <property name="decimals">
-            <number>3</number>
+            <number>4</number>
            </property>
            <property name="minimum">
-            <double>-200.000000000000000</double>
+            <double>-200.0000</double>
            </property>
            <property name="maximum">
-            <double>8000.000000000000000</double>
+            <double>8000.0000</double>
            </property>
           </widget>
          </item>
          <item row="0" column="1">
           <widget class="QDoubleSpinBox" name="sBNmeaPosition1">
            <property name="toolTip">
-            <string>Latitude to send to base station</string>
-           </property>
-           <property name="suffix">
-            <string>°</string>
+            <string>Latitude to send to base station (deg)</string>
            </property>
            <property name="decimals">
-            <number>9</number>
+            <number>14</number>
            </property>
            <property name="minimum">
-            <double>-180.000000000000000</double>
+            <double>-180.00000000000000</double>
            </property>
            <property name="maximum">
-            <double>180.000000000000000</double>
+            <double>180.00000000000000</double>
            </property>
           </widget>
          </item>
          <item row="0" column="2">
           <widget class="QDoubleSpinBox" name="sBNmeaPosition2">
            <property name="toolTip">
-            <string>Longitude to send to base station</string>
-           </property>
-           <property name="suffix">
-            <string>°</string>
+            <string>Longitude to send to base station (deg)</string>
            </property>
            <property name="decimals">
-            <number>9</number>
+            <number>14</number>
            </property>
            <property name="minimum">
-            <double>-90.000000000000000</double>
+            <double>-90.00000000000000</double>
            </property>
            <property name="maximum">
-            <double>90.000000000000000</double>
+            <double>90.00000000000000</double>
            </property>
           </widget>
          </item>
@@ -383,16 +371,13 @@
          <item row="0" column="3">
           <widget class="QDoubleSpinBox" name="sBMaxBaseLine">
            <property name="toolTip">
-            <string>Maximum baseline which will trigger the reset command to be executed</string>
-           </property>
-           <property name="suffix">
-            <string> km</string>
+            <string>Maximum baseline (km) which will trigger the reset command to be executed</string>
            </property>
            <property name="maximum">
-            <double>99999.990000000005239</double>
+            <double>99999.99</double>
            </property>
            <property name="value">
-            <double>10.000000000000000</double>
+            <double>10.00</double>
            </property>
           </widget>
          </item>

--- a/app/qtapp/rtknavi_qt/markdlg.ui
+++ b/app/qtapp/rtknavi_qt/markdlg.ui
@@ -46,57 +46,48 @@
      <item>
       <widget class="QDoubleSpinBox" name="sBLatitude">
        <property name="toolTip">
-        <string>Latitude of marker</string>
-       </property>
-       <property name="suffix">
-        <string>°</string>
+        <string>Latitude of marker (deg)</string>
        </property>
        <property name="decimals">
-        <number>9</number>
+        <number>14</number>
        </property>
        <property name="minimum">
-        <double>-180.000000000000000</double>
+        <double>-180.00000000000000</double>
        </property>
        <property name="maximum">
-        <double>180.000000000000000</double>
+        <double>180.00000000000000</double>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QDoubleSpinBox" name="sBLongitude">
        <property name="toolTip">
-        <string>Longitude of marker</string>
-       </property>
-       <property name="suffix">
-        <string>°</string>
+        <string>Longitude of marker (deg)</string>
        </property>
        <property name="decimals">
-        <number>9</number>
+        <number>14</number>
        </property>
        <property name="minimum">
-        <double>-90.000000000000000</double>
+        <double>-90.00000000000000</double>
        </property>
        <property name="maximum">
-        <double>90.000000000000000</double>
+        <double>90.00000000000000</double>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QDoubleSpinBox" name="sBHeight">
        <property name="toolTip">
-        <string>Height of marker</string>
-       </property>
-       <property name="suffix">
-        <string> m</string>
+        <string>Height of marker (m)</string>
        </property>
        <property name="decimals">
-        <number>3</number>
+        <number>4</number>
        </property>
        <property name="minimum">
-        <double>-500.000000000000000</double>
+        <double>-500.0000</double>
        </property>
        <property name="maximum">
-        <double>9000.000000000000000</double>
+        <double>9000.0000</double>
        </property>
       </widget>
      </item>

--- a/app/qtapp/rtkplot_qt/conndlg.ui
+++ b/app/qtapp/rtkplot_qt/conndlg.ui
@@ -200,10 +200,7 @@
    <item row="6" column="3">
     <widget class="QSpinBox" name="sBTimeoutTime">
      <property name="toolTip">
-      <string>Timeout to detect inactivity</string>
-     </property>
-     <property name="suffix">
-      <string> ms</string>
+      <string>Timeout to detect inactivity (ms)</string>
      </property>
      <property name="maximum">
       <number>1000000</number>
@@ -260,10 +257,7 @@
    <item row="6" column="5">
     <widget class="QSpinBox" name="sBReconnectTime">
      <property name="toolTip">
-      <string>Timeout until reconnect</string>
-     </property>
-     <property name="suffix">
-      <string> ms</string>
+      <string>Timeout until reconnect (ms)</string>
      </property>
      <property name="maximum">
       <number>1000000</number>

--- a/app/qtapp/rtkplot_qt/mapoptdlg.ui
+++ b/app/qtapp/rtkplot_qt/mapoptdlg.ui
@@ -56,9 +56,6 @@
         <property name="toolTip">
          <string>Image width in pixel</string>
         </property>
-        <property name="suffix">
-         <string> px</string>
-        </property>
         <property name="maximum">
          <number>100000</number>
         </property>
@@ -81,9 +78,6 @@
        <widget class="QSpinBox" name="sBMapSize2">
         <property name="toolTip">
          <string>Image height in pixel</string>
-        </property>
-        <property name="suffix">
-         <string> px</string>
         </property>
         <property name="maximum">
          <number>100000</number>
@@ -127,10 +121,7 @@
       <item row="1" column="2">
        <widget class="QDoubleSpinBox" name="sBLongitude">
         <property name="toolTip">
-         <string>Longitude of map center</string>
-        </property>
-        <property name="suffix">
-         <string>°</string>
+         <string>Longitude of map center (deg)</string>
         </property>
         <property name="decimals">
          <number>9</number>
@@ -149,10 +140,7 @@
       <item row="1" column="3">
        <widget class="QDoubleSpinBox" name="sBLatitude">
         <property name="toolTip">
-         <string>Latitutde of map center</string>
-        </property>
-        <property name="suffix">
-         <string>°</string>
+         <string>Latitutde of map center (deg)</string>
         </property>
         <property name="decimals">
          <number>9</number>
@@ -193,9 +181,6 @@
         <property name="toolTip">
          <string>Scaling factor in x-direction in meter per pixel</string>
         </property>
-        <property name="suffix">
-         <string> m/px</string>
-        </property>
         <property name="decimals">
          <number>5</number>
         </property>
@@ -214,9 +199,6 @@
        <widget class="QDoubleSpinBox" name="sBScaleY">
         <property name="toolTip">
          <string>Scaling factor in y-direction in meter per pixel</string>
-        </property>
-        <property name="suffix">
-         <string> m/px</string>
         </property>
         <property name="decimals">
          <number>5</number>

--- a/app/qtapp/rtkplot_qt/plotopt.ui
+++ b/app/qtapp/rtkplot_qt/plotopt.ui
@@ -45,13 +45,10 @@
       <item row="15" column="8" colspan="3">
        <widget class="QDoubleSpinBox" name="sBReferencePosition2">
         <property name="toolTip">
-         <string>Longitude of receiver</string>
-        </property>
-        <property name="suffix">
-         <string>°</string>
+         <string>Longitude of receiver (deg)</string>
         </property>
         <property name="decimals">
-         <number>9</number>
+         <number>14</number>
         </property>
         <property name="minimum">
          <double>-180.000000000000000</double>
@@ -947,10 +944,7 @@
       <item row="15" column="11" colspan="4">
        <widget class="QDoubleSpinBox" name="sBReferencePosition3">
         <property name="toolTip">
-         <string>Height of receiver</string>
-        </property>
-        <property name="suffix">
-         <string> m</string>
+         <string>Height of receiver (m)</string>
         </property>
         <property name="decimals">
          <number>4</number>
@@ -999,10 +993,7 @@
       <item row="14" column="12" colspan="4">
        <widget class="QSpinBox" name="sBRefreshCycle">
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the plot update cycle time for real‐time plots.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="suffix">
-         <string> ms</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the plot update cycle time (ms) for real‐time plots.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="maximum">
          <number>100000</number>
@@ -1028,10 +1019,7 @@
       <item row="10" column="7">
        <widget class="QSpinBox" name="sBBufferSize">
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the buffer size for real‐time solution plots in epochs. The older solutions over the buffer size are deleted for real‐time plots.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="suffix">
-         <string> bytes</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the buffer (bytes) size for real‐time solution plots in epochs. The older solutions over the buffer size are deleted for real‐time plots.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="maximum">
          <number>1000000</number>
@@ -1690,13 +1678,10 @@
       <item row="15" column="7">
        <widget class="QDoubleSpinBox" name="sBReferencePosition1">
         <property name="toolTip">
-         <string>Latitude of receiver</string>
-        </property>
-        <property name="suffix">
-         <string>°</string>
+         <string>Latitude of receiver (deg)</string>
         </property>
         <property name="decimals">
-         <number>9</number>
+         <number>14</number>
         </property>
         <property name="minimum">
          <double>-90.000000000000000</double>

--- a/app/qtapp/rtkplot_qt/skydlg.ui
+++ b/app/qtapp/rtkplot_qt/skydlg.ui
@@ -60,10 +60,7 @@
       <item>
        <widget class="QSpinBox" name="sBSkySize1">
         <property name="toolTip">
-         <string>Sky image width</string>
-        </property>
-        <property name="suffix">
-         <string> px</string>
+         <string>Sky image width (px)</string>
         </property>
         <property name="maximum">
          <number>1000000</number>
@@ -89,10 +86,7 @@
       <item>
        <widget class="QSpinBox" name="sBSkySize2">
         <property name="toolTip">
-         <string>Sky image height</string>
-        </property>
-        <property name="suffix">
-         <string> px</string>
+         <string>Sky image height (px)</string>
         </property>
         <property name="maximum">
          <number>1000000</number>
@@ -121,10 +115,7 @@
       <item row="0" column="3">
        <widget class="QDoubleSpinBox" name="sBSkyCenter2">
         <property name="toolTip">
-         <string>Center position of sky image</string>
-        </property>
-        <property name="suffix">
-         <string> px</string>
+         <string>Center position of sky image (px)</string>
         </property>
        </widget>
       </item>
@@ -179,10 +170,7 @@
       <item row="0" column="1">
        <widget class="QDoubleSpinBox" name="sBSkyCenter1">
         <property name="toolTip">
-         <string>Center position of sky image</string>
-        </property>
-        <property name="suffix">
-         <string> px</string>
+         <string>Center position of sky image (px)</string>
         </property>
        </widget>
       </item>
@@ -205,10 +193,7 @@
       <item row="1" column="1">
        <widget class="QDoubleSpinBox" name="sBSkyFOV1">
         <property name="toolTip">
-         <string>Rotation of image along roll direction</string>
-        </property>
-        <property name="suffix">
-         <string>°</string>
+         <string>Rotation of image along roll direction (deg)</string>
         </property>
         <property name="minimum">
          <double>-180.000000000000000</double>
@@ -222,9 +207,6 @@
        <widget class="QDoubleSpinBox" name="sBSkyScale">
         <property name="toolTip">
          <string>Sky image scaling factor</string>
-        </property>
-        <property name="suffix">
-         <string/>
         </property>
         <property name="minimum">
          <double>0.000000000000000</double>
@@ -240,10 +222,7 @@
       <item row="1" column="3">
        <widget class="QDoubleSpinBox" name="sBSkyFOV2">
         <property name="toolTip">
-         <string>Rotation of image along pitch direction</string>
-        </property>
-        <property name="suffix">
-         <string>°</string>
+         <string>Rotation of image along pitch direction (deg)</string>
         </property>
         <property name="minimum">
          <double>-180.000000000000000</double>
@@ -288,10 +267,7 @@
       <item row="1" column="5">
        <widget class="QDoubleSpinBox" name="sBSkyFOV3">
         <property name="toolTip">
-         <string>Rotation of image along yaw direction</string>
-        </property>
-        <property name="suffix">
-         <string>°</string>
+         <string>Rotation of image along yaw direction (deg)</string>
         </property>
         <property name="minimum">
          <double>-180.000000000000000</double>
@@ -375,9 +351,6 @@
         <property name="toolTip">
          <string>Distortion (1 = no distortion)</string>
         </property>
-        <property name="suffix">
-         <string/>
-        </property>
         <property name="decimals">
          <number>1</number>
         </property>
@@ -387,9 +360,6 @@
        <widget class="QDoubleSpinBox" name="sBSkyDest4">
         <property name="toolTip">
          <string>Distortion (1 = no distortion)</string>
-        </property>
-        <property name="suffix">
-         <string/>
         </property>
         <property name="decimals">
          <number>1</number>
@@ -423,9 +393,6 @@
         <property name="toolTip">
          <string>Distortion (1 = no distortion)</string>
         </property>
-        <property name="suffix">
-         <string/>
-        </property>
         <property name="decimals">
          <number>1</number>
         </property>
@@ -451,9 +418,6 @@
        <widget class="QDoubleSpinBox" name="sBSkyDest7">
         <property name="toolTip">
          <string>Distortion (1 = no distortion)</string>
-        </property>
-        <property name="suffix">
-         <string/>
         </property>
         <property name="decimals">
          <number>1</number>
@@ -481,9 +445,6 @@
         <property name="toolTip">
          <string>Distortion (1 = no distortion)</string>
         </property>
-        <property name="suffix">
-         <string/>
-        </property>
         <property name="decimals">
          <number>1</number>
         </property>
@@ -494,9 +455,6 @@
         <property name="toolTip">
          <string>Distortion (1 = no distortion)</string>
         </property>
-        <property name="suffix">
-         <string/>
-        </property>
         <property name="decimals">
          <number>1</number>
         </property>
@@ -506,9 +464,6 @@
        <widget class="QDoubleSpinBox" name="sBSkyDest6">
         <property name="toolTip">
          <string>Distortion (1 = no distortion)</string>
-        </property>
-        <property name="suffix">
-         <string/>
         </property>
         <property name="decimals">
          <number>1</number>
@@ -561,9 +516,6 @@
        <widget class="QDoubleSpinBox" name="sBSkyDest8">
         <property name="toolTip">
          <string>Distortion (1 = no distortion)</string>
-        </property>
-        <property name="suffix">
-         <string/>
         </property>
         <property name="decimals">
          <number>1</number>

--- a/app/qtapp/rtkpost_qt/kmzconv.ui
+++ b/app/qtapp/rtkpost_qt/kmzconv.ui
@@ -407,40 +407,31 @@
          </property>
          <item>
           <widget class="QDoubleSpinBox" name="sBOffset1">
-           <property name="suffix">
-            <string> m</string>
-           </property>
            <property name="decimals">
             <number>4</number>
            </property>
            <property name="maximum">
-            <double>1000.000000000000000</double>
+            <double>1000.0000</double>
            </property>
           </widget>
          </item>
          <item>
           <widget class="QDoubleSpinBox" name="sBOffset2">
-           <property name="suffix">
-            <string> m</string>
-           </property>
            <property name="decimals">
             <number>4</number>
            </property>
            <property name="maximum">
-            <double>10000.000000000000000</double>
+            <double>10000.0000</double>
            </property>
           </widget>
          </item>
          <item>
           <widget class="QDoubleSpinBox" name="sBOffset3">
-           <property name="suffix">
-            <string> m</string>
-           </property>
            <property name="decimals">
             <number>4</number>
            </property>
            <property name="maximum">
-            <double>10000.000000000000000</double>
+            <double>10000.0000</double>
            </property>
           </widget>
          </item>
@@ -468,17 +459,14 @@
       </item>
       <item row="4" column="2">
        <widget class="QDoubleSpinBox" name="sBTimeInterval">
-        <property name="suffix">
-         <string> s</string>
-        </property>
         <property name="decimals">
          <number>1</number>
         </property>
         <property name="maximum">
-         <double>100000.000000000000000</double>
+         <double>100000.0000</double>
         </property>
         <property name="value">
-         <double>1.000000000000000</double>
+         <double>1.0000</double>
         </property>
        </widget>
       </item>

--- a/app/qtapp/rtkpost_qt/postmain.ui
+++ b/app/qtapp/rtkpost_qt/postmain.ui
@@ -249,9 +249,6 @@
          </item>
          <item row="2" column="7">
           <widget class="QDoubleSpinBox" name="sBTimeUnit">
-           <property name="suffix">
-            <string> h</string>
-           </property>
            <property name="maximum">
             <double>3600.000000000000000</double>
            </property>

--- a/app/qtapp/strsvr_qt/svroptdlg.ui
+++ b/app/qtapp/strsvr_qt/svroptdlg.ui
@@ -56,10 +56,7 @@
    <item row="0" column="3">
     <widget class="QSpinBox" name="sBAveragePeriodRate">
      <property name="toolTip">
-      <string>Average time for data rate</string>
-     </property>
-     <property name="suffix">
-      <string> ms</string>
+      <string>Average time for data rate (ms)</string>
      </property>
      <property name="maximum">
       <number>1000000</number>
@@ -105,10 +102,7 @@
    <item row="4" column="1">
     <widget class="QSpinBox" name="sBDataTimeout">
      <property name="toolTip">
-      <string>Time to detect inactivity</string>
-     </property>
-     <property name="suffix">
-      <string> ms</string>
+      <string>Time to detect inactivity (ms)</string>
      </property>
      <property name="maximum">
       <number>1000000</number>
@@ -196,10 +190,7 @@
    <item row="2" column="1">
     <widget class="QSpinBox" name="sBServerCycle">
      <property name="toolTip">
-      <string>Server cycle time</string>
-     </property>
-     <property name="suffix">
-      <string> ms</string>
+      <string>Server cycle time (ms)</string>
      </property>
      <property name="maximum">
       <number>10000</number>
@@ -212,10 +203,7 @@
    <item row="6" column="1">
     <widget class="QSpinBox" name="sBReconnectInterval">
      <property name="toolTip">
-      <string>Interval to reconnect</string>
-     </property>
-     <property name="suffix">
-      <string> ms</string>
+      <string>Interval to reconnect (ms)</string>
      </property>
      <property name="maximum">
       <number>100000</number>
@@ -291,10 +279,7 @@
    <item row="0" column="1">
     <widget class="QSpinBox" name="sBServerBufferSize">
      <property name="toolTip">
-      <string>Size of the read buffer</string>
-     </property>
-     <property name="suffix">
-      <string> bytes</string>
+      <string>Size of the read buffer (bytes)</string>
      </property>
      <property name="maximum">
       <number>1000000</number>
@@ -340,10 +325,7 @@
    <item row="2" column="3">
     <widget class="QSpinBox" name="sBFileSwapMargin">
      <property name="toolTip">
-      <string>Time to switch to new file</string>
-     </property>
-     <property name="suffix">
-      <string> s</string>
+      <string>Time to switch to new file (s)</string>
      </property>
      <property name="minimum">
       <number>0</number>
@@ -373,9 +355,6 @@
     <widget class="QSpinBox" name="sBNmeaCycle">
      <property name="toolTip">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the NMEA GPGGA transmission cycle to NRTK server in ms.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="suffix">
-      <string> ms</string>
      </property>
      <property name="maximum">
       <number>100000</number>
@@ -410,19 +389,16 @@
      <item row="0" column="3">
       <widget class="QDoubleSpinBox" name="sBAntennaPos3">
        <property name="toolTip">
-        <string>Station Height</string>
-       </property>
-       <property name="suffix">
-        <string> m</string>
+        <string>Station Height (m)</string>
        </property>
        <property name="decimals">
-        <number>3</number>
+        <number>4</number>
        </property>
        <property name="minimum">
-        <double>-1000.000000000000000</double>
+        <double>-1000.0000</double>
        </property>
        <property name="maximum">
-        <double>10000.000000000000000</double>
+        <double>10000.0000</double>
        </property>
       </widget>
      </item>
@@ -445,95 +421,80 @@
      <item row="0" column="1">
       <widget class="QDoubleSpinBox" name="sBAntennaPos1">
        <property name="toolTip">
-        <string>Station Latitude</string>
-       </property>
-       <property name="suffix">
-        <string>°</string>
+        <string>Station Latitude (deg)</string>
        </property>
        <property name="decimals">
-        <number>8</number>
+        <number>14</number>
        </property>
        <property name="minimum">
-        <double>-90.000000000000000</double>
+        <double>-90.00000000000000</double>
        </property>
        <property name="maximum">
-        <double>90.000000000000000</double>
+        <double>90.00000000000000</double>
        </property>
       </widget>
      </item>
      <item row="0" column="2">
       <widget class="QDoubleSpinBox" name="sBAntennaPos2">
        <property name="toolTip">
-        <string>Station Longitude</string>
-       </property>
-       <property name="suffix">
-        <string>°</string>
+        <string>Station Longitude (deg)</string>
        </property>
        <property name="decimals">
-        <number>8</number>
+        <number>14</number>
        </property>
        <property name="minimum">
-        <double>-180.000000000000000</double>
+        <double>-180.00000000000000</double>
        </property>
        <property name="maximum">
-        <double>180.000000000000000</double>
+        <double>180.00000000000000</double>
        </property>
       </widget>
      </item>
      <item row="1" column="3">
       <widget class="QDoubleSpinBox" name="sBAntennaOffset3">
        <property name="toolTip">
-        <string>Antenna height offset</string>
-       </property>
-       <property name="suffix">
-        <string> m</string>
+        <string>Antenna height offset (m)</string>
        </property>
        <property name="decimals">
         <number>4</number>
        </property>
        <property name="minimum">
-        <double>-1000.000000000000000</double>
+        <double>-1000.0000</double>
        </property>
        <property name="maximum">
-        <double>1000.000000000000000</double>
+        <double>1000.0000</double>
        </property>
       </widget>
      </item>
      <item row="1" column="2">
       <widget class="QDoubleSpinBox" name="sBAntennaOffset2">
        <property name="toolTip">
-        <string>Antenna offset in north direction</string>
-       </property>
-       <property name="suffix">
-        <string> m</string>
+        <string>Antenna offset in north direction (m)</string>
        </property>
        <property name="decimals">
         <number>4</number>
        </property>
        <property name="minimum">
-        <double>-1000.000000000000000</double>
+        <double>-1000.0000</double>
        </property>
        <property name="maximum">
-        <double>1000.000000000000000</double>
+        <double>1000.0000</double>
        </property>
       </widget>
      </item>
      <item row="1" column="1">
       <widget class="QDoubleSpinBox" name="sBAntennaOffset1">
        <property name="toolTip">
-        <string>Antenna offset in east direction</string>
-       </property>
-       <property name="suffix">
-        <string> m</string>
+        <string>Antenna offset in east direction (m)</string>
        </property>
        <property name="decimals">
         <number>4</number>
        </property>
        <property name="minimum">
-        <double>-1000.000000000000000</double>
+        <double>-1000.0000</double>
        </property>
        <property name="maximum">
-        <double>10000.000000000000000</double>
+        <double>10000.0000</double>
        </property>
       </widget>
      </item>
@@ -625,10 +586,7 @@
    <item row="16" column="1" colspan="3">
     <widget class="QSpinBox" name="sBProgressBar">
      <property name="toolTip">
-      <string>Maximum range of input byte buffer</string>
-     </property>
-     <property name="suffix">
-      <string> kb</string>
+      <string>Maximum range of input byte buffer (kb)</string>
      </property>
      <property name="maximum">
       <number>100000</number>


### PR DESCRIPTION
Can see that a lot of effort was put into adding unit suffixes to input boxes, but personally it's frustrating to have to work around them to position a cursor to avoid them, frustrates copy and paste, and it's frustrating and error prone to have to manually copy over a value. The number of decimal places and their validation also frustrates copy and paste, e.g. copy a latitude or longitude with 14 decimal places and it just will not paste into these input boxes where they are defined for 8 or 9 decimal places, can manually count and cut just the expected number of decimal places but that's frustrating. So this is a frustrated removal of all the suffixes, and an increase in the number of decimal places to 14 for latitudes and longitudes and to 4 for many other distances to reduce validation conflicts. Just close this PR if it's not the direction you wish.

Avoid bundling a unit suffix onto numerical input boxes. While this helps presentation it frustrates copying values into these boxed. Move the units to the associate box name or help box.

Increase the number of decimal places for latitude and longitude from 9 to 14. Attempts to paste a numerical value with more decimal places would fail and this avoids this frustration, up to 14 decimal places.

For distances use 4 decimal places more consistently.