### PR TITLE
rtknavi_qt: keep the stream details even if disabled

### DIFF
--- a/app/qtapp/rtknavi_qt/navimain.cpp
+++ b/app/qtapp/rtknavi_qt/navimain.cpp
@@ -514,10 +514,8 @@ void MainWindow::showOptionsDialog()
 
         strfmt[i] = inputFormat[i];
 
-        if (!streamEnabled[i]) {
-            strtype[i] = STR_NONE;
-            strncpy(strpath[i], "", MAXSTR-1);
-        } else if (strtype[i] == STR_SERIAL) {
+        strncpy(strpath[i], "", MAXSTR-1);
+        if (strtype[i] == STR_SERIAL) {
             strncpy(strpath[i], qPrintable(paths[i][0]), MAXSTR-1);
         } else if (strtype[i] == STR_FILE) {
             strncpy(strpath[i], qPrintable(paths[i][2]), MAXSTR-1);


### PR DESCRIPTION
Noticed the stream details being lost when disabling and then re-enabling a stream, and it occurred when the options were opened with the stream disabled. The stream details were not being cleared when a stream was disabled otherwise.

When the options were opened the stream details were copied over only when the stream was enabled which lost the stream details when disabled. Change this to keep the stream details even if disabled, so that a stream can be disabled and re-enabled without having to reenter all the details.