### PR TITLE
convbin: round the rinex version after scaling

### DIFF
--- a/app/consapp/convbin/convbin.c
+++ b/app/consapp/convbin/convbin.c
@@ -518,7 +518,7 @@ static int cmdopts(int argc, char **argv, rnxopt_t *opt, char **ifile,
             }
         }
         else if (!strcmp(argv[i],"-v" )&&i+1<argc) {
-            opt->rnxver=(int)(atof(argv[++i])*100.0);
+            opt->rnxver=(int)round(atof(argv[++i])*100.0);
         }
         else if (!strcmp(argv[i],"-od")) {
             opt->obstype|=OBSTYPE_DOP;


### PR DESCRIPTION
Had seen 4.02 being truncate to 401 after scaling rather than 402.