### PR TITLE
quieten compiler warnings

### DIFF
--- a/app/qtapp/rtknavi_qt/navimain.cpp
+++ b/app/qtapp/rtknavi_qt/navimain.cpp
@@ -142,7 +142,7 @@ MainWindow::MainWindow(QWidget *parent)
             satellitesAzimuth[i][j] = satellitesElevation[i][j] = 0.0;
             for (int k = 0; k < NFREQ; k++) {
                 validSatellites[i][j][k] = 0;
-                satellitesSNR[i][j][k] = 0;
+                satellitesSNR[i][j][k] = 0.0;
             }
         }
 
@@ -1664,7 +1664,8 @@ void MainWindow::drawSolutionPlot(QLabel *plot, int type, int freq)
 
     int w = buffer.size().width() - 2;
     int h = buffer.height() - 2;
-    int i, j, x, sat[2][MAXSAT], ns[2], snr[2][MAXSAT][NFREQ], vsat[2][MAXSAT][NFREQ];
+    int i, j, x, sat[2][MAXSAT], ns[2], vsat[2][MAXSAT][NFREQ];
+    double snr[2][MAXSAT][NFREQ];
     int topMargin = QFontMetrics(optDialog->panelFont).height()*3/2;
     double az[2][MAXSAT], el[2][MAXSAT], rr[3], pos[3];
 
@@ -1698,7 +1699,7 @@ void MainWindow::drawSolutionPlot(QLabel *plot, int type, int freq)
             for (j = 0; j < numSatellites[i]; j++) {
                 for (int k = 0; k < NFREQ; k++) {
                     validSatellites[i][j][k] = 0;
-                    satellitesSNR[i][j][k] = 0;
+                    satellitesSNR[i][j][k] = 0.0;
                 }
             }
         }
@@ -1780,7 +1781,7 @@ void MainWindow::updatePlot()
     }
 }
 // snr color ----------------------------------------------------------------
