### PR TITLE
clang-format: align C pointer asterisk to the right

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,3 +4,4 @@ BasedOnStyle: Google
 Language: Cpp
 ColumnLimit: 100
 UseTab: Never
+PointerAlignment: Right


### PR DESCRIPTION
Noticed the output of clang-format was now aligning the pointer asterisk to the left, so this add an explicit alignment to the right to be consistent with the current code style.