### PR TITLE
win32 thread local: correct definition

### DIFF
--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -67,7 +67,7 @@ extern "C" {
 #elif defined(__GNUC__)
 #define THREADLOCAL __thread
 #elif defined(_MSC_VER)
-#define THREADLOCAL __declspec(__thread)
+#define THREADLOCAL __declspec(thread)
 #else
 #define THREADLOCAL
 #endif


### PR DESCRIPTION
Must have got this wrong, this change works with MSVC and does not break the windows apps builds.