### PR TITLE
rtcm3: clarify the QZSS L1C/B signal index

### DIFF
--- a/src/rtcm3.c
+++ b/src/rtcm3.c
@@ -101,9 +101,9 @@ const char *msm_sig_gal[32] = {
     "", "",   "",   "",   "",   "",   "",   ""};                           // 25-32
 const char *msm_sig_qzs[32] = {
     // QZSS: ref [17] table 3.5-105.
-    // 1E(4), 1Z, 1B, 6E, 6Z, 5D, 5P, 5Z are tentative from the PocketSDR extensions
-    // 1E(2) seen from Trimble station.
-    "",   "1C", "1E", "",   "1E", "1Z", "1B", "",  "6S", "6L", "6X", "6E",  //  1-12
+    // 1Z, 1B, 6E, 6Z, 5D, 5P, 5Z are tentative from the PocketSDR extensions
+    // 1E tentative, noted from Trimble Alloy and Septentrio PolaRx5 receivers.
+    "",   "1C", "1E", "",     "", "1Z", "1B", "",  "6S", "6L", "6X", "6E",  //  1-12
     "6Z", "",   "2S", "2L", "2X", "",   "",   "",  "",   "5I", "5Q", "5X",  // 13-24
     "5D", "5P", "5Z", "",   "",   "1S", "1L", "1X"};                        // 25-32
 const char *msm_sig_sbs[32] = {


### PR DESCRIPTION
It appears to be an adopted standard even if tentative so it seems appropriate to remove the duplicate PocketSDR mapping for this signal. BNC have also adopped this and had some background see https://software.rtcm-ntrip.org/ticket/221 This table is also used by rtcm3e.c and the duplicate would be masked and conflicting there anyway.

This appears to be a tentative standard and has been noted from Septentrio and Trimble receivers, so remove the tentative index 3 for this signal which was adopted from PocketSDR.