### PR TITLE
rtkplot: allocate nav_t on the heap

### DIFF
--- a/app/qtapp/rtkplot_qt/plotdata.cpp
+++ b/app/qtapp/rtkplot_qt/plotdata.cpp
@@ -182,7 +182,7 @@ void Plot::readObservation(const QStringList &files)
     clearObservation();
 
     observation = obs;
-    navigation = *nav;
+    *navigation = *nav;
     free(nav);
     station = sta;
     simulatedObservation = 0;
@@ -321,7 +321,7 @@ void Plot::readNavigation(const QStringList &files)
 
     timeSpan(&ts, &te, &tint);
 
-    freenav(&navigation, 0xFF);
+    freenav(navigation, 0xFF);
 
     showMessage(tr("Reading navigation data..."));
 
@@ -329,11 +329,11 @@ void Plot::readNavigation(const QStringList &files)
 
     for (i = 0; i < files.size(); i++) {
         readrnxt(qPrintable(QDir::toNativeSeparators(files.at(i))), 1, ts, te, tint,
-                 qPrintable(plotOptDialog->getRinexOptions()), NULL, &navigation, NULL);
+                 qPrintable(plotOptDialog->getRinexOptions()), NULL, navigation, NULL);
     }
-    uniqnav(&navigation);
+    uniqnav(navigation);
 