-QColor MainWindow::snrColor(int snr)
+QColor MainWindow::snrColor(double snr)
 {
     QColor color[] = {Qt::darkGreen, Color::Orange, Color::Fuchsia, Qt::blue, Qt::red, Qt::darkGray};
     uint32_t r1, g1, b1;
@@ -1788,9 +1789,9 @@ QColor MainWindow::snrColor(int snr)
     double a;
     int i;
 
-    if (snr < 25) return color[5];
-    if (snr < 27) return color[4];
-    if (snr > 47) return color[0];
+    if (snr < 25.0) return color[5];
+    if (snr < 27.0) return color[4];
+    if (snr > 47.0) return color[0];
     a = (snr - 27.5) / 5.0;
     i = static_cast<int>(a);
     a -= i;
@@ -1812,7 +1813,8 @@ void MainWindow::drawSnr(QPainter &c, int w, int h, int x0, int y0,
         QColor(128, 128, 128)
     };
     static const QColor color_sys[] = {Qt::darkGreen, Color::Orange, Color::Fuchsia, Qt::blue, Qt::red, Color::Teal, Qt::darkGray};
-    int i, j, snrIdx, sysIdx, numSystems, x1, y1, height, offset, topMargin, bottomMargin, hh, barDistance, barWidth, snr[NFREQ + 1], sysMask[7] = {0};
+    int i, j, snrIdx, sysIdx, numSystems, x1, y1, height, offset, topMargin, bottomMargin, hh, barDistance, barWidth, sysMask[7] = {0};
+    double snr[NFREQ + 1];
     char id[8], sys[] = "GREJCS", *q;
 
     trace(4, "drawSnr: w=%d h=%d x0=%d y0=%d index=%d freq=%d\n", w, h, x0, y0, index, freq);
@@ -1828,7 +1830,7 @@ void MainWindow::drawSnr(QPainter &c, int w, int h, int x0, int y0,
     for (snr[0] = MINSNR + 10; snr[0] < MAXSNR; snr[0] += 10) {
         y1 = y0 + hh - (snr[0] - MINSNR) * hh / (MAXSNR - MINSNR);
         c.drawLine(x0 + 2, y1, x0 + w - 20, y1);
-        drawText(c, x0 + w - 4, y1, QLocale().toString(snr[0]), Qt::darkGray, 2, 0);
+        drawText(c, x0 + w - 4, y1, QString::number(qRound(snr[0])), Qt::darkGray, 2, 0);
     }
 
     // draw outer box
@@ -1846,7 +1848,8 @@ void MainWindow::drawSnr(QPainter &c, int w, int h, int x0, int y0,
         satno2id(satellites[index][i], id);
         sysIdx = (q = strchr(sys, id[0])) ? (int)(q - sys) : 6;
 
-        for (j = snr[0] = 0; j < NFREQ; j++) {
+        snr[0] = 0.0;
+        for (j = 0; j < NFREQ; j++) {
             snr[j + 1] = satellitesSNR[index][i][j];
             if ((freq && freq == j + 1) || ((!freq || freq > NFREQ) && snr[j + 1] > snr[0]))
                 snr[0] = snr[j + 1];  // store max snr
@@ -1854,7 +1857,7 @@ void MainWindow::drawSnr(QPainter &c, int w, int h, int x0, int y0,
         for (j = 0; j < NFREQ + 2; j++) {
             snrIdx = j < NFREQ + 1 ? j : 0;
             offset = j < NFREQ + 1 ? 0 : 2;
-            if (snr[snrIdx] > 0) height = (snr[snrIdx] - MINSNR) * hh / (MAXSNR - MINSNR);
+            if (snr[snrIdx] > 0) height = (int)round((snr[snrIdx] - MINSNR) * hh / (MAXSNR - MINSNR));
             else height = offset;
             height = height > y1 - 2 ? y1 - 2 : (height < 0 ? 0 : height);  // limit bar from going negative or too high
 
@@ -1896,7 +1899,8 @@ void MainWindow::drawSatellites(QPainter &c, int w, int h, int x0, int y0,
     QColor color_text;
     QPoint p(w / 2, h / 2);
     double r = qMin(w * 0.95, h * 0.95) / 2, azel[MAXSAT * 2], dop[4];
-    int i, j, k, sysIdx, radius, x[MAXSAT], y[MAXSAT], snr[NFREQ + 1], nsats = 0;
+    int i, j, k, sysIdx, radius, x[MAXSAT], y[MAXSAT], nsats = 0;
+    double snr[NFREQ + 1];
     char id[8], sys[] = "GREJCIS", *q;
 
     trace(4, "drawSatellites: w=%d h=%d index=%d freq=%d\n", w, h, index, freq);
@@ -1906,7 +1910,8 @@ void MainWindow::drawSatellites(QPainter &c, int w, int h, int x0, int y0,
     // draw satellites
     for (i = 0, k = numSatellites[index] - 1; i < numSatellites[index] && i < MAXSAT; i++, k--) {
         if (satellitesElevation[index][k] <= 0.0) continue;
-        for (j = snr[0] = 0; j < NFREQ; j++) {
+        snr[0] = 0.0;
+        for (j = 0; j < NFREQ; j++) {
             snr[j + 1] = satellitesSNR[index][k][j];
             if ((freq && freq == j + 1) || ((!freq || freq > NFREQ) && snr[j + 1] > snr[0])) {
                 snr[0] = snr[j + 1]; // max snr
@@ -1915,7 +1920,7 @@ void MainWindow::drawSatellites(QPainter &c, int w, int h, int x0, int y0,
         int anyValidSatFreq = 0;
         for (int fi = 0; fi < NFREQ; fi++)
           if (validSatellites[index][k][fi]) { anyValidSatFreq = 1; break; }
-        if (anyValidSatFreq && (freq > NFREQ || snr[freq] > 0)) {
+        if (anyValidSatFreq && (freq > NFREQ || snr[freq] > 0.0)) {
             azel[nsats * 2] = satellitesAzimuth[index][k];
             azel[nsats * 2 + 1] = satellitesElevation[index][k];
             nsats++;
@@ -1930,7 +1935,7 @@ void MainWindow::drawSatellites(QPainter &c, int w, int h, int x0, int y0,
                         (freq < NFREQ + 1 ? snrColor(snr[freq]) : color_sys[sysIdx]));
         c.setPen(Qt::darkGray);
         color_text = Qt::white;
-        if (freq < NFREQ + 1 && snr[freq] <= 0) {
+        if (freq < NFREQ + 1 && snr[freq] <= 0.0) {
             c.setPen(Color::Silver);
             color_text = Color::Silver;
         }

--- a/app/qtapp/rtknavi_qt/navimain.h
+++ b/app/qtapp/rtknavi_qt/navimain.h
@@ -137,7 +137,7 @@ private:
     void showFrequenciesDialog();
     void showMaskDialog();
     void showKeyDialog();
-    QColor snrColor(int snr);
+    QColor snrColor(double snr);
 
 public:
     OptDialog *optDialog;
@@ -160,7 +160,8 @@ public:
     int monitorPortOpen;
 
     int solutionsCurrent, solutionsStart, solutionsEnd, numSatellites[2], solutionCurrentStatus;
-    int satellites[2][MAXSAT], satellitesSNR[2][MAXSAT][NFREQ], validSatellites[2][MAXSAT][NFREQ];
+    int satellites[2][MAXSAT], validSatellites[2][MAXSAT][NFREQ];
+    double satellitesSNR[2][MAXSAT][NFREQ];
     double satellitesAzimuth[2][MAXSAT], satellitesElevation[2][MAXSAT];
     gtime_t *timeStamps;
     int *solutionStatus, *numValidSatellites;

--- a/app/winapp/rtknavi/navimain.cpp
+++ b/app/winapp/rtknavi/navimain.cpp
@@ -141,7 +141,7 @@ __fastcall TMainForm::TMainForm(TComponent* Owner)
         Sat[i][j]=0;
         Az[i][j]=El[i][j]=0.0;
         for (int k=0;k<NFREQ;k++) {
-          Snr[i][j][k]=0;
+          Snr[i][j][k]=0.0;
           Vsat[i][j][k]=0;
         }
     }
@@ -1669,7 +1669,8 @@ void __fastcall TMainForm::DrawPlot(TImage *plot, int type, int freq)
     TCanvas *c=plot->Canvas;
     TLabel *label[]={Plabel1,Plabel2,Plabel3,Pos1,Pos2,Pos3};
     int w=plot->Parent->Width-2,h=plot->Parent->Height-2;
-    int i,j,x,sat[2][MAXSAT],ns[2],snr[2][MAXSAT][NFREQ],vsat[2][MAXSAT][NFREQ];
+    int i,j,x,sat[2][MAXSAT],ns[2],vsat[2][MAXSAT][NFREQ];
+    double snr[2][MAXSAT][NFREQ];
     int tm=PanelFont->Size*3/2;
     char name[16];
     double az[2][MAXSAT],el[2][MAXSAT],rr[3],rs[6],e[3],pos[3],azel[2];
@@ -1802,16 +1803,16 @@ void __fastcall TMainForm::UpdatePlot(void)
     }
 }
 // snr color ----------------------------------------------------------------
-TColor __fastcall TMainForm::SnrColor(int snr)
+TColor __fastcall TMainForm::SnrColor(double snr)
 {
     TColor color[]={clGreen,CLORANGE,clFuchsia,clBlue,clRed,clGray};
     uint32_t c1,c2,r1,r2,g1,g2,b1,b2;
     double a;
     int i;
     
-    if (snr<25) return color[5];
-    if (snr<27) return color[4];
-    if (snr>47) return color[0];
+    if (snr<25.0) return color[5];
+    if (snr<27.0) return color[4];
+    if (snr>47.0) return color[0];
     a=(snr-27.5)/5.0;
     i=(int)a; a-=i;
     c1=(uint32_t)color[3-i];
@@ -1837,7 +1838,8 @@ void __fastcall TMainForm::DrawSnr(TCanvas *c, int w, int h, int x0, int y0,
         clGreen,(TColor)0xAAFF,clFuchsia,clBlue,clRed,clTeal,clGray
     };
     UTF8String s; 
-    int i,j,k,l,n,x1,x2,y1,y2,y3,k1,tm,bm,hh,ww,www,snr[NFREQ+1],mask[7]={0};
+    int i,j,k,l,n,x1,x2,y1,y2,y3,k1,tm,bm,hh,ww,www,mask[7]={0};
+    double snr[NFREQ+1];
     char id[8],sys[]="GREJCIS",*q;
     
     trace(4,"DrawSnr: w=%d h=%d x0=%d y0=%d index=%d freq=%d\n",w,h,x0,y0,index,freq);
@@ -1850,7 +1852,7 @@ void __fastcall TMainForm::DrawSnr(TCanvas *c, int w, int h, int x0, int y0,
     for (snr[0]=MINSNR+10;snr[0]<MAXSNR;snr[0]+=10) {
         y1=y0+hh-(snr[0]-MINSNR)*hh/(MAXSNR-MINSNR);
         c->MoveTo(x0+2,y1); c->LineTo(x0+w-2,y1);
-        DrawText(c,x0+w-4,y1,s.sprintf("%d",snr[0]),clGray,2,0);
+        DrawText(c,x0+w-4,y1,s.sprintf("%d",(int)round(snr[0])),clGray,2,0);
     }
     y1=y0+hh;
     TRect b(x0+2,y0,x0+w-2,y1);
@@ -1865,8 +1867,9 @@ void __fastcall TMainForm::DrawSnr(TCanvas *c, int w, int h, int x0, int y0,
         x1=x0+i*(w-16)/Nsat[index]+ww/2;
         satno2id(Sat[index][i],id);
         l=(q=strchr(sys,id[0]))?(int)(q-sys):6;
-        
-        for (j=snr[0]=0;j<NFREQ;j++) {
+
+        snr[0]=0.0;
+        for (j=0;j<NFREQ;j++) {
             snr[j+1]=Snr[index][i][j];
             if ((freq&&freq==j+1)||((!freq||freq>NFREQ)&&snr[j+1]>snr[0])) {
                 snr[0]=snr[j+1];
@@ -1876,7 +1879,7 @@ void __fastcall TMainForm::DrawSnr(TCanvas *c, int w, int h, int x0, int y0,
             k=j<NFREQ+1?j:0;
             y3=j<NFREQ+1?0:2;
             y2=y1-y3;
-            if (snr[k]>0) y2-=(snr[k]-MINSNR)*hh/(MAXSNR-MINSNR)-y3;
+            if (snr[k]>0) y2-=(int)round((snr[k]-MINSNR)*hh/(MAXSNR-MINSNR)-y3);
             y2=y2<2?2:(y1<y2?y1:y2);
             
             TRect r1(x1,y1,x1+www,y2);
@@ -1916,7 +1919,8 @@ void __fastcall TMainForm::DrawSat(TCanvas *c, int w, int h, int x0, int y0,
     UTF8String s;
     TPoint p(w/2,h/2);
     double r=MIN(w*0.95,h*0.95)/2,azel[MAXSAT*2],dop[4];
-    int i,j,k,l,d,x[MAXSAT],y[MAXSAT],snr[NFREQ+1],ns=0;
+    int i,j,k,l,d,x[MAXSAT],y[MAXSAT],ns=0;
+    double snr[NFREQ+1];
     char id[8],sys[]="GREJCIS",*q;
     
     trace(4,"DrawSat: w=%d h=%d index=%d freq=%d\n",w,h,index,freq);
@@ -1925,7 +1929,8 @@ void __fastcall TMainForm::DrawSat(TCanvas *c, int w, int h, int x0, int y0,
     
     for (i=0,k=Nsat[index]-1;i<Nsat[index]&&i<MAXSAT;i++,k--) {
         if (El[index][k]<=0.0) continue;
-        for (j=snr[0]=0;j<NFREQ;j++) {
+        snr[0]=0;
+        for (j=0;j<NFREQ;j++) {
             snr[j+1]=Snr[index][k][j];
             if ((freq&&freq==j+1)||((!freq||freq>NFREQ)&&snr[j+1]>snr[0])) {
                 snr[0]=snr[j+1]; // max snr

--- a/app/winapp/rtknavi/navimain.h
+++ b/app/winapp/rtknavi/navimain.h
@@ -233,7 +233,7 @@ private:
 	void __fastcall SaveOpt      (void);
 	void __fastcall SetTrayIcon  (int index);
 	int  __fastcall ExecCmd      (AnsiString cmd, int show);
-	TColor __fastcall SnrColor   (int snr);
+	TColor __fastcall SnrColor   (double snr);
 public:
 	AnsiString IniFile;
 	
@@ -254,7 +254,8 @@ public:
 	int MoniPort,OpenPort,AutoRun;
 	
 	int PSol,PSolS,PSolE,Nsat[2],SolCurrentStat;
-	int Sat[2][MAXSAT],Snr[2][MAXSAT][NFREQ],Vsat[2][MAXSAT][NFREQ];
+	int Sat[2][MAXSAT],Vsat[2][MAXSAT][NFREQ];
+	double Snr[2][MAXSAT][NFREQ];
 	double Az[2][MAXSAT],El[2][MAXSAT];
 	gtime_t *Time;
 	int *SolStat,*Nvsat;

--- a/app/winapp/rtkplot/plotmain.cpp
+++ b/app/winapp/rtkplot/plotmain.cpp
@@ -1445,7 +1445,7 @@ void __fastcall TPlot::DispDblClick(TObject *Sender)
     TPoint p((int)X0,(int)Y0);
     double x,y;
     
-    trace(3,"DispDblClick X=%d Y=%d\n",p.x,p.y);
+    trace(3,"DispDblClick X=%ld Y=%ld\n",p.x,p.y);
     
     if (BtnFixHoriz->Down) return;
     

--- a/src/rcv/binex.c
+++ b/src/rcv/binex.c
@@ -987,7 +987,7 @@ static uint8_t *decode_bnx_7f_05_obs(raw_t *raw, uint8_t *buff, int sat,
         }
         if (k<0) {
             data->P[i]=data->L[i]=0.0;
-            data->D[i]=data->SNR[i]=0.0;
+            data->D[i]=data->SNR[i]=0.0f;
             data->LLI[i]=0;
             data->code[i]=CODE_NONE;
         }
@@ -995,8 +995,8 @@ static uint8_t *decode_bnx_7f_05_obs(raw_t *raw, uint8_t *buff, int sat,
             freq=code2freq(sys,codes[code[k]],fcn);
             data->P[i]=range[k];
             data->L[i]=phase[k]*freq/CLIGHT;
-            data->D[i]=dopp[k];
-            data->SNR[i]=cnr[k];
+            data->D[i]=(float)dopp[k];
+            data->SNR[i]=(float)cnr[k];
             data->code[i]=codes[code[k]];
             data->LLI[i]=slip[k]?1:0;
             mask[k]=1;
@@ -1008,7 +1008,7 @@ static uint8_t *decode_bnx_7f_05_obs(raw_t *raw, uint8_t *buff, int sat,
         }
         if (k>=nobs) {
             data->P[i]=data->L[i]=0.0;
-            data->D[i]=data->SNR[i]=0.0;
+            data->D[i]=data->SNR[i]=0.0f;
             data->LLI[i]=0;
             data->code[i]=CODE_NONE;
         }
@@ -1016,8 +1016,8 @@ static uint8_t *decode_bnx_7f_05_obs(raw_t *raw, uint8_t *buff, int sat,
             freq=code2freq(sys,codes[code[k]],fcn);
             data->P[i]=range[k];
             data->L[i]=phase[k]*freq/CLIGHT;
-            data->D[i]=dopp[k];
-            data->SNR[i]=cnr[k];
+            data->D[i]=(float)dopp[k];
+            data->SNR[i]=(float)cnr[k];
             data->code[i]=codes[code[k]];
             data->LLI[i]=slip[k]?1:0;
             mask[k]=1;

--- a/src/rcv/comnav.c
+++ b/src/rcv/comnav.c
@@ -387,7 +387,7 @@ static int decode_rangeb(raw_t *raw)
             raw->obs.data[index].L  [pos]=-adr;
             raw->obs.data[index].P  [pos]=psr;
             raw->obs.data[index].D  [pos]=(float)dop;
-            raw->obs.data[index].SNR[pos]=0.0<=snr&&snr<255.0?snr:0;
+            raw->obs.data[index].SNR[pos]=0.0<=snr&&snr<255.0?(float)snr:0.0f;
             raw->obs.data[index].LLI[pos]=(unsigned char)lli;
             raw->obs.data[index].code[pos]=code;
 #ifdef RTK_DISABLED

--- a/src/rcv/crescent.c
+++ b/src/rcv/crescent.c
@@ -145,7 +145,7 @@ static int decode_cresraw(raw_t *raw)
         raw->obs.data[n].P[0]=pr;
         raw->obs.data[n].L[0]=cp*freq/CLIGHT;
         raw->obs.data[n].D[0]=-(float)(dop*freq/CLIGHT);
-        raw->obs.data[n].SNR[0]=snr;
+        raw->obs.data[n].SNR[0]=(float)snr;
         raw->obs.data[n].LLI[0]=(uint8_t)lli;
         raw->obs.data[n].code[0]=CODE_L1C;
         
@@ -256,13 +256,13 @@ static int decode_cresraw2(raw_t *raw)
                 raw->obs.data[n].P[j]=pr[j]==0.0?0.0:pr[j]-toff;
                 raw->obs.data[n].L[j]=cp[j]==0.0?0.0:cp[j]-toff*freq[j]/CLIGHT;
                 raw->obs.data[n].D[j]=-(float)dop[j];
-                raw->obs.data[n].SNR[j]=snr[j];
+                raw->obs.data[n].SNR[j]=(float)snr[j];
                 raw->obs.data[n].LLI[j]=(uint8_t)lli[j];
                 raw->obs.data[n].code[j]=j==0?CODE_L1C:CODE_L2P;
             }
             else {
                 raw->obs.data[n].L[j]=raw->obs.data[n].P[j]=0.0;
-                raw->obs.data[n].D[j]=raw->obs.data[n].SNR[j]=0.0;
+                raw->obs.data[n].D[j]=raw->obs.data[n].SNR[j]=0.0f;
                 raw->obs.data[n].LLI[j]=0;
                 raw->obs.data[n].code[j]=CODE_NONE;
             }
@@ -461,13 +461,13 @@ static int decode_cresgloraw(raw_t *raw)
                 raw->obs.data[n].P[j]=pr[j]==0.0?0.0:pr[j]-toff;
                 raw->obs.data[n].L[j]=cp[j]==0.0?0.0:cp[j]-toff*freq[j]/CLIGHT;
                 raw->obs.data[n].D[j]=-(float)dop[j];
-                raw->obs.data[n].SNR[j]=snr[j];
+                raw->obs.data[n].SNR[j]=(float)snr[j];
                 raw->obs.data[n].LLI[j]=(uint8_t)lli[j];
                 raw->obs.data[n].code[j]=j==0?CODE_L1C:CODE_L2P;
             }
             else {
                 raw->obs.data[n].L[j]=raw->obs.data[n].P[j]=0.0;
-                raw->obs.data[n].D[j]=raw->obs.data[n].SNR[j]=0.0;
+                raw->obs.data[n].D[j]=raw->obs.data[n].SNR[j]=0.0f;
                 raw->obs.data[n].LLI[j]=0;
                 raw->obs.data[n].code[j]=CODE_NONE;
             }

--- a/src/rcv/javad.c
+++ b/src/rcv/javad.c
@@ -232,7 +232,7 @@ static int flushobuf(raw_t *raw)
         raw->obuf.data[i].time=time0;
         for (j=0;j<NFREQ+NEXOBS;j++) {
             raw->obuf.data[i].L[j]=raw->obuf.data[i].P[j]=0.0;
-            raw->obuf.data[i].D[j]=raw->obuf.data[i].SNR[j]=0.0;
+            raw->obuf.data[i].D[j]=raw->obuf.data[i].SNR[j]=0.0f;
             raw->obuf.data[i].LLI[j]=0;
             raw->obuf.data[i].code[j]=CODE_NONE;
         }
@@ -1581,7 +1581,7 @@ static int decode_Ex(raw_t *raw, char sig)
         
         if ((idx=checkpri(sys,code,raw->opt,idx))>=0) {
             if (!settag(raw->obuf.data+i,raw->time)) continue;
-            raw->obuf.data[i].SNR[idx]=cnr;
+            raw->obuf.data[i].SNR[idx]=(float)cnr;
         }
     }
     return 0;
@@ -1612,7 +1612,7 @@ static int decode_xE(raw_t *raw, char sig)
         
         if ((idx=checkpri(sys,code,raw->opt,idx))>=0) {
             if (!settag(raw->obuf.data+i,raw->time)) continue;
-            raw->obuf.data[i].SNR[idx]=cnr*0.25;
+            raw->obuf.data[i].SNR[idx]=(float)(cnr*0.25);
         }
     }
     return 0;

--- a/src/rcv/novatel.c
+++ b/src/rcv/novatel.c
@@ -180,7 +180,7 @@ static int obsindex(obs_t *obs, gtime_t time, int sat)
     obs->data[i].sat=sat;
     for (j=0;j<NFREQ+NEXOBS;j++) {
         obs->data[i].L[j]=obs->data[i].P[j]=0.0;
-        obs->data[i].D[j]=obs->data[i].SNR[j]=0.0;
+        obs->data[i].D[j]=obs->data[i].SNR[j]=0.0f;
         obs->data[i].LLI[j]=0;
         obs->data[i].code[j]=CODE_NONE;
     }
@@ -438,7 +438,7 @@ static int decode_rangecmpb(raw_t *raw)
             raw->obs.data[index].L  [idx]=adr;
             raw->obs.data[index].P  [idx]=psr;
             raw->obs.data[index].D  [idx]=(float)dop;
-            raw->obs.data[index].SNR[idx]=snr;
+            raw->obs.data[index].SNR[idx]=(float)snr;
             raw->obs.data[index].LLI[idx]=(uint8_t)lli;
             raw->obs.data[index].code[idx]=(uint8_t)code;
         }
@@ -521,7 +521,7 @@ static int decode_rangeb(raw_t *raw)
             raw->obs.data[index].L  [idx]=-adr;
             raw->obs.data[index].P  [idx]=psr;
             raw->obs.data[index].D  [idx]=(float)dop;
-            raw->obs.data[index].SNR[idx]=snr;
+            raw->obs.data[index].SNR[idx]=(float)snr;
             raw->obs.data[index].LLI[idx]=(uint8_t)lli;
             raw->obs.data[index].code[idx]=(uint8_t)code;
         }
@@ -1113,7 +1113,7 @@ static int decode_rgeb(raw_t *raw)
             raw->obs.data[index].L  [freq]=-adr; /* flip sign */
             raw->obs.data[index].P  [freq]=psr;
             raw->obs.data[index].D  [freq]=(float)dop;
-            raw->obs.data[index].SNR[freq]=0.0<=snr&&snr<255.0?snr:0;
+            raw->obs.data[index].SNR[freq]=0.0<=snr&&snr<255.0?(float)snr:0.0f;
             raw->obs.data[index].LLI[freq]=(uint8_t)lli;
             raw->obs.data[index].code[freq]=freq==0?CODE_L1C:CODE_L2P;
         }
@@ -1178,7 +1178,7 @@ static int decode_rged(raw_t *raw)
             raw->obs.data[index].L  [freq]=adr;
             raw->obs.data[index].P  [freq]=psr;
             raw->obs.data[index].D  [freq]=(float)dop;
-            raw->obs.data[index].SNR[freq]=snr;
+            raw->obs.data[index].SNR[freq]=(float)snr;
             raw->obs.data[index].LLI[freq]=(uint8_t)lli;
             raw->obs.data[index].code[freq]=freq==0?CODE_L1C:CODE_L2P;
         }

--- a/src/rcv/nvs.c
+++ b/src/rcv/nvs.c
@@ -67,7 +67,6 @@ static int decode_xf5raw(raw_t *raw)
 {
     gtime_t time;
     double tadj=0.0,toff=0.0,tn;
-    int dTowInt;
     double dTowUTC, dTowGPS, dTowFrac, L1, P1, D1;
     double gpsutcTimescale;
     uint8_t rcvTimeScaleCorr, sys, carrNo;
@@ -105,7 +104,7 @@ static int decode_xf5raw(raw_t *raw)
     dTowGPS = dTowUTC + gpsutcTimescale;
     
     /* Tweak pseudoranges to allow Rinex to represent the NVS time of measure */
-    dTowInt  = 10.0*floor((dTowGPS/10.0)+0.5);
+    int dTowInt  = (int)(10.0*floor((dTowGPS/10.0)+0.5));
     dTowFrac = dTowGPS - (double) dTowInt;
     time=gpst2time(week, dTowInt*0.001);
     
@@ -145,7 +144,7 @@ static int decode_xf5raw(raw_t *raw)
                   sat,L1,P1,D1);
             continue;
         }
-        raw->obs.data[n].SNR[0]=I1(p+3);
+        raw->obs.data[n].SNR[0]=(float)I1(p+3);
         if (sys==SYS_GLO) {
             raw->obs.data[n].L[0]  =  L1 - toff*(FREQ1_GLO+DFRQ1_GLO*carrNo);
         } else {
@@ -164,7 +163,7 @@ static int decode_xf5raw(raw_t *raw)
         
         for (j=1;j<NFREQ+NEXOBS;j++) {
             raw->obs.data[n].L[j]=raw->obs.data[n].P[j]=0.0;
-            raw->obs.data[n].D[j]=raw->obs.data[n].SNR[j]=0.0;
+            raw->obs.data[n].D[j]=raw->obs.data[n].SNR[j]=0.0f;
             raw->obs.data[n].LLI[j]=0;
             raw->obs.data[n].code[j]=CODE_NONE;
         }
@@ -262,7 +261,7 @@ static int decode_gloephem(int sat, raw_t *raw)
         geph.acc[0]=R8(p+51) * 1e+6;
         geph.acc[1]=R8(p+59) * 1e+6;
         geph.acc[2]=R8(p+67) * 1e+6;
-        tb = R8(p+75) * 1e-3;
+        tb = (int)(R8(p+75) * 1e-3);
         tk = tb;
         geph.gamn  =R4(p+83);
         geph.taun  =R4(p+87) * 1e-3;

--- a/src/rcv/rt17.c
+++ b/src/rcv/rt17.c
@@ -1705,7 +1705,7 @@ static int DecodeType17(raw_t *Raw, uint32_t rif)
             if (Flags1 & M_BIT6) /* L1 data valid */
             {
                 /* Measure of L1 signal strength (dB * 4) */
-                obs->SNR[0] = U1(p)*0.25;
+                obs->SNR[0] = (float)(U1(p)*0.25);
                 p++;
                 
                 /* Full L1 C/A code or P-code pseudorange (meters) */
@@ -1725,7 +1725,7 @@ static int DecodeType17(raw_t *Raw, uint32_t rif)
             if (Flags1 & M_BIT0)  /* L2 data loaded */
             {
                 /* Measure of L2 signal strength (dB * 4) */
-                obs->SNR[1] = U1(p)*0.25;
+                obs->SNR[1] = (float)(U1(p)*0.25);
                 p++;
                 
                 /* L2 Continuous Phase (cycles) */
@@ -1784,7 +1784,7 @@ static int DecodeType17(raw_t *Raw, uint32_t rif)
             if (Flags1 & M_BIT6) /* L1 data valid */
             {           
                 /* Measure of satellite signal strength (dB) */
-                obs->SNR[0] = R8(p);
+                obs->SNR[0] = (float)R8(p);
                 p += 8;
 
                 /* Full L1 C/A code or P-code pseudorange (meters) */
@@ -1797,7 +1797,7 @@ static int DecodeType17(raw_t *Raw, uint32_t rif)
                 p += 8;
 
                 /* L1 Doppler (Hz) */
-                obs->D[0] = R8(p);
+                obs->D[0] = (float)R8(p);
                 p += 8;
 
                 /* Reserved 8 bytes */
@@ -1807,7 +1807,7 @@ static int DecodeType17(raw_t *Raw, uint32_t rif)
             if (Flags1 & M_BIT0) /* L2 data loaded */
             {
                 /* Measure of L2 signal strength (dB) */
-                obs->SNR[1] = R8(p);
+                obs->SNR[1] = (float)R8(p);
                 p += 8;
 
                 /* L2 Continuous Phase (cycles) */                
@@ -1833,7 +1833,7 @@ static int DecodeType17(raw_t *Raw, uint32_t rif)
                 p++; /* U1 Reserved byte */
 
                 /* L2 Doppler (Hz) */
-                obs->D[1] = R8(p);
+                obs->D[1] = (float)R8(p);
                 p += 8;
             }
         }

--- a/src/rcv/septentrio.c
+++ b/src/rcv/septentrio.c
@@ -582,7 +582,7 @@ static void init_obsd(gtime_t time, int sat, obsd_t *data)
 
     for (i = 0; i < NFREQ+NEXOBS; i++) {
         data->L[i] = data->P[i] = 0.0;
-        data->D[i] = data->SNR[i] = 0.0;
+        data->D[i] = data->SNR[i] = 0.0f;
         data->Lstd[i] = data->Pstd[i] = 0.0;
         data->LLI[i] = 0;
         data->code[i] = CODE_NONE;
@@ -666,7 +666,7 @@ static int flushobuf(raw_t *raw) {
         raw->obuf.data[i].time.sec = 0;
         for (j = 0; j < NFREQ + NEXOBS; j++) {
             raw->obuf.data[i].L[j] = raw->obuf.data[i].P[j] = 0.0;
-            raw->obuf.data[i].D[j] = raw->obuf.data[i].SNR[j] = 0.0;
+            raw->obuf.data[i].D[j] = raw->obuf.data[i].SNR[j] = 0.0f;
             raw->obuf.data[i].Lstd[j] = raw->obuf.data[i].Pstd[j] = 0.0;
             raw->obuf.data[i].LLI[j] = 0;
             raw->obuf.data[i].code[j] = CODE_NONE;
@@ -786,7 +786,7 @@ static int decode_measepoch(raw_t *raw)
         }
         if (U1(p+15) != 255) {
             S1 = U1(p+15)*0.25 + ((sig==1 || sig==2) ? 0.0 : 10.0);
-            raw->obuf.data[n].SNR[idx] = S1;
+            raw->obuf.data[n].SNR[idx] = (float)S1;
         }
         raw->obuf.data[n].code[idx] = code;
 
@@ -814,7 +814,7 @@ static int decode_measepoch(raw_t *raw)
             }
             if (U1(p+2) != 255) {
                 S2 = U1(p+2)*0.25 + ((sig==1 || sig==2) ? 0.0 : 10.0);
-                raw->obuf.data[n].SNR[idx] = S2;
+                raw->obuf.data[n].SNR[idx] = (float)S2;
             }
             if (P1!=0.0 && (getbits(p+3, 5, 3)!=-4 || U2(p+6)!=0)) {
                 P2 = P1+getbits(p+3, 5, 3)*65.536 + U2(p+6)*0.001;
@@ -909,7 +909,7 @@ static int decode_measepochextra(raw_t *raw)
 
         if ((revision >= 3) && (sbLen >= 16)) {  /* later revision contains high-resolution extension for CN0 values*/
             misc = U1(p_chan+15);
-            raw->obuf.data[n].SNR[idx] += (misc & 0x7) * 0.03125;
+            raw->obuf.data[n].SNR[idx] += (float)((misc & 0x7) * 0.03125);
         }
     }
 
@@ -1086,7 +1086,7 @@ static int decode_meas3ranges(raw_t *raw) {
                         freqMaster = code2freq(Meas3_NavSys[navsys], codeMaster, glofnc);
                         double pr = prbase + ((double)pr_lsb + 4294967296.0 * (double)prMsb) * .001;
                         raw->obuf.data[n].P[masterFreqIndex] = pr;
-                        raw->obuf.data[n].SNR[masterFreqIndex] = CN0 + 24.0;
+                        raw->obuf.data[n].SNR[masterFreqIndex] = (float)(CN0 + 24.0);
                         raw->obuf.data[n].code[masterFreqIndex] = codeMaster;
                         if (cmc != 0)
                             raw->obuf.data[n].L[masterFreqIndex] = pr / (CLIGHT/freqMaster) - 131.072 + (double)cmc * .001;
@@ -1132,7 +1132,7 @@ static int decode_meas3ranges(raw_t *raw) {
                         uint8_t isGPSPCode = (navsys == 0) && (codeMaster == CODE_L1W || codeMaster == CODE_L2W);
 
                         raw->obuf.data[n].P[masterFreqIndex] = ((double)prLsb + 4294967296.0 * (double)prMsb) * .001;
-                        raw->obuf.data[n].SNR[masterFreqIndex] = isGPSPCode ? CN0 : CN0 + 10.0;
+                        raw->obuf.data[n].SNR[masterFreqIndex] = isGPSPCode ? (float)CN0 : (float)(CN0 + 10.0);
                         raw->obuf.data[n].code[masterFreqIndex] = codeMaster;
                         if (cmc != 0)
                             raw->obuf.data[n].L[masterFreqIndex] = raw->obuf.data[n].P[masterFreqIndex] / (CLIGHT/freqMaster) - 2097.152 + (double)cmc * .001;
@@ -1167,7 +1167,7 @@ static int decode_meas3ranges(raw_t *raw) {
                         raw->obuf.data[n].P[masterFreqIndex] = master_reference->P[masterFreqIndex] +
                                                        ((int64_t)sbf->meas3_refEpoch.prRate[navsys][svid] * 64 * (int32_t)(TOW % refEpochInterval) / 1000) * .001 +
                                                        (double)pr * .001 - 65.536;
-                        raw->obuf.data[n].SNR[masterFreqIndex] = master_reference->SNR[masterFreqIndex] - 4.0 + CN0;
+                        raw->obuf.data[n].SNR[masterFreqIndex] = (float)(master_reference->SNR[masterFreqIndex] - 4.0 + CN0);
                         raw->obuf.data[n].code[masterFreqIndex] = codeMaster;
                         if (cmc != 0)
                             raw->obuf.data[n].L[masterFreqIndex] = (raw->obuf.data[n].P[masterFreqIndex] - master_reference->P[masterFreqIndex]) / (CLIGHT/freqMaster) +
@@ -1198,7 +1198,7 @@ static int decode_meas3ranges(raw_t *raw) {
                         raw->obuf.data[n].P[masterFreqIndex] = masterReference->P[masterFreqIndex] + ((int64_t)sbf->meas3_refEpoch.prRate[navsys][svid] * 64 * (int32_t)(TOW % refEpochInterval) / 1000) * .001 + (double)pr * .001 - 8.192;
                         if (cmc != 0)
                             raw->obuf.data[n].L[masterFreqIndex] = (raw->obuf.data[n].P[masterFreqIndex] - masterReference->P[masterFreqIndex]) / (CLIGHT/freqMaster) + masterReference->L[masterFreqIndex] - 8.192 + (double)cmc * .001;
-                        raw->obuf.data[n].SNR[masterFreqIndex] = masterReference->SNR[masterFreqIndex] - 1.0 + CN0;
+                        raw->obuf.data[n].SNR[masterFreqIndex] = (float)(masterReference->SNR[masterFreqIndex] - 1.0 + CN0);
                         raw->obuf.data[n].LLI[masterFreqIndex] = masterReference->LLI[masterFreqIndex];
                         raw->lockt[satNo-1][masterFreqIndex] = sbf->meas3_refEpoch.lockt[navsys][svid][masterFreqIndex];
                         raw->obuf.data[n].code[masterFreqIndex] = codeMaster;
@@ -1269,9 +1269,9 @@ static int decode_meas3ranges(raw_t *raw) {
                                                           - 32.768 + cmcRes * .001;
 
                                 if ((navsys == 0) && (codeSlave == CODE_L1W || codeSlave == CODE_L2W))
-                                    raw->obuf.data[n].SNR[slaveFreqIndex] = raw->obuf.data[n].SNR[masterFreqIndex] - 3.0 - CN0;
+                                  raw->obuf.data[n].SNR[slaveFreqIndex] = (float)(raw->obuf.data[n].SNR[masterFreqIndex] - 3.0 - CN0);
                                 else
-                                    raw->obuf.data[n].SNR[slaveFreqIndex] = CN0 + 24.0;
+                                  raw->obuf.data[n].SNR[slaveFreqIndex] = (float)(CN0 + 24.0);
 
                                 raw->obuf.data[n].code[slaveFreqIndex] = codeSlave;
                                 raw->obuf.data[n].LLI[slaveFreqIndex] = (lockTime < raw->lockt[satNo-1][slaveFreqIndex] ? LLI_SLIP : 0) | (lti3 == 0 ? LLI_HALFC : 0);
@@ -1300,9 +1300,9 @@ static int decode_meas3ranges(raw_t *raw) {
                                     raw->obuf.data[n].L[slaveFreqIndex] = raw->obuf.data[n].P[slaveFreqIndex] / (CLIGHT/freqSlave) - 2097.152 + cmc * 0.001;
 
                                 if ((navsys == 0) && (codeSlave == CODE_L1W || codeSlave == CODE_L2W))
-                                    raw->obuf.data[n].SNR[slaveFreqIndex] = CN0;
+                                    raw->obuf.data[n].SNR[slaveFreqIndex] = (float)CN0;
                                 else
-                                    raw->obuf.data[n].SNR[slaveFreqIndex] = CN0 + 10.0;
+                                    raw->obuf.data[n].SNR[slaveFreqIndex] = (float)(CN0 + 10.0);
 
                                 raw->obuf.data[n].code[slaveFreqIndex] = codeSlave;
                                 raw->obuf.data[n].LLI[slaveFreqIndex] = (lockTime < raw->lockt[satNo-1][slaveFreqIndex] ? LLI_SLIP : 0) | (lti4 == 0 ? LLI_HALFC : 0);
@@ -1334,7 +1334,7 @@ static int decode_meas3ranges(raw_t *raw) {
                                                                       (raw->obuf.data[n].L[slaveFreqIndex] - slaveReference->L[slaveRefFreqIdx]) * (CLIGHT/freqSlave)
                                                                       - 2.048 + dPr * 0.001);
 
-                                raw->obuf.data[n].SNR[slaveFreqIndex] = slaveReference->SNR[slaveRefFreqIdx] - 2.0 + CN0;
+                                raw->obuf.data[n].SNR[slaveFreqIndex] = (float)(slaveReference->SNR[slaveRefFreqIdx] - 2.0 + CN0);
 
                                 raw->obuf.data[n].code[slaveFreqIndex] = codeSlave;
                                 raw->obuf.data[n].LLI[slaveFreqIndex] = slaveReference->LLI[slaveRefFreqIdx];
@@ -1512,13 +1512,13 @@ int decode_meas3CN(raw_t* raw)
         masterFreqIndex = sbf->meas3_freqAssignment[navsys][svid][0];
 
         uint8_t mc = (U1(raw->buff + 16 + offset / 2) >> ((offset % 2) * 4)) & 0xf;
-        raw->obuf.data[n].SNR[masterFreqIndex] += mc * 0.0625 - 0.5;
+        raw->obuf.data[n].SNR[masterFreqIndex] += (float)(mc * 0.0625 - 0.5);
         offset++;
         for (int i = 1; i<MEAS3_SIG_MAX; i++) {
             slaveFreqIndex = sbf->meas3_freqAssignment[navsys][svid][i];
             if (slaveFreqIndex < 0)
                 break;
-            raw->obuf.data[n].SNR[slaveFreqIndex] += ((U1(raw->buff + 16 + offset / 2) >> ((offset % 2) * 4)) & 0xf) * .0625 - 0.5;
+            raw->obuf.data[n].SNR[slaveFreqIndex] += (float)(((U1(raw->buff + 16 + offset / 2) >> ((offset % 2) * 4)) & 0xf) * .0625 - 0.5);
             offset++;
         }
     }

--- a/src/rcv/skytraq.c
+++ b/src/rcv/skytraq.c
@@ -269,7 +269,7 @@ static int decode_stqraw(raw_t *raw)
         
         raw->obs.data[n].P[0]=pr1;
         raw->obs.data[n].L[0]=cp1;
-        raw->obs.data[n].D[0]=!(ind&2)?0.0:R4(p+18);
+        raw->obs.data[n].D[0]=!(ind&2)?0.0f:(float)R4(p+18);
         raw->obs.data[n].SNR[0]=U1(p+1);
         raw->obs.data[n].LLI[0]=0;
         raw->obs.data[n].code[0]=sys==SYS_CMP?CODE_L2I:CODE_L1C;
@@ -289,7 +289,7 @@ static int decode_stqraw(raw_t *raw)
         
         for (j=1;j<NFREQ+NEXOBS;j++) {
             raw->obs.data[n].L[j]=raw->obs.data[n].P[j]=0.0;
-            raw->obs.data[n].D[j]=raw->obs.data[n].SNR[j]=0.0;
+            raw->obs.data[n].D[j]=raw->obs.data[n].SNR[j]=0.0f;
             raw->obs.data[n].LLI[j]=0;
             raw->obs.data[n].code[j]=CODE_NONE;
         }
@@ -301,7 +301,7 @@ static int decode_stqraw(raw_t *raw)
 /* decode skytraq extended raw measurement data v.1 (0xE5) -------------------*/
 static int decode_stqrawx(raw_t *raw)
 {
-    uint8_t *p=raw->buff+4,ind;
+    uint8_t *p=raw->buff+4;
     double tow,peri,pr1,cp1;
     int i,j,k,ver,week,nsat,sys,sig,prn,sat,n=0,idx;
 
@@ -335,7 +335,7 @@ static int decode_stqrawx(raw_t *raw)
         if (sys==SYS_GLO) {
             raw->nav.geph[prn-1].frq=(int)(U1(p+2)&0xF)-7;
         }
-        ind=U2(p+27);
+        uint16_t ind=U2(p+27);
         pr1=!(ind&1)?0.0:R8(p+ 4);
         cp1=!(ind&4)?0.0:R8(p+12);
         cp1-=floor((cp1+1E9)/2E9)*2E9; /* -10^9 < cp1 < 10^9 */
@@ -349,7 +349,7 @@ static int decode_stqrawx(raw_t *raw)
             raw->obs.data[n].rcv=0;
             for (k=0;k<NFREQ+NEXOBS;k++) {
                 raw->obs.data[n].L[k]=raw->obs.data[n].P[k]=0.0;
-                raw->obs.data[n].D[k]=raw->obs.data[n].SNR[k]=0.0;
+                raw->obs.data[n].D[k]=raw->obs.data[n].SNR[k]=0.0f;
                 raw->obs.data[n].LLI[k]=0;
                 raw->obs.data[n].code[k]=CODE_NONE;
             }
@@ -357,7 +357,7 @@ static int decode_stqrawx(raw_t *raw)
         }
         raw->obs.data[j].P[idx]=pr1;
         raw->obs.data[j].L[idx]=cp1;
-        raw->obs.data[j].D[idx]=!(ind&2)?0.0:R4(p+20);
+        raw->obs.data[j].D[idx]=!(ind&2)?0.0f:(float)R4(p+20);
         raw->obs.data[j].SNR[idx]=U1(p+3);
         raw->obs.data[j].LLI[idx]=0;
         raw->obs.data[j].code[idx]=sig;

--- a/src/rcv/swiftnav.c
+++ b/src/rcv/swiftnav.c
@@ -351,7 +351,7 @@ static int sisa_index(double value)
     else if (value<=0.5) return (int)(value/0.01);
     else if (value<=1.0) return (int)((value-0.5)/0.02)+50;
     else if (value<=2.0) return (int)((value-1.0)/0.04)+75;
-    return ((int)(value-2.0)/0.16)+100;
+    return (int)((value-2.0)/0.16)+100;
 }
 
 /* SBP checksum calculation --------------------------------------------------*/
@@ -533,7 +533,7 @@ static int decode_msgobs(raw_t *raw) {
       raw->obuf.data[ii].P[freq] = (flags & 0x1) ? pseudorange : 0.0;
       raw->obuf.data[ii].L[freq] = (flags & 0x2) ? carr_phase : 0.0;
       raw->obuf.data[ii].D[freq] = (flags & 0x8) ? (float)freq_doppler : 0.0f;
-      raw->obuf.data[ii].SNR[freq] = cn0_int * 0.25;
+      raw->obuf.data[ii].SNR[freq] = (float)(cn0_int * 0.25);
       raw->obuf.data[ii].code[freq] = code;
 
       if (flags & 0x2) {
@@ -1570,7 +1570,7 @@ extern int input_sbpjsonf(raw_t *raw, FILE *fp) {
   pcPayloadBeg = (uint8_t *)strchr((char *)pcTmp, '\"') + 1;
   pcPayloadEnd = (uint8_t *)strchr((char *)pcPayloadBeg, '\"') - 1;
   if ((NULL == pcPayloadBeg) || (NULL == pcPayloadEnd)) return 0;
-  uPayloadSize = pcPayloadEnd - pcPayloadBeg + 1;
+  uPayloadSize = (uint32_t)(pcPayloadEnd - pcPayloadBeg) + 1;
   pcPayloadEnd[1] = 0;
   /* fprintf(stderr, "%4d: %s\n", uPayloadSize, pcPayloadBeg); */
   memset(puPayloadTmp, 0, sizeof(puPayloadTmp));

--- a/src/rcv/tersus.c
+++ b/src/rcv/tersus.c
@@ -262,7 +262,7 @@ static int decode_rangeb(raw_t *raw)
             raw->obs.data[index].L  [pos]=-adr;
             raw->obs.data[index].P  [pos]=psr;
             raw->obs.data[index].D  [pos]=(float)dop;
-            raw->obs.data[index].SNR[pos]=0.0<=snr&&snr<255.0?snr:0;
+            raw->obs.data[index].SNR[pos]=0.0<=snr&&snr<255.0?(float)snr:0.0f;
             raw->obs.data[index].LLI[pos]=(unsigned char)lli;
             raw->obs.data[index].code[pos]=code;
         }
@@ -346,7 +346,7 @@ static int decode_rangecmpb(raw_t *raw)
             raw->obs.data[index].L  [pos]=adr;
             raw->obs.data[index].P  [pos]=psr;
             raw->obs.data[index].D  [pos]=(float)dop;
-            raw->obs.data[index].SNR[pos]=0.0<=snr&&snr<255.0?snr:0;
+            raw->obs.data[index].SNR[pos]=0.0<=snr&&snr<255.0?(float)snr:0.0f;
             raw->obs.data[index].LLI[pos]=(unsigned char)lli;
             raw->obs.data[index].code[pos]=code;
         }

--- a/src/rcv/ublox.c
+++ b/src/rcv/ublox.c
@@ -363,8 +363,8 @@ static int decode_rxmraw(raw_t *raw)
         
         for (j=1;j<NFREQ+NEXOBS;j++) {
             raw->obs.data[n].L[j]=raw->obs.data[n].P[j]=0.0;
-            raw->obs.data[n].D[j]=raw->obs.data[n].SNR[j]=0.0;
-            raw->obs.data[n].Lstd[j]=raw->obs.data[n].Pstd[j]=0.0;
+            raw->obs.data[n].D[j]=raw->obs.data[n].SNR[j]=0.0f;
+            raw->obs.data[n].Lstd[j]=raw->obs.data[n].Pstd[j]=0.0f;
             raw->obs.data[n].LLI[j]=0;
             raw->obs.data[n].code[j]=CODE_NONE;
         }
@@ -524,8 +524,8 @@ static int decode_rxmrawx(raw_t *raw)
             raw->obs.data[n].rcv=0;
             for (k=0;k<NFREQ+NEXOBS;k++) {
                 raw->obs.data[n].L[k]=raw->obs.data[n].P[k]=0.0;
-                raw->obs.data[n].D[k]=raw->obs.data[n].SNR[k]=0.0;
-                raw->obs.data[n].Lstd[k]=raw->obs.data[n].Pstd[k]=0.0;
+                raw->obs.data[n].D[k]=raw->obs.data[n].SNR[k]=0.0f;
+                raw->obs.data[n].Lstd[k]=raw->obs.data[n].Pstd[k]=0.0f;
                 raw->obs.data[n].LLI[k]=0;
                 raw->obs.data[n].code[k]=CODE_NONE;
             }
@@ -533,10 +533,10 @@ static int decode_rxmrawx(raw_t *raw)
         }
         raw->obs.data[j].L[idx]=L;
         raw->obs.data[j].P[idx]=P;
-        raw->obs.data[j].Lstd[idx] = rcvstds ? cpstd * 0.004 : 0;
-        raw->obs.data[j].Pstd[idx] = rcvstds ? 0.01 * pow(2, prstd) : 0.0;
+        raw->obs.data[j].Lstd[idx] = rcvstds ? (float)(cpstd * 0.004) : 0.0f;
+        raw->obs.data[j].Pstd[idx] = rcvstds ? (float)(0.01 * pow(2, prstd)) : 0.0f;
         raw->obs.data[j].D[idx]=(float)D;
-        raw->obs.data[j].SNR[idx]=cn0;
+        raw->obs.data[j].SNR[idx]=(float)cn0;
         raw->obs.data[j].LLI[idx]=(uint8_t)LLI;
         raw->obs.data[j].code[idx]=(uint8_t)code;
         if (L!=0.0) raw->lockflag[sat-1][idx]=0; /* clear slip carry-forward flag if valid phase*/
@@ -693,9 +693,9 @@ static int decode_trkmeas(raw_t *raw)
         raw->obs.data[n].P[0]=tau*CLIGHT;
         raw->obs.data[n].L[0]=-adr;
         raw->obs.data[n].D[0]=(float)dop;
-        raw->obs.data[n].SNR[0]=snr;
+        raw->obs.data[n].SNR[0]=(float)snr;
         raw->obs.data[n].code[0]=sys==SYS_CMP?CODE_L2I:CODE_L1C;
-        raw->obs.data[n].Lstd[0] = rcvstds ? (8 - qi) * 0.004 : 0;
+        raw->obs.data[n].Lstd[0] = rcvstds ? (float)((8 - qi) * 0.004) : 0.0f;
         raw->obs.data[n].LLI[0]=raw->lockt[sat-1][1]>0.0?1:0;
         if (sys==SYS_SBS) { /* half-cycle valid */
             raw->obs.data[n].LLI[0]|=lock2>142?0:2;
@@ -711,8 +711,8 @@ static int decode_trkmeas(raw_t *raw)
         }
         for (j=1;j<NFREQ+NEXOBS;j++) {
             raw->obs.data[n].L[j]=raw->obs.data[n].P[j]=0.0;
-            raw->obs.data[n].D[j]=raw->obs.data[n].SNR[j]=0.0;
-            raw->obs.data[n].Lstd[j]=raw->obs.data[n].Pstd[j]=0.0;
+            raw->obs.data[n].D[j]=raw->obs.data[n].SNR[j]=0.0f;
+            raw->obs.data[n].Lstd[j]=raw->obs.data[n].Pstd[j]=0.0f;
             raw->obs.data[n].LLI[j]=0;
             raw->obs.data[n].code[j]=CODE_NONE;
         }
@@ -820,14 +820,14 @@ static int decode_trkd5(raw_t *raw)
         raw->obs.data[n].P[0]=tau*CLIGHT;
         raw->obs.data[n].L[0]=-adr;
         raw->obs.data[n].D[0]=(float)dop;
-        raw->obs.data[n].SNR[0]=snr;
+        raw->obs.data[n].SNR[0]=(float)snr;
         raw->obs.data[n].code[0]=sys==SYS_CMP?CODE_L2I:CODE_L1C;
         raw->obs.data[n].LLI[0]=raw->lockt[sat-1][1]>0.0?1:0;
         raw->lockt[sat-1][1]=0.0;
         
         for (j=1;j<NFREQ+NEXOBS;j++) {
             raw->obs.data[n].L[j]=raw->obs.data[n].P[j]=0.0;
-            raw->obs.data[n].D[j]=raw->obs.data[n].SNR[j]=0.0;
+            raw->obs.data[n].D[j]=raw->obs.data[n].SNR[j]=0.0f;
             raw->obs.data[n].LLI[j]=0;
             raw->obs.data[n].code[j]=CODE_NONE;
         }

--- a/src/rcv/unicore.c
+++ b/src/rcv/unicore.c
@@ -817,14 +817,14 @@ static int decode_obsvmb(raw_t* raw)
             raw->obs.data[index].L[idx] = -adr;
             raw->obs.data[index].P[idx] = psr;
             raw->obs.data[index].D[idx] = (float)dop;
-            raw->obs.data[index].SNR[idx] = snr;
+            raw->obs.data[index].SNR[idx] = (float)snr;
             raw->obs.data[index].LLI[idx] = (uint8_t)lli;
             raw->obs.data[index].code[idx] = (uint8_t)code;
             if (rcvstds) {
                 double pstd = U2(p + 20) * 0.01;  // Meters
-                raw->obs.data[index].Pstd[idx] = pstd;
+                raw->obs.data[index].Pstd[idx] = (float)pstd;
                 double lstd = U2(p + 22) * 0.0001; // Cycles
-                raw->obs.data[index].Lstd[idx] = lstd;
+                raw->obs.data[index].Lstd[idx] = (float)lstd;
             }
         }
     }

--- a/src/rinex.c
+++ b/src/rinex.c
@@ -915,14 +915,14 @@ static int decode_obsdata(FILE *fp, char *buff, double ver, int mask,
         switch (ind->type[i]) {
             case 0: obs->P[p[i]]=val[i];
                     obs->code[p[i]]=ind->code[i];
-                    obs->Pstd[p[i]] = std[i] > 0 ? 0.01 * pow(2, std[i] + 5) : 0;
+                    obs->Pstd[p[i]] = std[i] > 0 ? (float)(0.01 * pow(2, std[i] + 5)) : 0.0f;
                     break;
             case 1: obs->L[p[i]]=val[i];
                     obs->LLI[p[i]]=lli[i];
-                    obs->Lstd[p[i]] = std[i] > 0 ? std[i] * 0.004 : 0;
+                    obs->Lstd[p[i]] = std[i] > 0 ? (float)(std[i] * 0.004) : 0.0f;
                     break;
             case 2: obs->D[p[i]]=(float)val[i]; break;
-            case 3: obs->SNR[p[i]]=val[i]; break;
+            case 3: obs->SNR[p[i]]=(float)val[i]; break;
         }
         trace(4, "obs: i=%d f=%d P=%14.3f L=%14.3f LLI=%d code=%d\n",i,p[i],obs->P[p[i]],
         obs->L[p[i]],obs->LLI[p[i]],obs->code[p[i]]);
@@ -1352,7 +1352,7 @@ static int decode_geph(double ver, int sat, gtime_t toc, double *data,
     if (ver >= 3.05) {
       geph->flags = (int)data[15]; // Status flags
       geph->dtaun = data[16];
-      geph->sva = data[17];
+      geph->sva = (int)data[17];
       geph->svh |= ((int)data[18]) << 1; // Extended SVH
     }
     /* some receiver output >128 for minus frequency number */
@@ -1618,7 +1618,7 @@ static int readrnxclk(FILE *fp, const char *opt, double ver, int index, nav_t *n
         if (std > 0) {
           if (last_std_idx < 0) {
             for (int j = 0; j < i; j++)
-              if (nav->pclk[j].clk[k][0] != 0) nav->pclk[j].std[k][0] = std;
+              if (nav->pclk[j].clk[k][0] != 0) nav->pclk[j].std[k][0] = (float)std;
           } else {
             // Linear interpolation of the variance.
             for (int j = last_std_idx + 1; j < i; j++) {
@@ -1637,7 +1637,7 @@ static int readrnxclk(FILE *fp, const char *opt, double ver, int index, nav_t *n
       if (last_std_idx >= 0) {
         double last_std = nav->pclk[last_std_idx].std[k][0];
         for (int j = last_std_idx + 1; j < nav->nc; j++)
-          if (nav->pclk[j].clk[k][0] != 0) nav->pclk[j].std[k][0] = last_std;
+          if (nav->pclk[j].clk[k][0] != 0) nav->pclk[j].std[k][0] = (float)last_std;
       }
     }
 
@@ -1732,7 +1732,7 @@ extern int rnxcomment(rnxopt_t *opt, const char *format, ...) {
         if (!*opt->comment[i]) break;
     }
     // Copy while wrapping overflow into the next comment line.
-    for (int j = 0, rem = strlen(buff); rem > 0; i++) {
+    for (int j = 0, rem = (int)strlen(buff); rem > 0; i++) {
         if (i >= MAXCOMMENT) return 0;
         int indent = j > 0 ? 2 : 0; // Indent overflow lines
         int n = rem > 60 - indent ? 60 - indent : rem;
@@ -2555,13 +2555,13 @@ extern int outrnxobsb(FILE *fp, const rnxopt_t *opt, const obsd_t *obs, int n,
                 case 'P': {
                   // To RTKLib RINEX encoding
                   float std = obs[ind[i]].Pstd[k];
-                  int stdi = std > 0.0003125 ? log2(std * 100) - 5 + 0.5 : 0;
+                  int stdi = std > 0.0003125 ? (int)trunc(log2(std * 100) - 5 + 0.5) : 0;
                   outrnxobsf(fp,obs[ind[i]].P[k],-1,stdi);
                   break;
                 }
                 case 'L': {
                   // To RTKLib RINEX encoding
-                  int lstdi = obs[ind[i]].Lstd[k] / 0.004 + 0.5;
+                  int lstdi = (int)trunc(obs[ind[i]].Lstd[k] / 0.004 + 0.5);
                   outrnxobsf(fp,obs[ind[i]].L[k]+dL,obs[ind[i]].LLI[k],lstdi);
                   break;
                 }

--- a/src/rtcm3.c
+++ b/src/rtcm3.c
@@ -377,7 +377,7 @@ static int decode_type1002(rtcm_t *rtcm)
             rtcm->obs.data[index].L[0]=pr1*freq/CLIGHT+cp1;
         }
         rtcm->obs.data[index].LLI[0]=lossoflock(rtcm,sat,0,lock1);
-        rtcm->obs.data[index].SNR[0]=snratio(cnr1*0.25);
+        rtcm->obs.data[index].SNR[0]=(float)snratio(cnr1*0.25);
         rtcm->obs.data[index].code[0]=code?CODE_L1P:CODE_L1C;
     }
     return sync?0:1;
@@ -434,7 +434,7 @@ static int decode_type1004(rtcm_t *rtcm)
             rtcm->obs.data[index].L[0]=pr1*freq[0]/CLIGHT+cp1;
         }
         rtcm->obs.data[index].LLI[0]=lossoflock(rtcm,sat,0,lock1);
-        rtcm->obs.data[index].SNR[0]=snratio(cnr1*0.25);
+        rtcm->obs.data[index].SNR[0]=(float)snratio(cnr1*0.25);
         rtcm->obs.data[index].code[0]=code1?CODE_L1P:CODE_L1C;
         
         if (pr21!=(int)0xFFFFE000) {
@@ -445,7 +445,7 @@ static int decode_type1004(rtcm_t *rtcm)
             rtcm->obs.data[index].L[1]=pr1*freq[1]/CLIGHT+cp2;
         }
         rtcm->obs.data[index].LLI[1]=lossoflock(rtcm,sat,1,lock2);
-        rtcm->obs.data[index].SNR[1]=snratio(cnr2*0.25);
+        rtcm->obs.data[index].SNR[1]=(float)snratio(cnr2*0.25);
         rtcm->obs.data[index].code[1]=L2codes[code2];
     }
     rtcm->obsflag=!sync;
@@ -682,7 +682,7 @@ static int decode_type1010(rtcm_t *rtcm)
             rtcm->obs.data[index].L[0]=pr1*freq1/CLIGHT+cp1;
         }
         rtcm->obs.data[index].LLI[0]=lossoflock(rtcm,sat,0,lock1);
-        rtcm->obs.data[index].SNR[0]=snratio(cnr1*0.25);
+        rtcm->obs.data[index].SNR[0]=(float)snratio(cnr1*0.25);
         rtcm->obs.data[index].code[0]=code?CODE_L1P:CODE_L1C;
     }
     return sync?0:1;
@@ -737,7 +737,7 @@ static int decode_type1012(rtcm_t *rtcm)
             rtcm->obs.data[index].L[0]=pr1*freq1/CLIGHT+cp1;
         }
         rtcm->obs.data[index].LLI[0]=lossoflock(rtcm,sat,0,lock1);
-        rtcm->obs.data[index].SNR[0]=snratio(cnr1*0.25);
+        rtcm->obs.data[index].SNR[0]=(float)snratio(cnr1*0.25);
         rtcm->obs.data[index].code[0]=code1?CODE_L1P:CODE_L1C;
         
         if (pr21!=(int)0xFFFFE000) {
@@ -749,7 +749,7 @@ static int decode_type1012(rtcm_t *rtcm)
             rtcm->obs.data[index].L[1]=pr1*freq2/CLIGHT+cp2;
         }
         rtcm->obs.data[index].LLI[1]=lossoflock(rtcm,sat,1,lock2);
-        rtcm->obs.data[index].SNR[1]=snratio(cnr2*0.25);
+        rtcm->obs.data[index].SNR[1]=(float)snratio(cnr2*0.25);
         rtcm->obs.data[index].code[1]=code2?CODE_L2P:CODE_L2C;
     }
     rtcm->obsflag=!sync;
@@ -759,7 +759,7 @@ static int decode_type1012(rtcm_t *rtcm)
 static int decode_type1013(rtcm_t *rtcm)
 {
   unsigned i = 24 + 12;
-  if (i + 58 > rtcm->len * 8) {
+  if (i + 58 > (size_t)rtcm->len * 8) {
     trace(2,"rtcm3 1013 length error: len=%d\n", rtcm->len);
     return -1;
   }
@@ -775,14 +775,14 @@ static int decode_type1013(rtcm_t *rtcm)
   unsigned leaps = getbitu(rtcm->buff, i, 8);
   i += 8;
 
-  if (i + nmsg * 29 > rtcm->len * 8) {
+  if (i + nmsg * 29 > (size_t)rtcm->len * 8) {
     trace(2,"rtcm3 1013 length error: len=%d nm=%d\n", rtcm->len, nmsg);
     return -1;
   }
 
   rtcm->nmsg = nmsg;
   uint8_t sync[32];
-  for (int n = 0; n < nmsg; n++) {
+  for (unsigned n = 0; n < nmsg; n++) {
     rtcm->msgs[n] = getbitu(rtcm->buff, i, 12);
     i += 12;
     sync[n] = getbitu(rtcm->buff, i, 1);
@@ -2266,7 +2266,7 @@ static void save_msm_obs(rtcm_t *rtcm, int sys, msm_h_t *h, const double *r,
                 }
                 rtcm->obs.data[index].LLI[idx[k]]=
                     lossoflock(rtcm,sat,idx[k],lock[j])+(half[j]?2:0);
-                rtcm->obs.data[index].SNR [idx[k]]=cnr[j];
+                rtcm->obs.data[index].SNR[idx[k]]=(float)cnr[j];
                 rtcm->obs.data[index].code[idx[k]]=code[k];
             }
             j++;

--- a/src/rtcm3e.c
+++ b/src/rtcm3e.c
@@ -795,20 +795,20 @@ static int encode_type1013(rtcm_t *rtcm, int sync)
     int i = 24;
     const double ep[] = {2000, 1, 1, 12, 0, 0};
     gtime_t utc = gpst2utc(rtcm->time);
-    int leaps = timediff(rtcm->time, utc);
+    int leaps = (int)round(timediff(rtcm->time, utc));
     double mjd = 51544.5 + (timediff(utc, epoch2time(ep))) / 86400.0;
-    uint32_t mjdi = floor(mjd);
-    uint32_t tod = round((mjd - mjdi) * 86400.0);
+    uint32_t mjdi = (uint32_t)floor(mjd);
+    uint32_t tod = (uint32_t)round((mjd - mjdi) * 86400.0);
     setbitu(rtcm->buff, i, 12, 1013      ); i += 12; // Message no.
     setbitu(rtcm->buff, i, 12, 0         ); i += 12; // Ref station id.
-    setbitu(rtcm->buff, i, 16, mjd       ); i += 16; // MJD.
+    setbitu(rtcm->buff, i, 16, mjdi      ); i += 16; // MJD.
     setbitu(rtcm->buff, i, 17, tod       ); i += 17; // Time of day, seconds.
     setbitu(rtcm->buff, i,  5, rtcm->nmsg); i +=  5; // Number of messages.
     setbitu(rtcm->buff, i,  8, leaps     ); i +=  8; // Leap seconds, GPST-UTC.
     for (int n = 0; n < rtcm->nmsg; n++) {
       setbitu(rtcm->buff, i, 12, rtcm->msgs[n]); i+=12; // Message ID.
       setbitu(rtcm->buff, i,  1, 1            ); i+= 1; // Synchronous.
-      setbitu(rtcm->buff, i, 16, round(rtcm->tint[n] * 10.0)); i+= 16; // Interval.
+      setbitu(rtcm->buff, i, 16, (unsigned)round(rtcm->tint[n] * 10.0)); i+= 16; // Interval.
     }
     rtcm->nbit=i;
     return 1;

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -1597,14 +1597,14 @@ extern double str2num(const char *s, int i, int n)
 *          gtime_t *t       O   gtime_t struct
 * return : status (0:ok,0>:error)
 *-----------------------------------------------------------------------------*/
-extern int str2time(const char *s, int i, int n, gtime_t *t)
+extern int str2time(const char *s, size_t i, size_t n, gtime_t *t)
 {
-    double ep[6];
-    char str[256],*p=str;
+    char str[256];
 
-    if (i<0||(int)strlen(s)<i||(int)sizeof(str)-1<i) return -1;
-    for (s+=i;*s&&--n>=0;) *p++=*s++;
-    *p='\0';
+    if (i >= strlen(s) || n >= sizeof(str)) return -1;
+    for (size_t j = 0; j < n; j++) str[j] = s[i + j];
+    str[n] = '\0';
+    double ep[6];
     if (sscanf(str,"%lf %lf %lf %lf %lf %lf",ep,ep+1,ep+2,ep+3,ep+4,ep+5)<6)
         return -1;
     if (ep[0]<100.0) ep[0]+=ep[0]<80.0?2000.0:1900.0;

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1456,7 +1456,7 @@ EXPORT void add_fatal(fatalfunc_t *func);
 /* time and string functions -------------------------------------------------*/
 EXPORT void    setstr(char *dst, const char *src, int n);
 EXPORT double  str2num(const char *s, int i, int n);
-EXPORT int     str2time(const char *s, int i, int n, gtime_t *t);
+EXPORT int     str2time(const char *s, size_t i, size_t n, gtime_t *t);
 EXPORT char    *time2str(gtime_t t, char str[40], int n);
 EXPORT gtime_t epoch2time(const double *ep);
 EXPORT void    time2epoch(gtime_t t, double *ep);
@@ -1843,7 +1843,7 @@ EXPORT void strunlock(stream_t *stream);
 EXPORT int  stropen  (stream_t *stream, int type, int mode, const char *path);
 EXPORT void strclose (stream_t *stream);
 EXPORT int  strread  (stream_t *stream, uint8_t *buff, int n);
-EXPORT int  strwrite (stream_t *stream, uint8_t *buff, int n);
+EXPORT int  strwrite (stream_t *stream, const uint8_t *buff, int n);
 EXPORT void strsync  (stream_t *stream1, stream_t *stream2);
 EXPORT int  strstat  (stream_t *stream, char *msg);
 EXPORT int  strstatx (stream_t *stream, char *msg);
@@ -1918,7 +1918,7 @@ EXPORT void rtksvrclosestr(rtksvr_t *svr, int index);
 EXPORT void rtksvrlock  (rtksvr_t *svr);
 EXPORT void rtksvrunlock(rtksvr_t *svr);
 EXPORT int  rtksvrostat (rtksvr_t *svr, int type, gtime_t *time, int sat[MAXSAT],
-                         double *az, double *el, int snr[MAXSAT][NFREQ], int vsat[MAXSAT][NFREQ]);
+                         double *az, double *el, double snr[MAXSAT][NFREQ], int vsat[MAXSAT][NFREQ]);
 EXPORT void rtksvrsstat (rtksvr_t *svr, int *sstat, char *msg);
 EXPORT int  rtksvrmark(rtksvr_t *svr, const char *name, const char *comment);
 

--- a/src/rtkpos.c
+++ b/src/rtkpos.c
@@ -1786,11 +1786,11 @@ static int resamb_LAMBDA(rtk_t *rtk, double *bias, double *xa,int gps,int glo,in
                     coeff[i] = coeff[i]*opt->thresar[0]+ar_poly_coeffs[i][j];
             }
             /* generate adjusted AR ratio based on # of sat pairs */
-            rtk->sol.thres = coeff[0];
+            rtk->sol.thres = (float)coeff[0];
             for (i=1;i<3;i++) {
-                rtk->sol.thres = rtk->sol.thres*1.0/(nb1+1.0)+coeff[i];
+                rtk->sol.thres = (float)(rtk->sol.thres*1.0/(nb1+1.0)+coeff[i]);
             }
-            rtk->sol.thres = MIN(MAX(rtk->sol.thres,opt->thresar[5]),opt->thresar[6]);
+            rtk->sol.thres = (float)MIN(MAX(rtk->sol.thres,opt->thresar[5]),opt->thresar[6]);
         } else
             rtk->sol.thres=(float)opt->thresar[0];
         /* validation by popular ratio-test of residuals*/
@@ -1848,9 +1848,9 @@ static int resamb_LAMBDA(rtk_t *rtk, double *bias, double *xa,int gps,int glo,in
 static int manage_amb_LAMBDA(rtk_t *rtk, double *bias, double *xa, const int *sat, int nf, int ns)
 {
     int gps1=-1,glo1=-1,sbas1=-1,gps2,glo2,sbas2,nb,rerun,dly;
-    float ratio1,posvar=0;
 
     /* calc position variance, will skip AR if too high to avoid false fix */
+    double posvar = 0;
     for (int i=0;i<3;i++) posvar+=rtk->P[i+i*rtk->nx];
     posvar/=3.0; /* maintain compatibility with previous code */
 
@@ -1913,7 +1913,7 @@ static int manage_amb_LAMBDA(rtk_t *rtk, double *bias, double *xa, const int *sa
     sbas1=(rtk->opt.navsys&SYS_GLO)?glo1:((rtk->opt.navsys&SYS_SBS)?1:0);
     /* first attempt to resolve ambiguities */
     nb=resamb_LAMBDA(rtk,bias,xa,gps1,glo1,sbas1);
-    ratio1=rtk->sol.ratio;
+    float ratio1=rtk->sol.ratio;
     /* reject bad satellites if AR filtering enabled */
     if (rtk->opt.arfilter) {
         rerun=0;
@@ -2049,7 +2049,7 @@ static int relpos(rtk_t *rtk, const obsd_t *obs, int nu, int nr,
 
      if (opt->mode!=PMODE_MOVEB) {
         /* check if exceeded max age of differential */
-        rtk->sol.age=dt;
+        rtk->sol.age=(float)dt;
         if (fabs(rtk->sol.age)>opt->maxtdiff) {
             errmsg(rtk,"age of differential error (age=%.1f)\n",rtk->sol.age);
             free(rs); free(dts); free(var); free(y); free(e); free(azel); free(freq);

--- a/src/rtksvr.c
+++ b/src/rtksvr.c
@@ -1170,13 +1170,13 @@ extern void rtksvrclosestr(rtksvr_t *svr, int index)
 *          int     *sat     O  satellite prn numbers
 *          double  *az      O  satellite azimuth angles (rad)
 *          double  *el      O  satellite elevation angles (rad)
-*          int     **snr    O  satellite snr for each freq (dBHz)
+*          double  **snr    O  satellite snr for each freq (dBHz)
 *                              snr[i][j] = sat i freq j snr
 *          int     *vsat    O  valid satellite flag
 * return : number of satellites
 *-----------------------------------------------------------------------------*/
 extern int rtksvrostat(rtksvr_t *svr, int rcv, gtime_t *time, int sat[MAXSAT],
-                       double *az, double *el, int snr[MAXSAT][NFREQ], int vsat[MAXSAT][NFREQ])
+                       double *az, double *el, double snr[MAXSAT][NFREQ], int vsat[MAXSAT][NFREQ])
 {
     tracet(4,"rtksvrostat: rcv=%d\n",rcv);
     
@@ -1191,7 +1191,7 @@ extern int rtksvrostat(rtksvr_t *svr, int rcv, gtime_t *time, int sat[MAXSAT],
         az  [i]=svr->rtk.ssat[sat[i]-1].azel[0];
         el  [i]=svr->rtk.ssat[sat[i]-1].azel[1];
         for (int j=0;j<NFREQ;j++) {
-            snr[i][j] = (int)(svr->obs[rcv][0].data[i].SNR[j] + 0.5);
+            snr[i][j] = svr->obs[rcv][0].data[i].SNR[j] + 0.5;
             if (svr->rtk.sol.stat == SOLQ_NONE || svr->rtk.sol.stat == SOLQ_SINGLE)
               vsat[i][j] = svr->rtk.ssat[sat[i] - 1].vs;
             else

--- a/src/rtksvr.c
+++ b/src/rtksvr.c
@@ -1170,13 +1170,13 @@ extern void rtksvrclosestr(rtksvr_t *svr, int index)
 *          int     *sat     O  satellite prn numbers
 *          double  *az      O  satellite azimuth angles (rad)
 *          double  *el      O  satellite elevation angles (rad)
-*          int     **snr    O  satellite snr for each freq (dBHz)
+*          double  **snr    O  satellite snr for each freq (dBHz)
 *                              snr[i][j] = sat i freq j snr
 *          int     *vsat    O  valid satellite flag
 * return : number of satellites
 *-----------------------------------------------------------------------------*/
 extern int rtksvrostat(rtksvr_t *svr, int rcv, gtime_t *time, int sat[MAXSAT],
-                       double *az, double *el, int snr[MAXSAT][NFREQ], int vsat[MAXSAT][NFREQ])
+                       double *az, double *el, double snr[MAXSAT][NFREQ], int vsat[MAXSAT][NFREQ])
 {
     tracet(4,"rtksvrostat: rcv=%d\n",rcv);
     
@@ -1191,7 +1191,7 @@ extern int rtksvrostat(rtksvr_t *svr, int rcv, gtime_t *time, int sat[MAXSAT],
         az  [i]=svr->rtk.ssat[sat[i]-1].azel[0];
         el  [i]=svr->rtk.ssat[sat[i]-1].azel[1];
         for (int j=0;j<NFREQ;j++) {
-            snr[i][j] = (int)(svr->obs[rcv][0].data[i].SNR[j] + 0.5);
+            snr[i][j] = svr->obs[rcv][0].data[i].SNR[j];
             if (svr->rtk.sol.stat == SOLQ_NONE || svr->rtk.sol.stat == SOLQ_SINGLE)
               vsat[i][j] = svr->rtk.ssat[sat[i] - 1].vs;
             else

--- a/src/stream.c
+++ b/src/stream.c
@@ -131,10 +131,14 @@
 #define dev_t               HANDLE
 #define socket_t            SOCKET
 typedef int socklen_t;
+#define PRIDEV              "p"
+#define PRISOCK             "llu"
 #else
 #define dev_t               int
 #define socket_t            int
 #define closesocket         close
+#define PRIDEV              "d"
+#define PRISOCK             "d"
 #endif
 
 /* type definition -----------------------------------------------------------*/
@@ -265,7 +269,7 @@ typedef struct {            /* memory buffer type */
 
 static tcpsvr_t *opentcpsvr(const char *path, char *msg);
 static void closetcpsvr(tcpsvr_t *tcpsvr);
-static int writetcpsvr(tcpsvr_t *tcpsvr, uint8_t *buff, int n, char *msg);
+static int writetcpsvr(tcpsvr_t *tcpsvr, const uint8_t *buff, int n, char *msg);
 
 /* global options ------------------------------------------------------------*/
 
@@ -284,7 +288,7 @@ static int readseribuff(serial_t *serial, uint8_t *buff, int nmax)
 {
     int ns;
     
-    tracet(5,"readseribuff: dev=%d\n",serial->dev);
+    tracet(5,"readseribuff: dev=%" PRIDEV "\n",serial->dev);
     
     rtklib_lock(&serial->lock);
     for (ns=0;serial->rp!=serial->wp&&ns<nmax;ns++) {
@@ -295,11 +299,11 @@ static int readseribuff(serial_t *serial, uint8_t *buff, int nmax)
     tracet(5,"readseribuff: ns=%d rp=%d wp=%d\n",ns,serial->rp,serial->wp);
     return ns;
 }
-static int writeseribuff(serial_t *serial, uint8_t *buff, int n)
+static int writeseribuff(serial_t *serial, const uint8_t *buff, int n)
 {
     int ns,wp;
     
-    tracet(5,"writeseribuff: dev=%d n=%d\n",serial->dev,n);
+    tracet(5,"writeseribuff: dev=%" PRIDEV " n=%d\n",serial->dev,n);
     
     rtklib_lock(&serial->lock);
     for (ns=0;ns<n;ns++) {
@@ -492,15 +496,14 @@ static serial_t *openserial(const char *path, int mode, char *msg)
         sprintf(path_tcp,":%d",tcp_port);
         serial->tcpsvr=opentcpsvr(path_tcp,msg_tcp);
     }
-    tracet(3,"openserial: dev=%d\n",serial->dev);
+    tracet(3,"openserial: dev=%" PRIDEV "\n",serial->dev);
     return serial;
 }
 /* close serial --------------------------------------------------------------*/
 static void closeserial(serial_t *serial)
 {
-    tracet(3,"closeserial: dev=%d\n",serial->dev);
-    
     if (!serial) return;
+    tracet(3,"closeserial: dev=%" PRIDEV "\n",serial->dev);
 #ifdef WIN32
     serial->state=0;
     WaitForSingleObject(serial->thread,10000);
@@ -524,14 +527,14 @@ static int readserial(serial_t *serial, uint8_t *buff, int n, char *msg)
 #else
     int nr;
 #endif
-    tracet(4,"readserial: dev=%d n=%d\n",serial->dev,n);
     if (!serial) return 0;
+    tracet(4,"readserial: dev=%" PRIDEV " n=%d\n",serial->dev,n);
 #ifdef WIN32
     if (!ReadFile(serial->dev,buff,n,&nr,NULL)) return 0;
 #else
     if ((nr=read(serial->dev,buff,n))<0) return 0;
 #endif
-    tracet(5,"readserial: exit dev=%d nr=%d\n",serial->dev,nr);
+    tracet(5,"readserial: exit dev=%" PRIDEV " nr=%lu\n",serial->dev,(unsigned long)nr);
     
     /* write received stream to tcp server port */
     if (serial->tcpsvr&&nr>0) {
@@ -541,14 +544,14 @@ static int readserial(serial_t *serial, uint8_t *buff, int n, char *msg)
     return nr;
 }
 /* write serial --------------------------------------------------------------*/
-static int writeserial(serial_t *serial, uint8_t *buff, int n, char *msg)
+static int writeserial(serial_t *serial, const uint8_t *buff, int n, char *msg)
 {
     (void)msg;
     int ns=0;
     
-    tracet(3,"writeserial: dev=%d n=%d\n",serial->dev,n);
-    
     if (!serial) return 0;
+    tracet(3,"writeserial: dev=%" PRIDEV " n=%d\n",serial->dev,n);
+
 #ifdef WIN32
     if ((ns=writeseribuff(serial,buff,n))<n) serial->error=1;
 #else
@@ -561,16 +564,16 @@ static int writeserial(serial_t *serial, uint8_t *buff, int n, char *msg)
         serial->error=1;
     }
 #endif
-    tracet(5,"writeserial: exit dev=%d ns=%d\n",serial->dev,ns);
+    tracet(5,"writeserial: exit dev=%" PRIDEV " ns=%d\n",serial->dev,ns);
     return ns;
 }
 /* get state serial ----------------------------------------------------------*/
-static int stateserial(serial_t *serial)
+static int stateserial(const serial_t *serial)
 {
     return !serial?0:(serial->error?-1:2);
 }
 /* get extended state serial -------------------------------------------------*/
-static int statexserial(serial_t *serial, char *msg)
+static int statexserial(const serial_t *serial, char *msg)
 {
     char *p=msg;
     int state=!serial?0:(serial->error?-1:2);
@@ -578,7 +581,7 @@ static int statexserial(serial_t *serial, char *msg)
     p+=sprintf(p,"serial:\n");
     p+=sprintf(p,"  state   = %d\n",state);
     if (!state) return 0;
-    p+=sprintf(p,"  dev     = %d\n",(int)serial->dev);
+    p+=sprintf(p,"  dev     = %" PRIDEV "\n",serial->dev);
     p+=sprintf(p,"  error   = %d\n",serial->error);
 #ifdef WIN32
     p+=sprintf(p,"  buffsize= %d\n",serial->buffsize);
@@ -783,12 +786,12 @@ static void swapclose(file_t *file)
     file->fp_tmp=file->fp_tag_tmp=NULL;
 }
 /* get state file ------------------------------------------------------------*/
-static int statefile(file_t *file)
+static int statefile(const file_t *file)
 {
     return file?2:0;
 }
 /* get extended state file ---------------------------------------------------*/
-static int statexfile(file_t *file, char *msg)
+static int statexfile(const file_t *file, char *msg)
 {
     char *p=msg,tstr1[40],tstr2[40];
     int state=file?2:0;
@@ -885,7 +888,7 @@ static int readfile(file_t *file, uint8_t *buff, int nmax, char *msg)
     return nr;
 }
 /* write file ----------------------------------------------------------------*/
-static int writefile(file_t *file, uint8_t *buff, int n, char *msg)
+static int writefile(file_t *file, const uint8_t *buff, int n, char *msg)
 {
     gtime_t wtime;
     uint64_t fpos_8B;
@@ -1020,22 +1023,22 @@ static int setsock(socket_t sock, char *msg)
 #else
     struct timeval tv={0};
 #endif
-    tracet(3,"setsock: sock=%d\n",sock);
+    tracet(3,"setsock: sock=%" PRISOCK "\n",sock);
     
     if (setsockopt(sock,SOL_SOCKET,SO_RCVTIMEO,(const char *)&tv,sizeof(tv))==-1||
         setsockopt(sock,SOL_SOCKET,SO_SNDTIMEO,(const char *)&tv,sizeof(tv))==-1) {
         sprintf(msg,"sockopt error: notimeo");
-        tracet(1,"setsock: setsockopt error 1 sock=%d err=%d\n",sock,errsock());
+        tracet(1,"setsock: setsockopt error 1 sock=%" PRISOCK " err=%d\n",sock,errsock());
         closesocket(sock);
         return 0;
     }
     if (setsockopt(sock,SOL_SOCKET,SO_RCVBUF,(const char *)&bs,sizeof(bs))==-1||
         setsockopt(sock,SOL_SOCKET,SO_SNDBUF,(const char *)&bs,sizeof(bs))==-1) {
-        tracet(1,"setsock: setsockopt error 2 sock=%d err=%d bs=%d\n",sock,errsock(),bs);
+        tracet(1,"setsock: setsockopt error 2 sock=%" PRISOCK " err=%d bs=%d\n",sock,errsock(),bs);
         sprintf(msg,"sockopt error: bufsiz");
     }
     if (setsockopt(sock,IPPROTO_TCP,TCP_NODELAY,(const char *)&mode,sizeof(mode))==-1) {
-        tracet(1,"setsock: setsockopt error 3 sock=%d err=%d\n",sock,errsock());
+        tracet(1,"setsock: setsockopt error 3 sock=%" PRISOCK " err=%d\n",sock,errsock());
         sprintf(msg,"sockopt error: nodelay");
     }
     return 1;
@@ -1046,7 +1049,11 @@ static socket_t accept_nb(socket_t sock, struct sockaddr *addr, socklen_t *len, 
     fd_set rs;
     FD_ZERO(&rs); FD_SET(sock, &rs);
     struct timeval tv = {0};
+#ifdef WIN32
+    int ret = select(0, &rs, NULL, NULL, &tv);
+#else
     int ret = select(sock + 1, &rs, NULL, NULL, &tv);
+#endif
     if (ret == 0) {
       *err = 0;
       return (socket_t)ret;
@@ -1084,7 +1091,11 @@ static int connect_nb(socket_t sock, struct sockaddr *addr, socklen_t len, int *
         fd_set rs, ws;
         FD_ZERO(&rs); FD_SET(sock, &rs); ws = rs;
         struct timeval tv = {0};
+#ifdef WIN32
+        if (select(0, &rs, &ws, NULL, &tv) == 0) {
+#else
         if (select(sock + 1, &rs, &ws, NULL, &tv) == 0) {
+#endif
           *err = 0;
           return 0;
         }
@@ -1101,7 +1112,11 @@ static int recv_nb(socket_t sock, uint8_t *buff, int n, int *err)
     fd_set rs;
     FD_ZERO(&rs); FD_SET(sock, &rs);
     struct timeval tv = {0};
+#ifdef WIN32
+    int ret = select(0, &rs, NULL, NULL, &tv);
+#else
     int ret = select(sock + 1, &rs, NULL, NULL, &tv);
+#endif
     if (ret < 0) {
       *err = errsock();
       return ret;
@@ -1123,12 +1138,16 @@ static int recv_nb(socket_t sock, uint8_t *buff, int n, int *err)
     return nr;
 }
 /* non-block send ------------------------------------------------------------*/
-static int send_nb(socket_t sock, uint8_t *buff, int n, int *err)
+static int send_nb(socket_t sock, const uint8_t *buff, int n, int *err)
 {
     fd_set ws;
     FD_ZERO(&ws); FD_SET(sock, &ws);
     struct timeval tv = {0};
+#ifdef WIN32
+    int ret = select(0, NULL, &ws, NULL, &tv);
+#else
     int ret = select(sock + 1, NULL, &ws, NULL, &tv);
+#endif
     if (ret < 0) {
       *err = errsock();
       return ret;
@@ -1148,7 +1167,7 @@ static int send_nb(socket_t sock, uint8_t *buff, int n, int *err)
 /* generate tcp socket -------------------------------------------------------*/
 static int gentcp(tcp_t *tcp, int type, char *msg)
 {
-    struct hostent *hp;
+    const struct hostent *hp;
 #ifdef SVR_REUSEADDR
     int opt=1;
 #endif
@@ -1212,13 +1231,13 @@ static int gentcp(tcp_t *tcp, int type, char *msg)
     }
     tcp->state=1;
     tcp->tact=tickget();
-    tracet(5,"gentcp: exit sock=%d\n",tcp->sock);
+    tracet(5,"gentcp: exit sock=%" PRISOCK "\n",tcp->sock);
     return 1;
 }
 /* disconnect tcp ------------------------------------------------------------*/
 static void discontcp(tcp_t *tcp, int tcon)
 {
-    tracet(3,"discontcp: sock=%d tcon=%d\n",tcp->sock,tcon);
+    tracet(3,"discontcp: sock=%" PRISOCK " tcon=%d\n",tcp->sock,tcon);
     
     closesocket(tcp->sock);
     tcp->state=0;
@@ -1293,18 +1312,18 @@ static int accsock(tcpsvr_t *tcpsvr, char *msg)
     socklen_t len=sizeof(addr);
     int i,err;
     
-    tracet(4,"accsock: sock=%d\n",tcpsvr->svr.sock);
+    tracet(4,"accsock: sock=%" PRISOCK "\n",tcpsvr->svr.sock);
     
     for (i=0;i<MAXCLI;i++) {
         if (tcpsvr->cli[i].state==0) break;
     }
     if (i>=MAXCLI) {
-        tracet(2,"accsock: too many clients sock=%d\n",tcpsvr->svr.sock);
+        tracet(2,"accsock: too many clients sock=%" PRISOCK "\n",tcpsvr->svr.sock);
         return 0;
     }
     if ((sock=accept_nb(tcpsvr->svr.sock,(struct sockaddr *)&addr,&len,&err))==(socket_t)-1) {
         sprintf(msg,"accept error (%d)",err);
-        tracet(1,"accsock: accept error sock=%d err=%d\n",tcpsvr->svr.sock,err);
+        tracet(1,"accsock: accept error sock=%" PRISOCK " err=%d\n",tcpsvr->svr.sock,err);
         closesocket(tcpsvr->svr.sock);
         tcpsvr->svr.state=0;
         return 0;
@@ -1316,7 +1335,7 @@ static int accsock(tcpsvr_t *tcpsvr, char *msg)
     memcpy(&tcpsvr->cli[i].addr,&addr,sizeof(addr));
     strcpy(tcpsvr->cli[i].saddr,inet_ntoa(addr.sin_addr));
     sprintf(msg,"%s",tcpsvr->cli[i].saddr);
-    tracet(3,"accsock: connected sock=%d addr=%s i=%d\n",
+    tracet(3,"accsock: connected sock=%" PRISOCK " addr=%s i=%d\n",
            tcpsvr->cli[i].sock,tcpsvr->cli[i].saddr,i);
     tcpsvr->cli[i].state=2;
     tcpsvr->cli[i].tact=tickget();
@@ -1325,7 +1344,7 @@ static int accsock(tcpsvr_t *tcpsvr, char *msg)
 /* wait socket accept --------------------------------------------------------*/
 static int waittcpsvr(tcpsvr_t *tcpsvr, char *msg)
 {
-    tracet(4,"waittcpsvr: sock=%d state=%d\n",tcpsvr->svr.sock,tcpsvr->svr.state);
+    tracet(4,"waittcpsvr: sock=%" PRISOCK " state=%d\n",tcpsvr->svr.sock,tcpsvr->svr.state);
     
     if (tcpsvr->svr.state<=0) return 0;
     
@@ -1348,7 +1367,7 @@ static int readtcpsvr(tcpsvr_t *tcpsvr, uint8_t *buff, int n, char *msg)
         
         if ((nr=recv_nb(tcpsvr->cli[i].sock,buff,n,&err))==-1) {
             if (err) {
-                tracet(2,"readtcpsvr: recv error sock=%d err=%d\n",
+                tracet(2,"readtcpsvr: recv error sock=%" PRISOCK " err=%d\n",
                        tcpsvr->cli[i].sock,err);
             }
             discontcp(&tcpsvr->cli[i],ticonnect);
@@ -1362,7 +1381,7 @@ static int readtcpsvr(tcpsvr_t *tcpsvr, uint8_t *buff, int n, char *msg)
     return 0;
 }
 /* write tcp server ----------------------------------------------------------*/
-static int writetcpsvr(tcpsvr_t *tcpsvr, uint8_t *buff, int n, char *msg)
+static int writetcpsvr(tcpsvr_t *tcpsvr, const uint8_t *buff, int n, char *msg)
 {
     int i,ns=0,nmax=0,err;
     
@@ -1375,7 +1394,7 @@ static int writetcpsvr(tcpsvr_t *tcpsvr, uint8_t *buff, int n, char *msg)
         
         if ((ns=send_nb(tcpsvr->cli[i].sock,buff,n,&err))==-1) {
             if (err) {
-                tracet(2,"writetcpsvr: send error i=%d sock=%d err=%d\n",i,
+                tracet(2,"writetcpsvr: send error i=%d sock=%" PRISOCK " err=%d\n",i,
                        tcpsvr->cli[i].sock,err);
             }
             discontcp(&tcpsvr->cli[i],ticonnect);
@@ -1389,19 +1408,19 @@ static int writetcpsvr(tcpsvr_t *tcpsvr, uint8_t *buff, int n, char *msg)
     return nmax;
 }
 /* get state tcp server ------------------------------------------------------*/
-static int statetcpsvr(tcpsvr_t *tcpsvr)
+static int statetcpsvr(const tcpsvr_t *tcpsvr)
 {
     return tcpsvr?tcpsvr->svr.state:0;
 }
 /* print extended state tcp --------------------------------------------------*/
-static int statextcp(tcp_t *tcp, char *msg)
+static int statextcp(const tcp_t *tcp, char *msg)
 {
     char *p=msg;
     
     p+=sprintf(p,"    state = %d\n",tcp->state);
     p+=sprintf(p,"    saddr = %s\n",tcp->saddr);
     p+=sprintf(p,"    port  = %d\n",tcp->port);
-    p+=sprintf(p,"    sock  = %d\n",(int)tcp->sock);
+    p+=sprintf(p,"    sock  = %" PRISOCK "\n", tcp->sock);
 #ifdef RTK_DISABLED /* for debug */
     p+=sprintf(p,"    tcon  = %d\n",tcp->tcon);
     p+=sprintf(p,"    tact  = %u\n",tcp->tact);
@@ -1410,7 +1429,7 @@ static int statextcp(tcp_t *tcp, char *msg)
     return (int)(p-msg);
 }
 /* get extended state tcp server ---------------------------------------------*/
-static int statextcpsvr(tcpsvr_t *tcpsvr, char *msg)
+static int statextcpsvr(const tcpsvr_t *tcpsvr, char *msg)
 {
     char *p=msg;
     int i,state=tcpsvr?tcpsvr->svr.state:0;
@@ -1432,7 +1451,7 @@ static int consock(tcpcli_t *tcpcli, char *msg)
 {
     int stat,err;
     
-    tracet(4,"consock: sock=%d\n",tcpcli->svr.sock);
+    tracet(4,"consock: sock=%" PRISOCK "\n",tcpcli->svr.sock);
     
     /* wait re-connect */
     if (tcpcli->svr.tcon<0||(tcpcli->svr.tcon>0&&
@@ -1443,7 +1462,7 @@ static int consock(tcpcli_t *tcpcli, char *msg)
     if ((stat=connect_nb(tcpcli->svr.sock,(struct sockaddr *)&tcpcli->svr.addr,
                          sizeof(tcpcli->svr.addr),&err))==-1) {
         sprintf(msg,"connect error (%d)",err);
-        tracet(2,"consock: connect error sock=%d err=%d\n",tcpcli->svr.sock,err);
+        tracet(2,"consock: connect error sock=%" PRISOCK " err=%d\n",tcpcli->svr.sock,err);
         closesocket(tcpcli->svr.sock);
         tcpcli->svr.state=0;
         return 0;
@@ -1453,7 +1472,7 @@ static int consock(tcpcli_t *tcpcli, char *msg)
         return 0;
     }
     sprintf(msg,"%s",tcpcli->svr.saddr);
-    tracet(3,"consock: connected sock=%d addr=%s\n",tcpcli->svr.sock,tcpcli->svr.saddr);
+    tracet(3,"consock: connected sock=%" PRISOCK " addr=%s\n",tcpcli->svr.sock,tcpcli->svr.saddr);
     tcpcli->svr.state=2;
     tcpcli->svr.tact=tickget();
     return 1;
@@ -1483,7 +1502,7 @@ static tcpcli_t *opentcpcli(const char *path, char *msg)
 /* close tcp client ----------------------------------------------------------*/
 static void closetcpcli(tcpcli_t *tcpcli)
 {
-    tracet(3,"closetcpcli: sock=%d\n",tcpcli->svr.sock);
+    tracet(3,"closetcpcli: sock=%" PRISOCK "\n",tcpcli->svr.sock);
     
     closesocket(tcpcli->svr.sock);
     free(tcpcli);
@@ -1491,7 +1510,7 @@ static void closetcpcli(tcpcli_t *tcpcli)
 /* wait socket connect -------------------------------------------------------*/
 static int waittcpcli(tcpcli_t *tcpcli, char *msg)
 {
-    tracet(4,"waittcpcli: sock=%d state=%d\n",tcpcli->svr.sock,tcpcli->svr.state);
+    tracet(4,"waittcpcli: sock=%" PRISOCK " state=%d\n",tcpcli->svr.sock,tcpcli->svr.state);
     
     if (tcpcli->svr.state<0) return 0;
     
@@ -1505,7 +1524,7 @@ static int waittcpcli(tcpcli_t *tcpcli, char *msg)
         if (tcpcli->toinact>0&&
             (int)(tickget()-tcpcli->svr.tact)>tcpcli->toinact) {
             sprintf(msg,"timeout");
-            tracet(2,"waittcpcli: inactive timeout sock=%d\n",tcpcli->svr.sock);
+            tracet(2,"waittcpcli: inactive timeout sock=%" PRISOCK "\n",tcpcli->svr.sock);
             discontcp(&tcpcli->svr,tcpcli->tirecon);
             return 0;
         }
@@ -1517,13 +1536,13 @@ static int readtcpcli(tcpcli_t *tcpcli, uint8_t *buff, int n, char *msg)
 {
     int nr,err;
     
-    tracet(4,"readtcpcli: sock=%d\n",tcpcli->svr.sock);
+    tracet(4,"readtcpcli: sock=%" PRISOCK "\n",tcpcli->svr.sock);
     
     if (!waittcpcli(tcpcli,msg)) return 0;
     
     if ((nr=recv_nb(tcpcli->svr.sock,buff,n,&err))==-1) {
         if (err) {
-            tracet(2,"readtcpcli: recv error sock=%d err=%d\n",tcpcli->svr.sock,err);
+            tracet(2,"readtcpcli: recv error sock=%" PRISOCK " err=%d\n",tcpcli->svr.sock,err);
             sprintf(msg,"recv error (%d)",err);
         }
         else {
@@ -1533,37 +1552,37 @@ static int readtcpcli(tcpcli_t *tcpcli, uint8_t *buff, int n, char *msg)
         return 0;
     }
     if (nr>0) tcpcli->svr.tact=tickget();
-    tracet(5,"readtcpcli: exit sock=%d nr=%d\n",tcpcli->svr.sock,nr);
+    tracet(5,"readtcpcli: exit sock=%" PRISOCK " nr=%d\n",tcpcli->svr.sock,nr);
     return nr;
 }
 /* write tcp client ----------------------------------------------------------*/
-static int writetcpcli(tcpcli_t *tcpcli, uint8_t *buff, int n, char *msg)
+static int writetcpcli(tcpcli_t *tcpcli, const uint8_t *buff, int n, char *msg)
 {
     int ns,err;
     
-    tracet(3,"writetcpcli: sock=%d state=%d n=%d\n",tcpcli->svr.sock,tcpcli->svr.state,n);
+    tracet(3,"writetcpcli: sock=%" PRISOCK " state=%d n=%d\n",tcpcli->svr.sock,tcpcli->svr.state,n);
     
     if (!waittcpcli(tcpcli,msg)) return 0;
     
     if ((ns=send_nb(tcpcli->svr.sock,buff,n,&err))==-1) {
         if (err) {
-            tracet(2,"writetcp: send error sock=%d err=%d\n",tcpcli->svr.sock,err);
+            tracet(2,"writetcp: send error sock=%" PRISOCK " err=%d\n",tcpcli->svr.sock,err);
             sprintf(msg,"send error (%d)",err);
         }
         discontcp(&tcpcli->svr,tcpcli->tirecon);
         return 0;
     }
     if (ns>0) tcpcli->svr.tact=tickget();
-    tracet(5,"writetcpcli: exit sock=%d ns=%d\n",tcpcli->svr.sock,ns);
+    tracet(5,"writetcpcli: exit sock=%" PRISOCK " ns=%d\n",tcpcli->svr.sock,ns);
     return ns;
 }
 /* get state tcp client ------------------------------------------------------*/
-static int statetcpcli(tcpcli_t *tcpcli)
+static int statetcpcli(const tcpcli_t *tcpcli)
 {
     return tcpcli?tcpcli->svr.state:0;
 }
 /* get extended state tcp client ---------------------------------------------*/
-static int statextcpcli(tcpcli_t *tcpcli, char *msg)
+static int statextcpcli(const tcpcli_t *tcpcli, char *msg)
 {
     (void)msg;
     return tcpcli?tcpcli->svr.state:0;
@@ -1837,7 +1856,7 @@ static int readntrip(ntrip_t *ntrip, uint8_t *buff, int n, char *msg)
     return readtcpcli(ntrip->tcp,buff,n,msg);
 }
 /* write ntrip ---------------------------------------------------------------*/
-static int writentrip(ntrip_t *ntrip, uint8_t *buff, int n, char *msg)
+static int writentrip(ntrip_t *ntrip, const uint8_t *buff, int n, char *msg)
 {
     tracet(3,"writentrip: n=%d\n",n);
     
@@ -1846,12 +1865,12 @@ static int writentrip(ntrip_t *ntrip, uint8_t *buff, int n, char *msg)
     return writetcpcli(ntrip->tcp,buff,n,msg);
 }
 /* get state ntrip -----------------------------------------------------------*/
-static int statentrip(ntrip_t *ntrip)
+static int statentrip(const ntrip_t *ntrip)
 {
     return !ntrip?0:(ntrip->state==0?ntrip->tcp->svr.state:ntrip->state);
 }
 /* get extended state ntrip --------------------------------------------------*/
-static int statexntrip(ntrip_t *ntrip, char *msg)
+static int statexntrip(const ntrip_t *ntrip, char *msg)
 {
     char *p=msg;
     int state=!ntrip?0:(ntrip->state==0?ntrip->tcp->svr.state:ntrip->state);
@@ -2033,7 +2052,7 @@ static void wait_ntripc(ntripc_t *ntripc, char *msg)
         
         if ((n=recv_nb(ntripc->tcp->cli[i].sock,buff,nmax,&err))==-1) {
             if (err) {
-                tracet(2,"wait_ntripc: recv error sock=%d err=%d\n",
+                tracet(2,"wait_ntripc: recv error sock=%" PRISOCK " err=%d\n",
                        ntripc->tcp->cli[i].sock,err);
             }
             discon_ntripc(ntripc,i);
@@ -2062,7 +2081,7 @@ static int readntripc(ntripc_t *ntripc, uint8_t *buff, int n, char *msg)
         
         if (nr<0) {
             if (err) {
-                tracet(2,"readntripc: recv error i=%d sock=%d err=%d\n",i,
+                tracet(2,"readntripc: recv error i=%d sock=%" PRISOCK " err=%d\n",i,
                        ntripc->tcp->cli[i].sock,err);
             }
             discon_ntripc(ntripc,i);
@@ -2075,7 +2094,7 @@ static int readntripc(ntripc_t *ntripc, uint8_t *buff, int n, char *msg)
     return 0;
 }
 /* write ntrip-caster --------------------------------------------------------*/
-static int writentripc(ntripc_t *ntripc, uint8_t *buff, int n, char *msg)
+static int writentripc(ntripc_t *ntripc, const uint8_t *buff, int n, char *msg)
 {
     int i,ns=0,err;
 
@@ -2090,7 +2109,7 @@ static int writentripc(ntripc_t *ntripc, uint8_t *buff, int n, char *msg)
         
         if (ns<n) {
             if (err) {
-                tracet(2,"writentripc: send error i=%d sock=%d err=%d\n",i,
+                tracet(2,"writentripc: send error i=%d sock=%" PRISOCK " err=%d\n",i,
                        ntripc->tcp->cli[i].sock,err);
             }
             discon_ntripc(ntripc,i);
@@ -2102,12 +2121,12 @@ static int writentripc(ntripc_t *ntripc, uint8_t *buff, int n, char *msg)
     return ns;
 }
 /* get state ntrip-caster ----------------------------------------------------*/
-static int statentripc(ntripc_t *ntripc)
+static int statentripc(const ntripc_t *ntripc)
 {
     return !ntripc?0:ntripc->state;
 }
 /* get extended state ntrip-caster -------------------------------------------*/
-static int statexntripc(ntripc_t *ntripc, char *msg)
+static int statexntripc(const ntripc_t *ntripc, char *msg)
 {
     char *p=msg;
     int i,state=!ntripc?0:ntripc->state;
@@ -2135,7 +2154,7 @@ static int statexntripc(ntripc_t *ntripc, char *msg)
 static udp_t *genudp(int type, int port, const char *saddr, char *msg)
 {
     udp_t *udp;
-    struct hostent *hp;
+    const struct hostent *hp;
     int bs=buffsize,opt=1;
     
     tracet(3,"genudp: type=%d\n",type);
@@ -2153,7 +2172,7 @@ static udp_t *genudp(int type, int port, const char *saddr, char *msg)
     }
     if (setsockopt(udp->sock,SOL_SOCKET,SO_RCVBUF,(const char *)&bs,sizeof(bs))==-1||
         setsockopt(udp->sock,SOL_SOCKET,SO_SNDBUF,(const char *)&bs,sizeof(bs))==-1) {
-        tracet(2,"genudp: setsockopt error sock=%d err=%d bs=%d\n",udp->sock,errsock(),bs);
+        tracet(2,"genudp: setsockopt error sock=%" PRISOCK " err=%d bs=%d\n",udp->sock,errsock(),bs);
         sprintf(msg,"sockopt error: bufsiz");
     }
     memset(&udp->addr,0,sizeof(udp->addr));
@@ -2166,7 +2185,7 @@ static udp_t *genudp(int type, int port, const char *saddr, char *msg)
         setsockopt(udp->sock,SOL_SOCKET,SO_REUSEADDR,(const char *)&opt, sizeof(opt));
 #endif
         if (bind(udp->sock,(struct sockaddr *)&udp->addr,sizeof(udp->addr))==-1) {
-            tracet(2,"genudp: bind error sock=%d port=%d err=%d\n",udp->sock,port,errsock());
+            tracet(2,"genudp: bind error sock=%" PRISOCK " port=%d err=%d\n",udp->sock,port,errsock());
             sprintf(msg,"bind error (%d): %d",errsock(),port);
             closesocket(udp->sock);
             free(udp);
@@ -2177,7 +2196,7 @@ static udp_t *genudp(int type, int port, const char *saddr, char *msg)
         if (!strcmp(saddr,"255.255.255.255")&&
             setsockopt(udp->sock,SOL_SOCKET,SO_BROADCAST,(const char *)&opt,
                        sizeof(opt))==-1) {
-            tracet(2,"genudp: setsockopt error sock=%d err=%d\n",udp->sock,errsock());
+            tracet(2,"genudp: setsockopt error sock=%" PRISOCK " err=%d\n",udp->sock,errsock());
             sprintf(msg,"sockopt error: broadcast");
         }
         if (!(hp=gethostbyname(saddr))) {
@@ -2210,7 +2229,7 @@ static udp_t *openudpsvr(const char *path, char *msg)
 /* close udp server ----------------------------------------------------------*/
 static void closeudpsvr(udp_t *udpsvr)
 {
-    tracet(3,"closeudpsvr: sock=%d\n",udpsvr->sock);
+    tracet(3,"closeudpsvr: sock=%" PRISOCK "\n", udpsvr->sock);
     
     closesocket(udpsvr->sock);
     free(udpsvr);
@@ -2223,21 +2242,25 @@ static int readudpsvr(udp_t *udpsvr, uint8_t *buff, int n, char *msg)
     fd_set rs;
     int ret,nr;
     
-    tracet(4,"readudpsvr: sock=%d n=%d\n",udpsvr->sock,n);
+    tracet(4,"readudpsvr: sock=%" PRISOCK " n=%d\n",udpsvr->sock,n);
     
     FD_ZERO(&rs); FD_SET(udpsvr->sock,&rs);
+#ifdef WIN32
+    ret=select(0,&rs,NULL,NULL,&tv);
+#else
     ret=select(udpsvr->sock+1,&rs,NULL,NULL,&tv);
+#endif
     if (ret<=0) return ret;
     nr=recvfrom(udpsvr->sock,(char *)buff,n,0,NULL,NULL);
     return nr<=0?-1:nr;
 }
 /* get state udp server ------------------------------------------------------*/
-static int stateudpsvr(udp_t *udpsvr)
+static int stateudpsvr(const udp_t *udpsvr)
 {
     return udpsvr?udpsvr->state:0;
 }
 /* get extended state udp server ---------------------------------------------*/
-static int statexudpsvr(udp_t *udpsvr, char *msg)
+static int statexudpsvr(const udp_t *udpsvr, char *msg)
 {
     char *p=msg;
     int state=udpsvr?udpsvr->state:0;
@@ -2246,7 +2269,7 @@ static int statexudpsvr(udp_t *udpsvr, char *msg)
     p+=sprintf(p,"  state   = %d\n",state);
     if (!state) return 0;
     p+=sprintf(p,"  type    = %d\n",udpsvr->type);
-    p+=sprintf(p,"  sock    = %d\n",(int)udpsvr->sock);
+    p+=sprintf(p,"  sock    = %" PRISOCK "\n", udpsvr->sock);
     sprintf(p,"  port    = %d\n",udpsvr->port);
     return state;
 }
@@ -2270,27 +2293,27 @@ static udp_t *openudpcli(const char *path, char *msg)
 /* close udp client ----------------------------------------------------------*/
 static void closeudpcli(udp_t *udpcli)
 {
-    tracet(3,"closeudpcli: sock=%d\n",udpcli->sock);
+    tracet(3,"closeudpcli: sock=%" PRISOCK "\n",udpcli->sock);
     
     closesocket(udpcli->sock);
     free(udpcli);
 }
 /* write udp client -----------------------------------------------------------*/
-static int writeudpcli(udp_t *udpcli, uint8_t *buff, int n, char *msg)
+static int writeudpcli(udp_t *udpcli, const uint8_t *buff, int n, char *msg)
 {
     (void)msg;
-    tracet(4,"writeudpcli: sock=%d n=%d\n",udpcli->sock,n);
+    tracet(4,"writeudpcli: sock=%" PRISOCK " n=%d\n",udpcli->sock,n);
     
     return (int)sendto(udpcli->sock,(char *)buff,n,0,
                        (struct sockaddr *)&udpcli->addr,sizeof(udpcli->addr));
 }
 /* get state udp client ------------------------------------------------------*/
-static int stateudpcli(udp_t *udpcli)
+static int stateudpcli(const udp_t *udpcli)
 {
     return udpcli?udpcli->state:0;
 }
 /* get extended state udp client ---------------------------------------------*/
-static int statexudpcli(udp_t *udpcli, char *msg)
+static int statexudpcli(const udp_t *udpcli, char *msg)
 {
     char *p=msg;
     int state=udpcli?udpcli->state:0;
@@ -2299,7 +2322,7 @@ static int statexudpcli(udp_t *udpcli, char *msg)
     p+=sprintf(p,"  state   = %d\n",state);
     if (!state) return 0;
     p+=sprintf(p,"  type    = %d\n",udpcli->type);
-    p+=sprintf(p,"  sock    = %d\n",(int)udpcli->sock);
+    p+=sprintf(p,"  sock    = %" PRISOCK "\n",udpcli->sock);
     p+=sprintf(p,"  addr    = %s\n",udpcli->saddr);
     sprintf(p,"  port    = %d\n",udpcli->port);
     return state;
@@ -2550,12 +2573,12 @@ static int readftp(ftp_t *ftp, uint8_t *buff, int n, char *msg)
     return (int)(p-buff);
 }
 /* get state ftp -------------------------------------------------------------*/
-static int stateftp(ftp_t *ftp)
+static int stateftp(const ftp_t *ftp)
 {
     return !ftp?0:(ftp->state==0?2:(ftp->state<=2?3:-1));
 }
 /* get extended state ftp ----------------------------------------------------*/
-static int statexftp(ftp_t *ftp, char *msg)
+static int statexftp(const ftp_t *ftp, char *msg)
 {
     (void)msg;
     return !ftp?0:(ftp->state==0?2:(ftp->state<=2?3:-1));
@@ -2615,7 +2638,7 @@ static int readmembuf(membuf_t *membuf, uint8_t *buff, int n, char *msg)
     return nr;
 }
 /* write memory buffer -------------------------------------------------------*/
-static int writemembuf(membuf_t *membuf, uint8_t *buff, int n, char *msg)
+static int writemembuf(membuf_t *membuf, const uint8_t *buff, int n, char *msg)
 {
     int i;
     
@@ -2639,12 +2662,12 @@ static int writemembuf(membuf_t *membuf, uint8_t *buff, int n, char *msg)
     return i;
 }
 /* get state memory buffer ---------------------------------------------------*/
-static int statemembuf(membuf_t *membuf)
+static int statemembuf(const membuf_t *membuf)
 {
     return !membuf?0:membuf->state;
 }
 /* get extended state memory buffer ------------------------------------------*/
-static int statexmembuf(membuf_t *membuf, char *msg)
+static int statexmembuf(const membuf_t *membuf, char *msg)
 {
     char *p=msg;
     int state=!membuf?0:membuf->state;
@@ -2953,7 +2976,7 @@ extern int strread(stream_t *stream, uint8_t *buff, int n)
 * return : status (0:error,1:ok)
 * notes  : write data to buffer and return immediately
 *-----------------------------------------------------------------------------*/
-extern int strwrite(stream_t *stream, uint8_t *buff, int n)
+extern int strwrite(stream_t *stream, const uint8_t *buff, int n)
 {
     uint32_t tick=tickget();
     char *msg=stream->msg;

--- a/src/stream.c
+++ b/src/stream.c
@@ -131,10 +131,14 @@
 #define dev_t               HANDLE
 #define socket_t            SOCKET
 typedef int socklen_t;
+#define PRIDEV              "p"
+#define PRISOCK             "llu"
 #else
 #define dev_t               int
 #define socket_t            int
 #define closesocket         close
+#define PRIDEV              "d"
+#define PRISOCK             "d"
 #endif
 
 /* type definition -----------------------------------------------------------*/
@@ -265,7 +269,7 @@ typedef struct {            /* memory buffer type */
 
 static tcpsvr_t *opentcpsvr(const char *path, char *msg);
 static void closetcpsvr(tcpsvr_t *tcpsvr);
-static int writetcpsvr(tcpsvr_t *tcpsvr, uint8_t *buff, int n, char *msg);
+static int writetcpsvr(tcpsvr_t *tcpsvr, const uint8_t *buff, int n, char *msg);
 
 /* global options ------------------------------------------------------------*/
 
@@ -284,7 +288,7 @@ static int readseribuff(serial_t *serial, uint8_t *buff, int nmax)
 {
     int ns;
     
-    tracet(5,"readseribuff: dev=%d\n",serial->dev);
+    tracet(5,"readseribuff: dev=%" PRIDEV "\n",serial->dev);
     
     rtklib_lock(&serial->lock);
     for (ns=0;serial->rp!=serial->wp&&ns<nmax;ns++) {
@@ -299,7 +303,7 @@ static int writeseribuff(serial_t *serial, uint8_t *buff, int n)
 {
     int ns,wp;
     
-    tracet(5,"writeseribuff: dev=%d n=%d\n",serial->dev,n);
+    tracet(5,"writeseribuff: dev=%" PRIDEV " n=%d\n",serial->dev,n);
     
     rtklib_lock(&serial->lock);
     for (ns=0;ns<n;ns++) {
@@ -492,15 +496,14 @@ static serial_t *openserial(const char *path, int mode, char *msg)
         sprintf(path_tcp,":%d",tcp_port);
         serial->tcpsvr=opentcpsvr(path_tcp,msg_tcp);
     }
-    tracet(3,"openserial: dev=%d\n",serial->dev);
+    tracet(3,"openserial: dev=%" PRIDEV "\n",serial->dev);
     return serial;
 }
 /* close serial --------------------------------------------------------------*/
 static void closeserial(serial_t *serial)
 {
-    tracet(3,"closeserial: dev=%d\n",serial->dev);
-    
     if (!serial) return;
+    tracet(3,"closeserial: dev=%" PRIDEV "\n",serial->dev);
 #ifdef WIN32
     serial->state=0;
     WaitForSingleObject(serial->thread,10000);
@@ -524,14 +527,14 @@ static int readserial(serial_t *serial, uint8_t *buff, int n, char *msg)
 #else
     int nr;
 #endif
-    tracet(4,"readserial: dev=%d n=%d\n",serial->dev,n);
     if (!serial) return 0;
+    tracet(4,"readserial: dev=%" PRIDEV " n=%d\n",serial->dev,n);
 #ifdef WIN32
     if (!ReadFile(serial->dev,buff,n,&nr,NULL)) return 0;
 #else
     if ((nr=read(serial->dev,buff,n))<0) return 0;
 #endif
-    tracet(5,"readserial: exit dev=%d nr=%d\n",serial->dev,nr);
+    tracet(5,"readserial: exit dev=%" PRIDEV " nr=%lu\n",serial->dev,(unsigned long)nr);
     
     /* write received stream to tcp server port */
     if (serial->tcpsvr&&nr>0) {
@@ -541,14 +544,14 @@ static int readserial(serial_t *serial, uint8_t *buff, int n, char *msg)
     return nr;
 }
 /* write serial --------------------------------------------------------------*/
-static int writeserial(serial_t *serial, uint8_t *buff, int n, char *msg)
+static int writeserial(serial_t *serial, const uint8_t *buff, int n, char *msg)
 {
     (void)msg;
     int ns=0;
     
-    tracet(3,"writeserial: dev=%d n=%d\n",serial->dev,n);
-    
     if (!serial) return 0;
+    tracet(3,"writeserial: dev=%" PRIDEV " n=%d\n",serial->dev,n);
+
 #ifdef WIN32
     if ((ns=writeseribuff(serial,buff,n))<n) serial->error=1;
 #else
@@ -561,16 +564,16 @@ static int writeserial(serial_t *serial, uint8_t *buff, int n, char *msg)
         serial->error=1;
     }
 #endif
-    tracet(5,"writeserial: exit dev=%d ns=%d\n",serial->dev,ns);
+    tracet(5,"writeserial: exit dev=%" PRIDEV " ns=%d\n",serial->dev,ns);
     return ns;
 }
 /* get state serial ----------------------------------------------------------*/
-static int stateserial(serial_t *serial)
+static int stateserial(const serial_t *serial)
 {
     return !serial?0:(serial->error?-1:2);
 }
 /* get extended state serial -------------------------------------------------*/
-static int statexserial(serial_t *serial, char *msg)
+static int statexserial(const serial_t *serial, char *msg)
 {
     char *p=msg;
     int state=!serial?0:(serial->error?-1:2);
@@ -578,7 +581,7 @@ static int statexserial(serial_t *serial, char *msg)
     p+=sprintf(p,"serial:\n");
     p+=sprintf(p,"  state   = %d\n",state);
     if (!state) return 0;
-    p+=sprintf(p,"  dev     = %d\n",(int)serial->dev);
+    p+=sprintf(p,"  dev     = %" PRIDEV "\n",serial->dev);
     p+=sprintf(p,"  error   = %d\n",serial->error);
 #ifdef WIN32
     p+=sprintf(p,"  buffsize= %d\n",serial->buffsize);
@@ -783,12 +786,12 @@ static void swapclose(file_t *file)
     file->fp_tmp=file->fp_tag_tmp=NULL;
 }
 /* get state file ------------------------------------------------------------*/
-static int statefile(file_t *file)
+static int statefile(const file_t *file)
 {
     return file?2:0;
 }
 /* get extended state file ---------------------------------------------------*/
-static int statexfile(file_t *file, char *msg)
+static int statexfile(const file_t *file, char *msg)
 {
     char *p=msg,tstr1[40],tstr2[40];
     int state=file?2:0;
@@ -885,7 +888,7 @@ static int readfile(file_t *file, uint8_t *buff, int nmax, char *msg)
     return nr;
 }
 /* write file ----------------------------------------------------------------*/
-static int writefile(file_t *file, uint8_t *buff, int n, char *msg)
+static int writefile(file_t *file, const uint8_t *buff, int n, char *msg)
 {
     gtime_t wtime;
     uint64_t fpos_8B;
@@ -1020,22 +1023,22 @@ static int setsock(socket_t sock, char *msg)
 #else
     struct timeval tv={0};
 #endif
-    tracet(3,"setsock: sock=%d\n",sock);
+    tracet(3,"setsock: sock=%" PRISOCK "\n",sock);
     
     if (setsockopt(sock,SOL_SOCKET,SO_RCVTIMEO,(const char *)&tv,sizeof(tv))==-1||
         setsockopt(sock,SOL_SOCKET,SO_SNDTIMEO,(const char *)&tv,sizeof(tv))==-1) {
         sprintf(msg,"sockopt error: notimeo");
-        tracet(1,"setsock: setsockopt error 1 sock=%d err=%d\n",sock,errsock());
+        tracet(1,"setsock: setsockopt error 1 sock=%" PRISOCK " err=%d\n",sock,errsock());
         closesocket(sock);
         return 0;
     }
     if (setsockopt(sock,SOL_SOCKET,SO_RCVBUF,(const char *)&bs,sizeof(bs))==-1||
         setsockopt(sock,SOL_SOCKET,SO_SNDBUF,(const char *)&bs,sizeof(bs))==-1) {
-        tracet(1,"setsock: setsockopt error 2 sock=%d err=%d bs=%d\n",sock,errsock(),bs);
+        tracet(1,"setsock: setsockopt error 2 sock=%" PRISOCK " err=%d bs=%d\n",sock,errsock(),bs);
         sprintf(msg,"sockopt error: bufsiz");
     }
     if (setsockopt(sock,IPPROTO_TCP,TCP_NODELAY,(const char *)&mode,sizeof(mode))==-1) {
-        tracet(1,"setsock: setsockopt error 3 sock=%d err=%d\n",sock,errsock());
+        tracet(1,"setsock: setsockopt error 3 sock=%" PRISOCK " err=%d\n",sock,errsock());
         sprintf(msg,"sockopt error: nodelay");
     }
     return 1;
@@ -1046,7 +1049,11 @@ static socket_t accept_nb(socket_t sock, struct sockaddr *addr, socklen_t *len, 
     fd_set rs;
     FD_ZERO(&rs); FD_SET(sock, &rs);
     struct timeval tv = {0};
+#ifdef WIN32
+    int ret = select(0, &rs, NULL, NULL, &tv);
+#else
     int ret = select(sock + 1, &rs, NULL, NULL, &tv);
+#endif
     if (ret == 0) {
       *err = 0;
       return (socket_t)ret;
@@ -1084,7 +1091,11 @@ static int connect_nb(socket_t sock, struct sockaddr *addr, socklen_t len, int *
         fd_set rs, ws;
         FD_ZERO(&rs); FD_SET(sock, &rs); ws = rs;
         struct timeval tv = {0};
+#ifdef WIN32
+        if (select(0, &rs, &ws, NULL, &tv) == 0) {
+#else
         if (select(sock + 1, &rs, &ws, NULL, &tv) == 0) {
+#endif
           *err = 0;
           return 0;
         }
@@ -1101,7 +1112,11 @@ static int recv_nb(socket_t sock, uint8_t *buff, int n, int *err)
     fd_set rs;
     FD_ZERO(&rs); FD_SET(sock, &rs);
     struct timeval tv = {0};
+#ifdef WIN32
+    int ret = select(0, &rs, NULL, NULL, &tv);
+#else
     int ret = select(sock + 1, &rs, NULL, NULL, &tv);
+#endif
     if (ret < 0) {
       *err = errsock();
       return ret;
@@ -1123,12 +1138,16 @@ static int recv_nb(socket_t sock, uint8_t *buff, int n, int *err)
     return nr;
 }
 /* non-block send ------------------------------------------------------------*/
-static int send_nb(socket_t sock, uint8_t *buff, int n, int *err)
+static int send_nb(socket_t sock, const uint8_t *buff, int n, int *err)
 {
     fd_set ws;
     FD_ZERO(&ws); FD_SET(sock, &ws);
     struct timeval tv = {0};
+#ifdef WIN32
+    int ret = select(0, NULL, &ws, NULL, &tv);
+#else
     int ret = select(sock + 1, NULL, &ws, NULL, &tv);
+#endif
     if (ret < 0) {
       *err = errsock();
       return ret;
@@ -1148,7 +1167,7 @@ static int send_nb(socket_t sock, uint8_t *buff, int n, int *err)
 /* generate tcp socket -------------------------------------------------------*/
 static int gentcp(tcp_t *tcp, int type, char *msg)
 {
-    struct hostent *hp;
+    const struct hostent *hp;
 #ifdef SVR_REUSEADDR
     int opt=1;
 #endif
@@ -1212,13 +1231,13 @@ static int gentcp(tcp_t *tcp, int type, char *msg)
     }
     tcp->state=1;
     tcp->tact=tickget();
-    tracet(5,"gentcp: exit sock=%d\n",tcp->sock);
+    tracet(5,"gentcp: exit sock=%" PRISOCK "\n",tcp->sock);
     return 1;
 }
 /* disconnect tcp ------------------------------------------------------------*/
 static void discontcp(tcp_t *tcp, int tcon)
 {
-    tracet(3,"discontcp: sock=%d tcon=%d\n",tcp->sock,tcon);
+    tracet(3,"discontcp: sock=%" PRISOCK " tcon=%d\n",tcp->sock,tcon);
     
     closesocket(tcp->sock);
     tcp->state=0;
@@ -1293,18 +1312,18 @@ static int accsock(tcpsvr_t *tcpsvr, char *msg)
     socklen_t len=sizeof(addr);
     int i,err;
     
-    tracet(4,"accsock: sock=%d\n",tcpsvr->svr.sock);
+    tracet(4,"accsock: sock=%" PRISOCK "\n",tcpsvr->svr.sock);
     
     for (i=0;i<MAXCLI;i++) {
         if (tcpsvr->cli[i].state==0) break;
     }
     if (i>=MAXCLI) {
-        tracet(2,"accsock: too many clients sock=%d\n",tcpsvr->svr.sock);
+        tracet(2,"accsock: too many clients sock=%" PRISOCK "\n",tcpsvr->svr.sock);
         return 0;
     }
     if ((sock=accept_nb(tcpsvr->svr.sock,(struct sockaddr *)&addr,&len,&err))==(socket_t)-1) {
         sprintf(msg,"accept error (%d)",err);
-        tracet(1,"accsock: accept error sock=%d err=%d\n",tcpsvr->svr.sock,err);
+        tracet(1,"accsock: accept error sock=%" PRISOCK " err=%d\n",tcpsvr->svr.sock,err);
         closesocket(tcpsvr->svr.sock);
         tcpsvr->svr.state=0;
         return 0;
@@ -1316,7 +1335,7 @@ static int accsock(tcpsvr_t *tcpsvr, char *msg)
     memcpy(&tcpsvr->cli[i].addr,&addr,sizeof(addr));
     strcpy(tcpsvr->cli[i].saddr,inet_ntoa(addr.sin_addr));
     sprintf(msg,"%s",tcpsvr->cli[i].saddr);
-    tracet(3,"accsock: connected sock=%d addr=%s i=%d\n",
+    tracet(3,"accsock: connected sock=%" PRISOCK " addr=%s i=%d\n",
            tcpsvr->cli[i].sock,tcpsvr->cli[i].saddr,i);
     tcpsvr->cli[i].state=2;
     tcpsvr->cli[i].tact=tickget();
@@ -1325,7 +1344,7 @@ static int accsock(tcpsvr_t *tcpsvr, char *msg)
 /* wait socket accept --------------------------------------------------------*/
 static int waittcpsvr(tcpsvr_t *tcpsvr, char *msg)
 {
-    tracet(4,"waittcpsvr: sock=%d state=%d\n",tcpsvr->svr.sock,tcpsvr->svr.state);
+    tracet(4,"waittcpsvr: sock=%" PRISOCK " state=%d\n",tcpsvr->svr.sock,tcpsvr->svr.state);
     
     if (tcpsvr->svr.state<=0) return 0;
     
@@ -1348,7 +1367,7 @@ static int readtcpsvr(tcpsvr_t *tcpsvr, uint8_t *buff, int n, char *msg)
         
         if ((nr=recv_nb(tcpsvr->cli[i].sock,buff,n,&err))==-1) {
             if (err) {
-                tracet(2,"readtcpsvr: recv error sock=%d err=%d\n",
+                tracet(2,"readtcpsvr: recv error sock=%" PRISOCK " err=%d\n",
                        tcpsvr->cli[i].sock,err);
             }
             discontcp(&tcpsvr->cli[i],ticonnect);
@@ -1362,7 +1381,7 @@ static int readtcpsvr(tcpsvr_t *tcpsvr, uint8_t *buff, int n, char *msg)
     return 0;
 }
 /* write tcp server ----------------------------------------------------------*/
-static int writetcpsvr(tcpsvr_t *tcpsvr, uint8_t *buff, int n, char *msg)
+static int writetcpsvr(tcpsvr_t *tcpsvr, const uint8_t *buff, int n, char *msg)
 {
     int i,ns=0,nmax=0,err;
     
@@ -1375,7 +1394,7 @@ static int writetcpsvr(tcpsvr_t *tcpsvr, uint8_t *buff, int n, char *msg)
         
         if ((ns=send_nb(tcpsvr->cli[i].sock,buff,n,&err))==-1) {
             if (err) {
-                tracet(2,"writetcpsvr: send error i=%d sock=%d err=%d\n",i,
+                tracet(2,"writetcpsvr: send error i=%d sock=%" PRISOCK " err=%d\n",i,
                        tcpsvr->cli[i].sock,err);
             }
             discontcp(&tcpsvr->cli[i],ticonnect);
@@ -1389,19 +1408,19 @@ static int writetcpsvr(tcpsvr_t *tcpsvr, uint8_t *buff, int n, char *msg)
     return nmax;
 }
 /* get state tcp server ------------------------------------------------------*/
-static int statetcpsvr(tcpsvr_t *tcpsvr)
+static int statetcpsvr(const tcpsvr_t *tcpsvr)
 {
     return tcpsvr?tcpsvr->svr.state:0;
 }
 /* print extended state tcp --------------------------------------------------*/
-static int statextcp(tcp_t *tcp, char *msg)
+static int statextcp(const tcp_t *tcp, char *msg)
 {
     char *p=msg;
     
     p+=sprintf(p,"    state = %d\n",tcp->state);
     p+=sprintf(p,"    saddr = %s\n",tcp->saddr);
     p+=sprintf(p,"    port  = %d\n",tcp->port);
-    p+=sprintf(p,"    sock  = %d\n",(int)tcp->sock);
+    p+=sprintf(p,"    sock  = %" PRISOCK "\n", tcp->sock);
 #ifdef RTK_DISABLED /* for debug */
     p+=sprintf(p,"    tcon  = %d\n",tcp->tcon);
     p+=sprintf(p,"    tact  = %u\n",tcp->tact);
@@ -1410,7 +1429,7 @@ static int statextcp(tcp_t *tcp, char *msg)
     return (int)(p-msg);
 }
 /* get extended state tcp server ---------------------------------------------*/
-static int statextcpsvr(tcpsvr_t *tcpsvr, char *msg)
+static int statextcpsvr(const tcpsvr_t *tcpsvr, char *msg)
 {
     char *p=msg;
     int i,state=tcpsvr?tcpsvr->svr.state:0;
@@ -1432,7 +1451,7 @@ static int consock(tcpcli_t *tcpcli, char *msg)
 {
     int stat,err;
     
-    tracet(4,"consock: sock=%d\n",tcpcli->svr.sock);
+    tracet(4,"consock: sock=%" PRISOCK "\n",tcpcli->svr.sock);
     
     /* wait re-connect */
     if (tcpcli->svr.tcon<0||(tcpcli->svr.tcon>0&&
@@ -1443,7 +1462,7 @@ static int consock(tcpcli_t *tcpcli, char *msg)
     if ((stat=connect_nb(tcpcli->svr.sock,(struct sockaddr *)&tcpcli->svr.addr,
                          sizeof(tcpcli->svr.addr),&err))==-1) {
         sprintf(msg,"connect error (%d)",err);
-        tracet(2,"consock: connect error sock=%d err=%d\n",tcpcli->svr.sock,err);
+        tracet(2,"consock: connect error sock=%" PRISOCK " err=%d\n",tcpcli->svr.sock,err);
         closesocket(tcpcli->svr.sock);
         tcpcli->svr.state=0;
         return 0;
@@ -1453,7 +1472,7 @@ static int consock(tcpcli_t *tcpcli, char *msg)
         return 0;
     }
     sprintf(msg,"%s",tcpcli->svr.saddr);
-    tracet(3,"consock: connected sock=%d addr=%s\n",tcpcli->svr.sock,tcpcli->svr.saddr);
+    tracet(3,"consock: connected sock=%" PRISOCK " addr=%s\n",tcpcli->svr.sock,tcpcli->svr.saddr);
     tcpcli->svr.state=2;
     tcpcli->svr.tact=tickget();
     return 1;
@@ -1483,7 +1502,7 @@ static tcpcli_t *opentcpcli(const char *path, char *msg)
 /* close tcp client ----------------------------------------------------------*/
 static void closetcpcli(tcpcli_t *tcpcli)
 {
-    tracet(3,"closetcpcli: sock=%d\n",tcpcli->svr.sock);
+    tracet(3,"closetcpcli: sock=%" PRISOCK "\n",tcpcli->svr.sock);
     
     closesocket(tcpcli->svr.sock);
     free(tcpcli);
@@ -1491,7 +1510,7 @@ static void closetcpcli(tcpcli_t *tcpcli)
 /* wait socket connect -------------------------------------------------------*/
 static int waittcpcli(tcpcli_t *tcpcli, char *msg)
 {
-    tracet(4,"waittcpcli: sock=%d state=%d\n",tcpcli->svr.sock,tcpcli->svr.state);
+    tracet(4,"waittcpcli: sock=%" PRISOCK " state=%d\n",tcpcli->svr.sock,tcpcli->svr.state);
     
     if (tcpcli->svr.state<0) return 0;
     
@@ -1505,7 +1524,7 @@ static int waittcpcli(tcpcli_t *tcpcli, char *msg)
         if (tcpcli->toinact>0&&
             (int)(tickget()-tcpcli->svr.tact)>tcpcli->toinact) {
             sprintf(msg,"timeout");
-            tracet(2,"waittcpcli: inactive timeout sock=%d\n",tcpcli->svr.sock);
+            tracet(2,"waittcpcli: inactive timeout sock=%" PRISOCK "\n",tcpcli->svr.sock);
             discontcp(&tcpcli->svr,tcpcli->tirecon);
             return 0;
         }
@@ -1517,13 +1536,13 @@ static int readtcpcli(tcpcli_t *tcpcli, uint8_t *buff, int n, char *msg)
 {
     int nr,err;
     
-    tracet(4,"readtcpcli: sock=%d\n",tcpcli->svr.sock);
+    tracet(4,"readtcpcli: sock=%" PRISOCK "\n",tcpcli->svr.sock);
     
     if (!waittcpcli(tcpcli,msg)) return 0;
     
     if ((nr=recv_nb(tcpcli->svr.sock,buff,n,&err))==-1) {
         if (err) {
-            tracet(2,"readtcpcli: recv error sock=%d err=%d\n",tcpcli->svr.sock,err);
+            tracet(2,"readtcpcli: recv error sock=%" PRISOCK " err=%d\n",tcpcli->svr.sock,err);
             sprintf(msg,"recv error (%d)",err);
         }
         else {
@@ -1533,37 +1552,37 @@ static int readtcpcli(tcpcli_t *tcpcli, uint8_t *buff, int n, char *msg)
         return 0;
     }
     if (nr>0) tcpcli->svr.tact=tickget();
-    tracet(5,"readtcpcli: exit sock=%d nr=%d\n",tcpcli->svr.sock,nr);
+    tracet(5,"readtcpcli: exit sock=%" PRISOCK " nr=%d\n",tcpcli->svr.sock,nr);
     return nr;
 }
 /* write tcp client ----------------------------------------------------------*/
-static int writetcpcli(tcpcli_t *tcpcli, uint8_t *buff, int n, char *msg)
+static int writetcpcli(tcpcli_t *tcpcli, const uint8_t *buff, int n, char *msg)
 {
     int ns,err;
     
-    tracet(3,"writetcpcli: sock=%d state=%d n=%d\n",tcpcli->svr.sock,tcpcli->svr.state,n);
+    tracet(3,"writetcpcli: sock=%" PRISOCK " state=%d n=%d\n",tcpcli->svr.sock,tcpcli->svr.state,n);
     
     if (!waittcpcli(tcpcli,msg)) return 0;
     
     if ((ns=send_nb(tcpcli->svr.sock,buff,n,&err))==-1) {
         if (err) {
-            tracet(2,"writetcp: send error sock=%d err=%d\n",tcpcli->svr.sock,err);
+            tracet(2,"writetcp: send error sock=%" PRISOCK " err=%d\n",tcpcli->svr.sock,err);
             sprintf(msg,"send error (%d)",err);
         }
         discontcp(&tcpcli->svr,tcpcli->tirecon);
         return 0;
     }
     if (ns>0) tcpcli->svr.tact=tickget();
-    tracet(5,"writetcpcli: exit sock=%d ns=%d\n",tcpcli->svr.sock,ns);
+    tracet(5,"writetcpcli: exit sock=%" PRISOCK " ns=%d\n",tcpcli->svr.sock,ns);
     return ns;
 }
 /* get state tcp client ------------------------------------------------------*/
-static int statetcpcli(tcpcli_t *tcpcli)
+static int statetcpcli(const tcpcli_t *tcpcli)
 {
     return tcpcli?tcpcli->svr.state:0;
 }
 /* get extended state tcp client ---------------------------------------------*/
-static int statextcpcli(tcpcli_t *tcpcli, char *msg)
+static int statextcpcli(const tcpcli_t *tcpcli, char *msg)
 {
     (void)msg;
     return tcpcli?tcpcli->svr.state:0;
@@ -1837,7 +1856,7 @@ static int readntrip(ntrip_t *ntrip, uint8_t *buff, int n, char *msg)
     return readtcpcli(ntrip->tcp,buff,n,msg);
 }
 /* write ntrip ---------------------------------------------------------------*/
-static int writentrip(ntrip_t *ntrip, uint8_t *buff, int n, char *msg)
+static int writentrip(ntrip_t *ntrip, const uint8_t *buff, int n, char *msg)
 {
     tracet(3,"writentrip: n=%d\n",n);
     
@@ -1846,12 +1865,12 @@ static int writentrip(ntrip_t *ntrip, uint8_t *buff, int n, char *msg)
     return writetcpcli(ntrip->tcp,buff,n,msg);
 }
 /* get state ntrip -----------------------------------------------------------*/
-static int statentrip(ntrip_t *ntrip)
+static int statentrip(const ntrip_t *ntrip)
 {
     return !ntrip?0:(ntrip->state==0?ntrip->tcp->svr.state:ntrip->state);
 }
 /* get extended state ntrip --------------------------------------------------*/
-static int statexntrip(ntrip_t *ntrip, char *msg)
+static int statexntrip(const ntrip_t *ntrip, char *msg)
 {
     char *p=msg;
     int state=!ntrip?0:(ntrip->state==0?ntrip->tcp->svr.state:ntrip->state);
@@ -2033,7 +2052,7 @@ static void wait_ntripc(ntripc_t *ntripc, char *msg)
         
         if ((n=recv_nb(ntripc->tcp->cli[i].sock,buff,nmax,&err))==-1) {
             if (err) {
-                tracet(2,"wait_ntripc: recv error sock=%d err=%d\n",
+                tracet(2,"wait_ntripc: recv error sock=%" PRISOCK " err=%d\n",
                        ntripc->tcp->cli[i].sock,err);
             }
             discon_ntripc(ntripc,i);
@@ -2062,7 +2081,7 @@ static int readntripc(ntripc_t *ntripc, uint8_t *buff, int n, char *msg)
         
         if (nr<0) {
             if (err) {
-                tracet(2,"readntripc: recv error i=%d sock=%d err=%d\n",i,
+                tracet(2,"readntripc: recv error i=%d sock=%" PRISOCK " err=%d\n",i,
                        ntripc->tcp->cli[i].sock,err);
             }
             discon_ntripc(ntripc,i);
@@ -2075,7 +2094,7 @@ static int readntripc(ntripc_t *ntripc, uint8_t *buff, int n, char *msg)
     return 0;
 }
 /* write ntrip-caster --------------------------------------------------------*/
-static int writentripc(ntripc_t *ntripc, uint8_t *buff, int n, char *msg)
+static int writentripc(ntripc_t *ntripc, const uint8_t *buff, int n, char *msg)
 {
     int i,ns=0,err;
 
@@ -2090,7 +2109,7 @@ static int writentripc(ntripc_t *ntripc, uint8_t *buff, int n, char *msg)
         
         if (ns<n) {
             if (err) {
-                tracet(2,"writentripc: send error i=%d sock=%d err=%d\n",i,
+                tracet(2,"writentripc: send error i=%d sock=%" PRISOCK " err=%d\n",i,
                        ntripc->tcp->cli[i].sock,err);
             }
             discon_ntripc(ntripc,i);
@@ -2102,12 +2121,12 @@ static int writentripc(ntripc_t *ntripc, uint8_t *buff, int n, char *msg)
     return ns;
 }
 /* get state ntrip-caster ----------------------------------------------------*/
-static int statentripc(ntripc_t *ntripc)
+static int statentripc(const ntripc_t *ntripc)
 {
     return !ntripc?0:ntripc->state;
 }
 /* get extended state ntrip-caster -------------------------------------------*/
-static int statexntripc(ntripc_t *ntripc, char *msg)
+static int statexntripc(const ntripc_t *ntripc, char *msg)
 {
     char *p=msg;
     int i,state=!ntripc?0:ntripc->state;
@@ -2135,7 +2154,7 @@ static int statexntripc(ntripc_t *ntripc, char *msg)
 static udp_t *genudp(int type, int port, const char *saddr, char *msg)
 {
     udp_t *udp;
-    struct hostent *hp;
+    const struct hostent *hp;
     int bs=buffsize,opt=1;
     
     tracet(3,"genudp: type=%d\n",type);
@@ -2153,7 +2172,7 @@ static udp_t *genudp(int type, int port, const char *saddr, char *msg)
     }
     if (setsockopt(udp->sock,SOL_SOCKET,SO_RCVBUF,(const char *)&bs,sizeof(bs))==-1||
         setsockopt(udp->sock,SOL_SOCKET,SO_SNDBUF,(const char *)&bs,sizeof(bs))==-1) {
-        tracet(2,"genudp: setsockopt error sock=%d err=%d bs=%d\n",udp->sock,errsock(),bs);
+        tracet(2,"genudp: setsockopt error sock=%" PRISOCK " err=%d bs=%d\n",udp->sock,errsock(),bs);
         sprintf(msg,"sockopt error: bufsiz");
     }
     memset(&udp->addr,0,sizeof(udp->addr));
@@ -2166,7 +2185,7 @@ static udp_t *genudp(int type, int port, const char *saddr, char *msg)
         setsockopt(udp->sock,SOL_SOCKET,SO_REUSEADDR,(const char *)&opt, sizeof(opt));
 #endif
         if (bind(udp->sock,(struct sockaddr *)&udp->addr,sizeof(udp->addr))==-1) {
-            tracet(2,"genudp: bind error sock=%d port=%d err=%d\n",udp->sock,port,errsock());
+            tracet(2,"genudp: bind error sock=%" PRISOCK " port=%d err=%d\n",udp->sock,port,errsock());
             sprintf(msg,"bind error (%d): %d",errsock(),port);
             closesocket(udp->sock);
             free(udp);
@@ -2177,7 +2196,7 @@ static udp_t *genudp(int type, int port, const char *saddr, char *msg)
         if (!strcmp(saddr,"255.255.255.255")&&
             setsockopt(udp->sock,SOL_SOCKET,SO_BROADCAST,(const char *)&opt,
                        sizeof(opt))==-1) {
-            tracet(2,"genudp: setsockopt error sock=%d err=%d\n",udp->sock,errsock());
+            tracet(2,"genudp: setsockopt error sock=%" PRISOCK " err=%d\n",udp->sock,errsock());
             sprintf(msg,"sockopt error: broadcast");
         }
         if (!(hp=gethostbyname(saddr))) {
@@ -2210,7 +2229,7 @@ static udp_t *openudpsvr(const char *path, char *msg)
 /* close udp server ----------------------------------------------------------*/
 static void closeudpsvr(udp_t *udpsvr)
 {
-    tracet(3,"closeudpsvr: sock=%d\n",udpsvr->sock);
+    tracet(3,"closeudpsvr: sock=%" PRISOCK "\n", udpsvr->sock);
     
     closesocket(udpsvr->sock);
     free(udpsvr);
@@ -2223,21 +2242,25 @@ static int readudpsvr(udp_t *udpsvr, uint8_t *buff, int n, char *msg)
     fd_set rs;
     int ret,nr;
     
-    tracet(4,"readudpsvr: sock=%d n=%d\n",udpsvr->sock,n);
+    tracet(4,"readudpsvr: sock=%" PRISOCK " n=%d\n",udpsvr->sock,n);
     
     FD_ZERO(&rs); FD_SET(udpsvr->sock,&rs);
+#ifdef WIN32
+    ret=select(0,&rs,NULL,NULL,&tv);
+#else
     ret=select(udpsvr->sock+1,&rs,NULL,NULL,&tv);
+#endif
     if (ret<=0) return ret;
     nr=recvfrom(udpsvr->sock,(char *)buff,n,0,NULL,NULL);
     return nr<=0?-1:nr;
 }
 /* get state udp server ------------------------------------------------------*/
-static int stateudpsvr(udp_t *udpsvr)
+static int stateudpsvr(const udp_t *udpsvr)
 {
     return udpsvr?udpsvr->state:0;
 }
 /* get extended state udp server ---------------------------------------------*/
-static int statexudpsvr(udp_t *udpsvr, char *msg)
+static int statexudpsvr(const udp_t *udpsvr, char *msg)
 {
     char *p=msg;
     int state=udpsvr?udpsvr->state:0;
@@ -2246,7 +2269,7 @@ static int statexudpsvr(udp_t *udpsvr, char *msg)
     p+=sprintf(p,"  state   = %d\n",state);
     if (!state) return 0;
     p+=sprintf(p,"  type    = %d\n",udpsvr->type);
-    p+=sprintf(p,"  sock    = %d\n",(int)udpsvr->sock);
+    p+=sprintf(p,"  sock    = %" PRISOCK "\n", udpsvr->sock);
     sprintf(p,"  port    = %d\n",udpsvr->port);
     return state;
 }
@@ -2270,27 +2293,27 @@ static udp_t *openudpcli(const char *path, char *msg)
 /* close udp client ----------------------------------------------------------*/
 static void closeudpcli(udp_t *udpcli)
 {
-    tracet(3,"closeudpcli: sock=%d\n",udpcli->sock);
+    tracet(3,"closeudpcli: sock=%" PRISOCK "\n",udpcli->sock);
     
     closesocket(udpcli->sock);
     free(udpcli);
 }
 /* write udp client -----------------------------------------------------------*/
-static int writeudpcli(udp_t *udpcli, uint8_t *buff, int n, char *msg)
+static int writeudpcli(udp_t *udpcli, const uint8_t *buff, int n, char *msg)
 {
     (void)msg;
-    tracet(4,"writeudpcli: sock=%d n=%d\n",udpcli->sock,n);
+    tracet(4,"writeudpcli: sock=%" PRISOCK " n=%d\n",udpcli->sock,n);
     
     return (int)sendto(udpcli->sock,(char *)buff,n,0,
                        (struct sockaddr *)&udpcli->addr,sizeof(udpcli->addr));
 }
 /* get state udp client ------------------------------------------------------*/
-static int stateudpcli(udp_t *udpcli)
+static int stateudpcli(const udp_t *udpcli)
 {
     return udpcli?udpcli->state:0;
 }
 /* get extended state udp client ---------------------------------------------*/
-static int statexudpcli(udp_t *udpcli, char *msg)
+static int statexudpcli(const udp_t *udpcli, char *msg)
 {
     char *p=msg;
     int state=udpcli?udpcli->state:0;
@@ -2299,7 +2322,7 @@ static int statexudpcli(udp_t *udpcli, char *msg)
     p+=sprintf(p,"  state   = %d\n",state);
     if (!state) return 0;
     p+=sprintf(p,"  type    = %d\n",udpcli->type);
-    p+=sprintf(p,"  sock    = %d\n",(int)udpcli->sock);
+    p+=sprintf(p,"  sock    = %" PRISOCK "\n",udpcli->sock);
     p+=sprintf(p,"  addr    = %s\n",udpcli->saddr);
     sprintf(p,"  port    = %d\n",udpcli->port);
     return state;
@@ -2550,12 +2573,12 @@ static int readftp(ftp_t *ftp, uint8_t *buff, int n, char *msg)
     return (int)(p-buff);
 }
 /* get state ftp -------------------------------------------------------------*/
-static int stateftp(ftp_t *ftp)
+static int stateftp(const ftp_t *ftp)
 {
     return !ftp?0:(ftp->state==0?2:(ftp->state<=2?3:-1));
 }
 /* get extended state ftp ----------------------------------------------------*/
-static int statexftp(ftp_t *ftp, char *msg)
+static int statexftp(const ftp_t *ftp, char *msg)
 {
     (void)msg;
     return !ftp?0:(ftp->state==0?2:(ftp->state<=2?3:-1));
@@ -2615,7 +2638,7 @@ static int readmembuf(membuf_t *membuf, uint8_t *buff, int n, char *msg)
     return nr;
 }
 /* write memory buffer -------------------------------------------------------*/
-static int writemembuf(membuf_t *membuf, uint8_t *buff, int n, char *msg)
+static int writemembuf(membuf_t *membuf, const uint8_t *buff, int n, char *msg)
 {
     int i;
     
@@ -2639,12 +2662,12 @@ static int writemembuf(membuf_t *membuf, uint8_t *buff, int n, char *msg)
     return i;
 }
 /* get state memory buffer ---------------------------------------------------*/
-static int statemembuf(membuf_t *membuf)
+static int statemembuf(const membuf_t *membuf)
 {
     return !membuf?0:membuf->state;
 }
 /* get extended state memory buffer ------------------------------------------*/
-static int statexmembuf(membuf_t *membuf, char *msg)
+static int statexmembuf(const membuf_t *membuf, char *msg)
 {
     char *p=msg;
     int state=!membuf?0:membuf->state;
@@ -2953,7 +2976,7 @@ extern int strread(stream_t *stream, uint8_t *buff, int n)
 * return : status (0:error,1:ok)
 * notes  : write data to buffer and return immediately
 *-----------------------------------------------------------------------------*/
-extern int strwrite(stream_t *stream, uint8_t *buff, int n)
+extern int strwrite(stream_t *stream, const uint8_t *buff, int n)
 {
     uint32_t tick=tickget();
     char *msg=stream->msg;


### PR DESCRIPTION
Building with Visual Studio, MSC, generated a lot of warnings that I had not seen with BCC. Significant issues were split out and this is the remainder of the changes to quieten them. Most are harmless expected coercion losses, but there was some odd code reworked.

Explicit type coercion.