-    if (navigation.n <= 0 && navigation.ng <= 0 && navigation.ns <= 0) {
+    if (navigation->n <= 0 && navigation->ng <= 0 && navigation->ns <= 0) {
         showMessage(tr("No navigation message: %1...").arg(QDir::toNativeSeparators(files.at(i))));
         readWaitEnd();
         return;
@@ -1225,7 +1225,7 @@ void Plot::updateObservation(int nobs)
 
         if (plotOptDialog->getReceiverPosition() == 0) { // single point position
             opt.err[0] = 900.0;
-            pntpos(observation.data + i, j - i, &navigation, &opt, &sol, azel, NULL, msg);
+            pntpos(observation.data + i, j - i, navigation, &opt, &sol, azel, NULL, msg);
             matcpy(rr, sol.rr, 3, 1);
             ecef2pos(rr, pos);
         } else if (plotOptDialog->getReceiverPosition() == 1) { // lat/lon/height
@@ -1245,7 +1245,7 @@ void Plot::updateObservation(int nobs)
                     continue;
                 }
             } else {
-                if (!satpos(time, time, sat, EPHOPT_BRDC, &navigation, rs, dts, &var, &svh)) {
+                if (!satpos(time, time, sat, EPHOPT_BRDC, navigation, rs, dts, &var, &svh)) {
                     continue;
                 }
             }
@@ -1294,10 +1294,10 @@ void Plot::updateMp()
         // Choose two frequencies to calculate reference I.
         double freq1 = 0.0, freq2 = 0.0, I = 0.0;
         for (int j = 0; j < NFREQ + NEXOBS; j++) {
-            freq1 = sat2freq(data->sat, data->code[j], &navigation);
+            freq1 = sat2freq(data->sat, data->code[j], navigation);
             if (data->L[j] == 0.0 || freq1 == 0.0 ) continue;
             for (int k = j + 1; k < NFREQ + NEXOBS; k++) {
-                freq2 = sat2freq(data->sat, data->code[k], &navigation);
+                freq2 = sat2freq(data->sat, data->code[k], navigation);
                 if (data->L[k] == 0.0 || freq2 == 0.0 || freq1 == freq2) continue;
                 I = -CLIGHT * (data->L[j] / freq1-data->L[k] / freq2) / (1.0 - SQR(freq1 / freq2));
                 break;
@@ -1307,7 +1307,7 @@ void Plot::updateMp()
         if (freq1 == 0.0 || freq2 == 0.0) continue;
 
         for (int j = 0; j < NFREQ + NEXOBS; j++) {
-            double freq = sat2freq(data->sat, data->code[j], &navigation);
+            double freq = sat2freq(data->sat, data->code[j], navigation);
             if (data->P[j] == 0.0 || data->L[j] == 0.0 || freq == 0.0) continue;
             multipath[j][i] = data->P[j] - CLIGHT * data->L[j] / freq - 2.0 * SQR(freq1 / freq) * I;
         }
@@ -1370,8 +1370,8 @@ void Plot::updateIono()
 
     for (i = 0; i < observation.n; i++) {
         data = observation.data + i;
-        freq1 = sat2freq(data->sat, data->code[0], &navigation);
-        freq2 = sat2freq(data->sat, data->code[1], &navigation);
+        freq1 = sat2freq(data->sat, data->code[0], navigation);
+        freq2 = sat2freq(data->sat, data->code[1], navigation);
         if (data->P[0] == 0.0 || data->P[1] == 0.0 || freq1 == 0.0 || freq2 == 0.0 || freq1 == freq2) continue;
 
         I = 1/ 40.308 * SQR(freq1)*SQR(freq2)/(SQR(freq1)-SQR(freq2))*1e-16;
@@ -1423,7 +1423,7 @@ void Plot::clearObservation()
     sta_t sta0 = {};
 
     freeobs(&observation);
-    freenav(&navigation, 0xFF);
+    freenav(navigation, 0xFF);
 
     delete [] indexObservation; indexObservation = NULL;
     delete [] azimuth; azimuth = NULL;

--- a/app/qtapp/rtkplot_qt/plotdraw.cpp
+++ b/app/qtapp/rtkplot_qt/plotdraw.cpp
@@ -1138,13 +1138,13 @@ void Plot::generateObservationSlips(int *LLI)
 
         if (plotOptDialog->getShowSlip() == 1) { // LG jump
             if (obstype.isNull()) {  // "ALL" selected
-                if ((freq1 = sat2freq(obs->sat, obs->code[0], &navigation)) == 0.0) continue;
+                if ((freq1 = sat2freq(obs->sat, obs->code[0], navigation)) == 0.0) continue;
 
                 LLI[i] = obs->LLI[0] & 2;
                 for (j = 1; j < NFREQ + NEXOBS; j++) {
                     LLI[i] |= obs->LLI[j] & 2;
 
-                    if ((freq2 = sat2freq(obs->sat, obs->code[j], &navigation)) == 0.0) continue;
+                    if ((freq2 = sat2freq(obs->sat, obs->code[j], navigation)) == 0.0) continue;
 
                     gf = CLIGHT * (obs->L[0] / freq1-obs->L[j] / freq2); // geometry-free
                     if (fabs(prev_gf[obs->sat-1][j] - gf) > THRESLIP) LLI[i] |= 1;
@@ -1165,8 +1165,8 @@ void Plot::generateObservationSlips(int *LLI)
                 LLI[i] = obs->LLI[j] & 2;
                 k = (j == 0) ? 1 : 0;  // selected reference for geometry-free solution
 
-                if ((freq1 = sat2freq(obs->sat, obs->code[k], &navigation)) == 0.0) continue;
-                if ((freq2 = sat2freq(obs->sat, obs->code[j], &navigation)) == 0.0) continue;
+                if ((freq1 = sat2freq(obs->sat, obs->code[k], navigation)) == 0.0) continue;
+                if ((freq2 = sat2freq(obs->sat, obs->code[j], navigation)) == 0.0) continue;
 
                 gf = CLIGHT * (obs->L[k] / freq1-obs->L[j] / freq2);
                 if (fabs(prev_gf[obs->sat-1][j] - gf) > THRESLIP) LLI[i] |= 1;
@@ -1238,20 +1238,20 @@ void Plot::drawObservationEphemeris(QPainter &c, double *yp)
         if (!satelliteSelection[sat]) continue;
 
         // GPS/Galileo/... ephemeris
-        for (i = 0; i < navigation.n; i++) {
-            if (navigation.eph[i].sat != sat + 1) continue;
+        for (i = 0; i < navigation->n; i++) {
+            if (navigation->eph[i].sat != sat + 1) continue;
 
-            graphSingle->toPoint(timePosition(navigation.eph[i].ttr), yp[sat], ps[0]);  // start position
+            graphSingle->toPoint(timePosition(navigation->eph[i].ttr), yp[sat], ps[0]);  // start position
             ps[1] = ps[0];
-            in = graphSingle->toPoint(timePosition(navigation.eph[i].toe), yp[sat], ps[2]);  // end position
+            in = graphSingle->toPoint(timePosition(navigation->eph[i].toe), yp[sat], ps[2]);  // end position
 
-            offset[navigation.eph[i].sat - 1] = offset[navigation.eph[i].sat - 1] ? 0 : 3;
+            offset[navigation->eph[i].sat - 1] = offset[navigation->eph[i].sat - 1] ? 0 : 3;
 
             for (k = 0; k < 3; k++)
-                ps[k].ry() += plotOptDialog->getMarkSize() + 2 + offset[navigation.eph[i].sat - 1];
+                ps[k].ry() += plotOptDialog->getMarkSize() + 2 + offset[navigation->eph[i].sat - 1];
             ps[0].ry() -= 2;
 
-            svh = navigation.eph[i].svh;
+            svh = navigation->eph[i].svh;
             // Mask QZS LEX health.
             int health = satsys(sat + 1, NULL) == SYS_QZS ? (svh & 0xfe) != 0 : svh != 0;
             graphSingle->drawPoly(c, ps, 3, health ? plotOptDialog->getMarkerColor(0, 5) : plotOptDialog->getCColor(1), 0);
@@ -1259,40 +1259,40 @@ void Plot::drawObservationEphemeris(QPainter &c, double *yp)
             if (in) graphSingle->drawMark(c, ps[2], Graph::MarkerTypes::Dot, health ? plotOptDialog->getMarkerColor(0, 5) : plotOptDialog->getCColor(1), health ? 4 : 3, 0);
         }
         // Glonass ephemeris
-        for (i = 0; i < navigation.ng; i++) {
-            if (navigation.geph[i].sat != sat + 1) continue;
+        for (i = 0; i < navigation->ng; i++) {
+            if (navigation->geph[i].sat != sat + 1) continue;
 
-            graphSingle->toPoint(timePosition(navigation.geph[i].tof), yp[sat], ps[0]);
+            graphSingle->toPoint(timePosition(navigation->geph[i].tof), yp[sat], ps[0]);
             ps[1] = ps[0];
-            in = graphSingle->toPoint(timePosition(navigation.geph[i].toe), yp[sat], ps[2]);
+            in = graphSingle->toPoint(timePosition(navigation->geph[i].toe), yp[sat], ps[2]);
 
-            offset[navigation.geph[i].sat - 1] = offset[navigation.geph[i].sat - 1] ? 0 : 3;
+            offset[navigation->geph[i].sat - 1] = offset[navigation->geph[i].sat - 1] ? 0 : 3;
 
             for (k = 0; k < 3; k++)
-                ps[k].ry() += plotOptDialog->getMarkSize() + 2 + offset[navigation.geph[i].sat - 1];
+                ps[k].ry() += plotOptDialog->getMarkSize() + 2 + offset[navigation->geph[i].sat - 1];
             ps[0].ry() -= 2;
 
-            svh = navigation.geph[i].svh;
+            svh = navigation->geph[i].svh;
             int health = (svh & 9) != 0 || (svh & 6) == 4;
             graphSingle->drawPoly(c, ps, 3, health ? plotOptDialog->getMarkerColor(0, 5) : plotOptDialog->getCColor(1), 0);
 
             if (in) graphSingle->drawMark(c, ps[2], Graph::MarkerTypes::Dot, health ? plotOptDialog->getMarkerColor(0, 5) : plotOptDialog->getCColor(1), health ? 4 : 3, 0);
         }
         // SBAS ephemeris
-        for (i = 0; i < navigation.ns; i++) {
-            if (navigation.seph[i].sat != sat + 1) continue;
+        for (i = 0; i < navigation->ns; i++) {
+            if (navigation->seph[i].sat != sat + 1) continue;
 
-            graphSingle->toPoint(timePosition(navigation.seph[i].tof), yp[sat], ps[0]);
+            graphSingle->toPoint(timePosition(navigation->seph[i].tof), yp[sat], ps[0]);
             ps[1] = ps[0];
-            in = graphSingle->toPoint(timePosition(navigation.seph[i].t0), yp[sat], ps[2]);
+            in = graphSingle->toPoint(timePosition(navigation->seph[i].t0), yp[sat], ps[2]);
 
-            offset[navigation.seph[i].sat - 1] = offset[navigation.seph[i].sat - 1] ? 0 : 3;
+            offset[navigation->seph[i].sat - 1] = offset[navigation->seph[i].sat - 1] ? 0 : 3;
 
             for (k = 0; k < 3; k++)
-                ps[k].ry() += plotOptDialog->getMarkSize() + 2 + offset[navigation.seph[i].sat - 1];
+                ps[k].ry() += plotOptDialog->getMarkSize() + 2 + offset[navigation->seph[i].sat - 1];
             ps[0].ry() -= 2;
 
-            svh = navigation.seph[i].svh;
+            svh = navigation->seph[i].svh;
             graphSingle->drawPoly(c, ps, 3, svh ? plotOptDialog->getMarkerColor(0, 5) : plotOptDialog->getCColor(1), 0);
 
             if (in) graphSingle->drawMark(c, ps[2], Graph::MarkerTypes::Dot, svh ? plotOptDialog->getMarkerColor(0, 5) : plotOptDialog->getCColor(1), svh ? 4 : 3, 0);
@@ -1450,7 +1450,7 @@ void Plot::drawSky(QPainter &c, int level)
         }
     }
 
-    if (navigation.n <= 0 && navigation.ng <= 0 && !simulatedObservation) {  // indicate if no navigation data is available
+    if (navigation->n <= 0 && navigation->ng <= 0 && !simulatedObservation) {  // indicate if no navigation data is available
         graphSky->getExtent(p1, p2);
         p2.rx() -= 10;
         p2.ry() -= 3;
@@ -1691,7 +1691,7 @@ void Plot::drawSky(QPainter &c, int level)
         }
     }
 
-    if (navigation.n <= 0 && navigation.ng <= 0 && !simulatedObservation) {  // indicate if no navigation data is available
+    if (navigation->n <= 0 && navigation->ng <= 0 && !simulatedObservation) {  // indicate if no navigation data is available
         graphSky->getExtent(p1, p2);
         p2.rx() -= 10;
         p2.ry() -= 3;
@@ -2004,7 +2004,7 @@ void Plot::drawDop(QPainter &c, int level)
         drawDopStat(c, dop, ns, n);
     }
 
-    if (navigation.n <= 0 && navigation.ng <= 0 && (doptype == 0 || doptype >= 2) && !simulatedObservation) {  // indicate if no navigation data is available
+    if (navigation->n <= 0 && navigation->ng <= 0 && (doptype == 0 || doptype >= 2) && !simulatedObservation) {  // indicate if no navigation data is available
         graphSingle->getExtent(p1, p2);
         p2.rx() -= 10;
         p2.ry() -= 3;
@@ -2861,7 +2861,7 @@ void Plot::drawIonoSky(QPainter &c, int level)
         }
     }
 
-    if (navigation.n <= 0 && navigation.ng <= 0 && !simulatedObservation) {  // indicate if no navigation data is available
+    if (navigation->n <= 0 && navigation->ng <= 0 && !simulatedObservation) {  // indicate if no navigation data is available
         graphSky->getExtent(p1, p2);
         p2.rx() -= 10;
         p2.ry() -= 3;

--- a/app/qtapp/rtkplot_qt/plotmain.cpp
+++ b/app/qtapp/rtkplot_qt/plotmain.cpp
@@ -136,7 +136,7 @@ Plot::Plot(QWidget *parent) : QMainWindow(parent), ui(new Ui::Plot)
 
     observationIndex = 0;
     observation = obs0;
-    memset(&navigation, 0, sizeof(navigation));
+    navigation = new nav_t{};
     station = sta0;
     gis = gis0;
     simulatedObservation = 0;
@@ -395,6 +395,8 @@ Plot::~Plot()
     delete lWRangeList;
 
     delete tVdirectorySelector;
+
+    delete navigation;
 }
 // callback on all events ----------------------------------------------------
 bool Plot::eventFilter(QObject *obj, QEvent *event)

--- a/app/qtapp/rtkplot_qt/plotmain.h
+++ b/app/qtapp/rtkplot_qt/plotmain.h
@@ -250,7 +250,7 @@ private:
     solstatbuf_t solutionStat[2];
     int solutionIndex[2];
     obs_t observation;
-    nav_t navigation;
+    nav_t *navigation;
     sta_t station;
     double *azimuth, *elevation, *multipath[NFREQ+NEXOBS], *ionosphere;
     char streamBuffer[1024];

--- a/app/winapp/rtkplot/plotdata.cpp
+++ b/app/winapp/rtkplot/plotdata.cpp
@@ -171,7 +171,7 @@ void __fastcall TPlot::ReadObs(TStrings *files)
     }
     ClearObs();
     Obs=obs;
-    Nav=*nav;
+    *Nav=*nav;
     free(nav);
     Sta=sta;
     SimObs=0;
@@ -309,18 +309,18 @@ void __fastcall TPlot::ReadNav(TStrings *files)
     
     TimeSpan(&ts,&te,&tint);
     
-    freenav(&Nav,0xFF);
+    freenav(Nav,0xFF);
     
     ShowMsg("reading nav data...");
     Application->ProcessMessages();
     
     for (i=0;i<files->Count;i++) {
         strcpy(navfile,U2A(files->Strings[i]).c_str());
-        readrnxt(navfile,1,ts,te,tint,opt,NULL,&Nav,NULL);
+        readrnxt(navfile,1,ts,te,tint,opt,NULL,Nav,NULL);
     }
-    uniqnav(&Nav);
+    uniqnav(Nav);
     
-    if (Nav.n<=0&&Nav.ng<=0&&Nav.ns<=0) {
+    if (Nav->n<=0&&Nav->ng<=0&&Nav->ns<=0) {
         ShowMsg(s.sprintf("no nav message: %s...",files->Strings[0].c_str()));
         ReadWaitEnd();
         return;
@@ -1231,7 +1231,7 @@ void __fastcall TPlot::UpdateObs(int nobs)
             char msg[128];
             
             opt.err[0]=900.0;
-            pntpos(Obs.data+i,j-i,&Nav,&opt,&sol,azel,NULL,msg);
+            pntpos(Obs.data+i,j-i,Nav,&opt,&sol,azel,NULL,msg);
             matcpy(rr,sol.rr,3,1);
             ecef2pos(rr,pos);
         }
@@ -1253,7 +1253,7 @@ void __fastcall TPlot::UpdateObs(int nobs)
                 if (!tle_pos(time,name,"","",&TLEData,NULL,rs)) continue;
             }
             else {
-                if (!satpos(time,time,sat,EPHOPT_BRDC,&Nav,rs,dts,&var,&svh)) {
+                if (!satpos(time,time,sat,EPHOPT_BRDC,Nav,rs,dts,&var,&svh)) {
                     continue;
                 }
             }
@@ -1304,10 +1304,10 @@ void __fastcall TPlot::UpdateMp(void)
 	// Choose two frequencies to calculate reference I.
         double freq1 = 0.0, freq2 = 0.0, I = 0.0;
         for (int j = 0; j < NFREQ + NEXOBS; j++) {
-            freq1 = sat2freq(data->sat, data->code[j], &Nav);
+            freq1 = sat2freq(data->sat, data->code[j], Nav);
             if (data->L[j] == 0.0 || freq1 == 0.0 ) continue;
             for (int k = j + 1; k < NFREQ + NEXOBS; k++) {
-                freq2 = sat2freq(data->sat, data->code[k], &Nav);
+                freq2 = sat2freq(data->sat, data->code[k], Nav);
                 if (data->L[k] == 0.0 || freq2 == 0.0 || freq1 == freq2) continue;
                 I = -CLIGHT * (data->L[j] / freq1-data->L[k] / freq2) / (1.0 - SQR(freq1 / freq2));
                 break;
@@ -1317,7 +1317,7 @@ void __fastcall TPlot::UpdateMp(void)
         if (freq1 == 0.0 || freq2 == 0.0) continue;
 
         for (int j=0;j<NFREQ+NEXOBS;j++) {
-            double freq=sat2freq(data->sat,data->code[j],&Nav);
+            double freq=sat2freq(data->sat,data->code[j],Nav);
             if (data->P[j]==0.0||data->L[j]==0.0||freq==0.0) continue;
             Mp[j][i]=data->P[j]-CLIGHT*data->L[j]/freq-2.0*SQR(freq1/freq)*I;
         }
@@ -1388,7 +1388,7 @@ void __fastcall TPlot::ClearObs(void)
     int i;
     
     freeobs(&Obs);
-    freenav(&Nav,0xFF);
+    freenav(Nav,0xFF);
     delete [] IndexObs; IndexObs=NULL;
     delete [] Az; Az=NULL;
     delete [] El; El=NULL;

--- a/app/winapp/rtkplot/plotdraw.cpp
+++ b/app/winapp/rtkplot/plotdraw.cpp
@@ -1015,11 +1015,11 @@ void __fastcall TPlot::GenObsSlip(int *LLI)
             double freq1,freq2,gf;
             
             if (!strcmp(obstype,"ALL")) {
-                if ((freq1=sat2freq(obs->sat,obs->code[0],&Nav))==0.0) continue;
+                if ((freq1=sat2freq(obs->sat,obs->code[0],Nav))==0.0) continue;
                 LLI[i]=obs->LLI[0]&2;
                 for (j=1;j<NFREQ+NEXOBS;j++) {
                     LLI[i]|=obs->LLI[j]&2;
-                    if ((freq2=sat2freq(obs->sat,obs->code[j],&Nav))==0.0) continue;
+                    if ((freq2=sat2freq(obs->sat,obs->code[j],Nav))==0.0) continue;
                     gf=CLIGHT*(obs->L[0]/freq1-obs->L[j]/freq2);
                     if (fabs(gfp[obs->sat-1][j]-gf)>THRESLIP) LLI[i]|=1;
                     gfp[obs->sat-1][j]=gf;
@@ -1037,8 +1037,8 @@ void __fastcall TPlot::GenObsSlip(int *LLI)
                 }    
                 LLI[i]=obs->LLI[j]&2;
                 k=(j==0)?1:0;
-                if ((freq1=sat2freq(obs->sat,obs->code[k],&Nav))==0.0) continue;
-                if ((freq2=sat2freq(obs->sat,obs->code[j],&Nav))==0.0) continue;
+                if ((freq1=sat2freq(obs->sat,obs->code[k],Nav))==0.0) continue;
+                if ((freq2=sat2freq(obs->sat,obs->code[j],Nav))==0.0) continue;
                 gf=CLIGHT*(obs->L[k]/freq1-obs->L[j]/freq2);
                 if (fabs(gfp[obs->sat-1][j]-gf)>THRESLIP) LLI[i]|=1;
                 gfp[obs->sat-1][j]=gf;
@@ -1102,53 +1102,53 @@ void __fastcall TPlot::DrawObsEphem(double *yp)
     
     for (i=0;i<MAXSAT;i++) {
         if (!SatSel[i]) continue;
-        for (j=0;j<Nav.n;j++) {
-            if (Nav.eph[j].sat!=i+1) continue;
-            GraphR->ToPoint(TimePos(Nav.eph[j].ttr),yp[i],ps[0]);
-            in=GraphR->ToPoint(TimePos(Nav.eph[j].toe),yp[i],ps[2]);
+        for (j=0;j<Nav->n;j++) {
+            if (Nav->eph[j].sat!=i+1) continue;
+            GraphR->ToPoint(TimePos(Nav->eph[j].ttr),yp[i],ps[0]);
+            in=GraphR->ToPoint(TimePos(Nav->eph[j].toe),yp[i],ps[2]);
             ps[1]=ps[0];
-            off[Nav.eph[j].sat-1]=off[Nav.eph[j].sat-1]?0:3;
+            off[Nav->eph[j].sat-1]=off[Nav->eph[j].sat-1]?0:3;
             
-            for (k=0;k<3;k++) ps[k].y+=MarkSize+2+off[Nav.eph[j].sat-1];
+            for (k=0;k<3;k++) ps[k].y+=MarkSize+2+off[Nav->eph[j].sat-1];
             ps[0].y-=2;
             
-            svh=Nav.eph[j].svh;
+            svh=Nav->eph[j].svh;
             // Mask QZS LEX health.
             int health = satsys(i + 1, NULL) == SYS_QZS ? (svh & 0xfe) != 0 : svh != 0;
             GraphR->DrawPoly(ps,3,health?MColor[0][5]:CColor[1],0);
             
             if (in) GraphR->DrawMark(ps[2],0,health?MColor[0][5]:CColor[1],health?4:3,0);
         }
-        for (j=0;j<Nav.ng;j++) {
-            if (Nav.geph[j].sat!=i+1) continue;
-            GraphR->ToPoint(TimePos(Nav.geph[j].tof),yp[i],ps[0]);
-            in=GraphR->ToPoint(TimePos(Nav.geph[j].toe),yp[i],ps[2]);
+        for (j=0;j<Nav->ng;j++) {
+            if (Nav->geph[j].sat!=i+1) continue;
+            GraphR->ToPoint(TimePos(Nav->geph[j].tof),yp[i],ps[0]);
+            in=GraphR->ToPoint(TimePos(Nav->geph[j].toe),yp[i],ps[2]);
             ps[1]=ps[0];
-            off[Nav.geph[j].sat-1]=off[Nav.geph[j].sat-1]?0:3;
-            for (k=0;k<3;k++) ps[k].y+=MarkSize+2+off[Nav.geph[j].sat-1];
+            off[Nav->geph[j].sat-1]=off[Nav->geph[j].sat-1]?0:3;
+            for (k=0;k<3;k++) ps[k].y+=MarkSize+2+off[Nav->geph[j].sat-1];
             ps[0].y-=2;
             
-            svh=Nav.geph[j].svh;
+            svh=Nav->geph[j].svh;
             int health = (svh & 9) != 0 || (svh & 6) == 4;
             GraphR->DrawPoly(ps,3,health?MColor[0][5]:CColor[1],0);
             
-            if (in) GraphR->DrawMark(ps[2],0,Nav.geph[j].svh?MColor[0][5]:CColor[1],
-                                     Nav.geph[j].svh?4:3,0);
+            if (in) GraphR->DrawMark(ps[2],0,Nav->geph[j].svh?MColor[0][5]:CColor[1],
+                                     Nav->geph[j].svh?4:3,0);
         }
-        for (j=0;j<Nav.ns;j++) {
-            if (Nav.seph[j].sat!=i+1) continue;
-            GraphR->ToPoint(TimePos(Nav.seph[j].tof),yp[i],ps[0]);
-            in=GraphR->ToPoint(TimePos(Nav.seph[j].t0),yp[i],ps[2]);
+        for (j=0;j<Nav->ns;j++) {
+            if (Nav->seph[j].sat!=i+1) continue;
+            GraphR->ToPoint(TimePos(Nav->seph[j].tof),yp[i],ps[0]);
+            in=GraphR->ToPoint(TimePos(Nav->seph[j].t0),yp[i],ps[2]);
             ps[1]=ps[0];
-            off[Nav.seph[j].sat-1]=off[Nav.seph[j].sat-1]?0:3;
-            for (k=0;k<3;k++) ps[k].y+=MarkSize+2+off[Nav.seph[j].sat-1];
+            off[Nav->seph[j].sat-1]=off[Nav->seph[j].sat-1]?0:3;
+            for (k=0;k<3;k++) ps[k].y+=MarkSize+2+off[Nav->seph[j].sat-1];
             ps[0].y-=2;
             
-            svh=Nav.seph[j].svh;
+            svh=Nav->seph[j].svh;
             GraphR->DrawPoly(ps,3,svh?MColor[0][5]:CColor[1],0);
             
-            if (in) GraphR->DrawMark(ps[2],0,Nav.seph[j].svh?MColor[0][5]:CColor[1],
-                                     Nav.seph[j].svh?4:3,0);
+            if (in) GraphR->DrawMark(ps[2],0,Nav->seph[j].svh?MColor[0][5]:CColor[1],
+                                     Nav->seph[j].svh?4:3,0);
         }
     }
 }
@@ -1387,7 +1387,7 @@ void __fastcall TPlot::DrawSky(int level)
             GraphS->DrawText(p2,ustr,col==clBlack?MColor[0][0]:col,2,2,0,MS_FONT);
         }
     }
-    if (Nav.n<=0&&Nav.ng<=0&&!SimObs) {
+    if (Nav->n<=0&&Nav->ng<=0&&!SimObs) {
         GraphS->GetPos(p1,p2);
         p2.x-=10;
         p2.y-=3;
@@ -1667,7 +1667,7 @@ void __fastcall TPlot::DrawDop(int level)
     else {
         DrawDopStat(dop,ns,n);
     }
-    if (Nav.n<=0&&Nav.ng<=0&&(doptype==0||doptype>=2)&&!SimObs) {
+    if (Nav->n<=0&&Nav->ng<=0&&(doptype==0||doptype>=2)&&!SimObs) {
         GraphR->GetPos(p1,p2);
         p2.x-=10;
         p2.y-=3;

--- a/app/winapp/rtkplot/plotmain.cpp
+++ b/app/winapp/rtkplot/plotmain.cpp
@@ -100,7 +100,7 @@ __fastcall TPlot::TPlot(TComponent* Owner) : TForm(Owner)
     obs0.data=NULL; obs0.n =obs0.nmax =0;
     ObsIndex=0;
     Obs=obs0;
-    memset(&Nav, 0, sizeof(Nav));
+    Nav = new nav_t{};
     Sta=sta0;
     Gis=gis0;
     SimObs=0;

--- a/app/winapp/rtkplot/plotmain.h
+++ b/app/winapp/rtkplot/plotmain.h
@@ -410,7 +410,7 @@ private:
     solstatbuf_t SolStat[2];
     int SolIndex[2];
     obs_t Obs;
-    nav_t Nav;
+    nav_t *Nav;
     sta_t Sta;
     double *Az,*El,*Mp[NFREQ+NEXOBS];
     char StrBuff[1024];


### PR DESCRIPTION
The stack allocation of a nav_t structure caused a stack overflow on a MSC Qt build, crashed on startup, so it is probably also close to being a problem with BCC. This moves it to the heap. Relevant to https://github.com/rtklibexplorer/RTKLIB/issues/897