### PR TITLE
Remove redundant function extern declarations

### DIFF
--- a/app/consapp/convbin/convbin.c
+++ b/app/consapp/convbin/convbin.c
@@ -182,7 +182,7 @@ static void printhelp(void)
     exit(0);
 }
 /* show message --------------------------------------------------------------*/
-extern int showmsg(const char *format, ...)
+int showmsg(const char *format, ...)
 {
     va_list arg;
     va_start(arg,format); vfprintf(stderr,format,arg); va_end(arg);

--- a/app/consapp/rnx2rtkp/rnx2rtkp.c
+++ b/app/consapp/rnx2rtkp/rnx2rtkp.c
@@ -78,15 +78,15 @@ static const char *help[]={
 " --version display release version"
 };
 /* show message --------------------------------------------------------------*/
-extern int showmsg(const char *format, ...)
+int showmsg(const char *format, ...)
 {
     va_list arg;
     va_start(arg,format); vfprintf(stderr,format,arg); va_end(arg);
     fprintf(stderr,"\r");
     return 0;
 }
-extern void settspan(gtime_t ts, gtime_t te) {}
-extern void settime(gtime_t time) {}
+void settspan(gtime_t ts, gtime_t te) {}
+void settime(gtime_t time) {}
 
 /* print help ----------------------------------------------------------------*/
 static void printhelp(void)

--- a/app/consapp/rtkrcv/vt.c
+++ b/app/consapp/rtkrcv/vt.c
@@ -57,7 +57,7 @@
 *          char   *dev      I   device ("": standard tty)
 * return : virtual console (NULL: error)
 *-----------------------------------------------------------------------------*/
-extern vt_t *vt_open(int sock, const char *dev)
+vt_t *vt_open(int sock, const char *dev)
 {
     const char mode[]={C_IAC,C_WILL,C_SUPPGA,C_IAC,C_WILL,C_ECHO};
     struct termios tio={0};
@@ -101,7 +101,7 @@ extern vt_t *vt_open(int sock, const char *dev)
 * args   : vt_t   *vt       I   virtual console
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void vt_close(vt_t *vt)
+void vt_close(vt_t *vt)
 {
     int i;
     
@@ -258,7 +258,7 @@ static int seq_esc(vt_t *vt)
 * return : status (1:ok,0:error)
 * notes  : if no input, return ok with *c='\0'
 *-----------------------------------------------------------------------------*/
-extern int vt_getc(vt_t *vt, char *c)
+int vt_getc(vt_t *vt, char *c)
 {
     struct timeval tv={0,1000}; /* timeout (us) */
     fd_set rs;
@@ -305,7 +305,7 @@ extern int vt_getc(vt_t *vt, char *c)
 *          in     n         I   buffer size
 * return : status (1:ok,0:no input)
 *-----------------------------------------------------------------------------*/
-extern int vt_gets(vt_t *vt, char *buff, int n)
+int vt_gets(vt_t *vt, char *buff, int n)
 {
     char c;
     
@@ -347,7 +347,7 @@ static int vt_putchar(vt_t *vt, char c)
 *          char   c         I   character
 * return : status (1:ok,0:error)
 *-----------------------------------------------------------------------------*/
-extern int vt_putc(vt_t *vt, char c)
+int vt_putc(vt_t *vt, char c)
 {
     if (c=='\n'&&!vt_putchar(vt,'\r')) return 0;
     return vt_putchar(vt,c);
@@ -358,7 +358,7 @@ extern int vt_putc(vt_t *vt, char c)
 *          char   *buff     I   strings
 * return : status (1:ok,0:error)
 *-----------------------------------------------------------------------------*/
-extern int vt_puts(vt_t *vt, const char *buff)
+int vt_puts(vt_t *vt, const char *buff)
 {
     const char *p;
     for (p=buff;*p;p++) if (!vt_putc(vt,*p)) return 0;
@@ -371,7 +371,7 @@ extern int vt_puts(vt_t *vt, const char *buff)
 *          ...              I   variable arguments
 * return : status (1:ok,0:error)
 *-----------------------------------------------------------------------------*/
-extern int vt_printf(vt_t *vt, const char *format, ...)
+int vt_printf(vt_t *vt, const char *format, ...)
 {
     va_list ap;
     char buff[MAXBUFF+1];
@@ -385,7 +385,7 @@ extern int vt_printf(vt_t *vt, const char *format, ...)
 * args   : vt_t   *vt       I   virtual console
 * return : status (1:break,0:no break)
 *-----------------------------------------------------------------------------*/
-extern int vt_chkbrk(vt_t *vt)
+int vt_chkbrk(vt_t *vt)
 {
     char c;
     vt->brk=0;
@@ -397,7 +397,7 @@ extern int vt_chkbrk(vt_t *vt)
 *          char   *file     I   log file path
 * return : status (1:ok,0:error)
 *-----------------------------------------------------------------------------*/
-extern int vt_openlog(vt_t *vt, const char *file)
+int vt_openlog(vt_t *vt, const char *file)
 {
     if (!vt||!vt->state||!(vt->logfp=fopen(file,"w"))) return 0;
     return 1;
@@ -407,7 +407,7 @@ extern int vt_openlog(vt_t *vt, const char *file)
 * args   : vt_t   *vt       I   virtual console
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void vt_closelog(vt_t *vt)
+void vt_closelog(vt_t *vt)
 {
     if (!vt||!vt->state||!vt->logfp) return;
     fclose(vt->logfp);

--- a/app/qtapp/rtkconv_qt/convmain.cpp
+++ b/app/qtapp/rtkconv_qt/convmain.cpp
@@ -64,7 +64,7 @@ static int abortf = 0;
 
 // show message in message area ---------------------------------------------
 extern "C" {
-    extern int showmsg(const char *format, ...)
+    int showmsg(const char *format, ...)
     {
         va_list arg;
         char buff[1024];
@@ -75,8 +75,8 @@ extern "C" {
 
         return abortf;
     }
-    extern void settime(gtime_t) {}
-    extern void settspan(gtime_t, gtime_t) {}
+    void settime(gtime_t) {}
+    void settspan(gtime_t, gtime_t) {}
 }
 
 // constructor --------------------------------------------------------------

--- a/app/qtapp/rtkget_qt/getmain.cpp
+++ b/app/qtapp/rtkget_qt/getmain.cpp
@@ -63,7 +63,7 @@ MainForm *mainForm;
 
 // show message in message area ---------------------------------------------
 extern "C" {
-    extern int showmsg(const char *format, ...)
+    int showmsg(const char *format, ...)
     {
         va_list arg;
         QString str;

--- a/app/qtapp/rtknavi_qt/navimain.cpp
+++ b/app/qtapp/rtknavi_qt/navimain.cpp
@@ -100,12 +100,12 @@ static int strfmt[] = {                         /* stream formats */
 
 // show message in message area ---------------------------------------------
 extern "C" {
-    extern int showmsg(const char *, ...)
+    int showmsg(const char *, ...)
     {
         return 0;
     }
-extern void settime(gtime_t) {}
-extern void settspan(gtime_t, gtime_t) {}
+void settime(gtime_t) {}
+void settspan(gtime_t, gtime_t) {}
 }
 
 // constructor --------------------------------------------------------------

--- a/app/qtapp/rtkplot_qt/plotmain.cpp
+++ b/app/qtapp/rtkplot_qt/plotmain.cpp
@@ -90,8 +90,8 @@
 #define qMaxSHAPEFILE 16             // max number of shape files
 
 extern "C" {
-    extern void settime(gtime_t) {}
-    extern void settspan(gtime_t, gtime_t) {}
+    void settime(gtime_t) {}
+    void settspan(gtime_t, gtime_t) {}
 }
 
 

--- a/app/qtapp/rtkpost_qt/postmain.cpp
+++ b/app/qtapp/rtkpost_qt/postmain.cpp
@@ -78,7 +78,7 @@ MainForm *mainForm;
 extern "C" {
 
 // show message in message area ---------------------------------------------
-extern int showmsg(const char *format, ...)
+int showmsg(const char *format, ...)
 {
     va_list arg;
     char buff[1024];
@@ -93,13 +93,13 @@ extern int showmsg(const char *format, ...)
     return mainForm->abortFlag;
 }
 // set time span of progress bar --------------------------------------------
-extern void settspan(gtime_t ts, gtime_t te)
+void settspan(gtime_t ts, gtime_t te)
 {
     tstart_ = ts;
     tend_ = te;
 }
 // set current time to show progress ----------------------------------------
-extern void settime(gtime_t time)
+void settime(gtime_t time)
 {
     double tt;
     if (tend_.time != 0 && tstart_.time != 0 && (tt = timediff(tend_, tstart_)) > 0.0) {

--- a/app/qtapp/srctblbrows_qt/browsmain.cpp
+++ b/app/qtapp/srctblbrows_qt/browsmain.cpp
@@ -37,9 +37,9 @@ static char buff[MAXSRCTBL];                            // source table buffer
 MainForm *mainForm;
 
 extern "C" {
-    extern int showmsg(const char *, ...)  {return 0;}
-    extern void settime(gtime_t) {}
-    extern void settspan(gtime_t, gtime_t) {}
+    int showmsg(const char *, ...)  {return 0;}
+    void settime(gtime_t) {}
+    void settspan(gtime_t, gtime_t) {}
 }
 
 /* get source table -------------------------------------------------------*/

--- a/app/qtapp/strsvr_qt/svrmain.cpp
+++ b/app/qtapp/strsvr_qt/svrmain.cpp
@@ -55,9 +55,9 @@
 strsvr_t strsvr;
 
 extern "C" {
-extern int showmsg(const char *, ...)  {return 0;}
-extern void settime(gtime_t) {}
-extern void settspan(gtime_t, gtime_t) {}
+int showmsg(const char *, ...)  {return 0;}
+void settime(gtime_t) {}
+void settspan(gtime_t, gtime_t) {}
 }
 
 

--- a/app/winapp/rtkconv/convmain.cpp
+++ b/app/winapp/rtkconv/convmain.cpp
@@ -48,7 +48,7 @@ static int abortf=0;
 
 // show message in message area ---------------------------------------------
 extern "C" {
-extern int showmsg(const char *format,...)
+int showmsg(const char *format,...)
 {
 	static int i=0;
 	va_list arg;

--- a/app/winapp/rtkget/getmain.cpp
+++ b/app/winapp/rtkget/getmain.cpp
@@ -46,7 +46,7 @@ static int abortf=0;          // abort flag
 
 // show message in message area ---------------------------------------------
 extern "C" {
-extern int showmsg(const char *format,...)
+int showmsg(const char *format,...)
 {
     va_list arg;
     AnsiString str;

--- a/app/winapp/rtknavi/navimain.cpp
+++ b/app/winapp/rtknavi/navimain.cpp
@@ -89,7 +89,7 @@ stream_t monistr;                       // monitor stream
 
 // show message in message area ---------------------------------------------
 extern "C" {
-extern int showmsg(const char *format,...) {return 0;}
+int showmsg(const char *format,...) {return 0;}
 }
 // convert degree to deg-min-sec --------------------------------------------
 static void degtodms(double deg, double *dms)

--- a/app/winapp/rtkpost/postmain.cpp
+++ b/app/winapp/rtkpost/postmain.cpp
@@ -64,7 +64,7 @@ static char base_[256]="";          // base-station name
 extern "C" {
 
 // show message in message area ---------------------------------------------
-extern int showmsg(const char *format, ...)
+int showmsg(const char *format, ...)
 {
     va_list arg;
     char buff[1024];
@@ -78,13 +78,13 @@ extern int showmsg(const char *format, ...)
     return MainForm->AbortFlag;
 }
 // set time span of progress bar --------------------------------------------
-extern void settspan(gtime_t ts, gtime_t te)
+void settspan(gtime_t ts, gtime_t te)
 {
     tstart_=ts;
     tend_  =te;
 }
 // set current time to show progress ----------------------------------------
-extern void settime(gtime_t time)
+void settime(gtime_t time)
 {
     static int i=0;
     double tt;

--- a/src/convgpx.c
+++ b/src/convgpx.c
@@ -135,7 +135,7 @@ static int savegpx(const char *file, const solbuf_t *solbuf, const char *name,
 *          int    outtime   I   output time (0:off,1:gpst,2:utc,3:jst)
 * return : status (0:ok,-1:file read,-2:file format,-3:no data,-4:file write)
 *-----------------------------------------------------------------------------*/
-extern int convgpx(const char *infile, const char *outfile, gtime_t ts,
+int convgpx(const char *infile, const char *outfile, gtime_t ts,
                    gtime_t te, double tint, int qflg, int mean, const char *name,
                    double *offset, int outtrk, int outpnt, int outalt, int outtime)
 {

--- a/src/convkml.c
+++ b/src/convkml.c
@@ -163,7 +163,7 @@ static int savekml(const char *file, const solbuf_t *solbuf, const char *name,
 * return : status (0:ok,-1:file read,-2:file format,-3:no data,-4:file write)
 * notes  : see ref [1] for google earth kml file format
 *-----------------------------------------------------------------------------*/
-extern int convkml(const char *infile, const char *outfile, gtime_t ts,
+int convkml(const char *infile, const char *outfile, gtime_t ts,
                    gtime_t te, double tint, int qflg, int mean, const char *name,
                    double *offset, int tcolor, int pcolor, int outalt, int outtime)
 {
@@ -277,7 +277,7 @@ static int savecsv(const char *file, const solbuf_t *solbuf, const char *name,
 //          int    outorder  I   output order (0:lat/lon,1:lon/lat)
 // Return : status (0:ok,-1:file read,-2:file format,-3:no data,-4:file write)
 //------------------------------------------------------------------------------
-extern int convcsv(const char *infile, const char *outfile, gtime_t ts, gtime_t te, double tint,
+int convcsv(const char *infile, const char *outfile, gtime_t ts, gtime_t te, double tint,
                    int qflg, int mean, const char *name, double *offset,
                    int outalt, int outtime, int outorder) {
   trace(3, "convcsv : infile=%s outfile=%s\n", infile, outfile);

--- a/src/convrnx.c
+++ b/src/convrnx.c
@@ -1462,7 +1462,7 @@ static int convrnx_s(int sess, int format, rnxopt_t *opt, const char *file,
 *          station ID (%r)
 *          the order of wild-card expanded files must be in-order by time
 *-----------------------------------------------------------------------------*/
-extern int convrnx(int format, rnxopt_t *opt, const char *file, char **ofile)
+int convrnx(int format, rnxopt_t *opt, const char *file, char **ofile)
 {
     gtime_t t0={0};
     rnxopt_t opt_=*opt;

--- a/src/convrnx.c
+++ b/src/convrnx.c
@@ -1457,7 +1457,7 @@ static int convrnx_s(int sess, int format, rnxopt_t *opt, const char *file,
 *          station ID (%r)
 *          the order of wild-card expanded files must be in-order by time
 *-----------------------------------------------------------------------------*/
-extern int convrnx(int format, rnxopt_t *opt, const char *file, char **ofile)
+int convrnx(int format, rnxopt_t *opt, const char *file, char **ofile)
 {
     gtime_t t0={0};
     rnxopt_t opt_=*opt;

--- a/src/datum.c
+++ b/src/datum.c
@@ -67,7 +67,7 @@ static int dlatdlon(const double *post, double *dpos)
 * return : status (0:ok,0>:error)
 * notes  : parameters file shall comply with GSI TKY2JGD.par
 *-----------------------------------------------------------------------------*/
-extern int loaddatump(const char *file)
+int loaddatump(const char *file)
 {
     FILE *fp;
     char buff[256];
@@ -97,7 +97,7 @@ extern int loaddatump(const char *file)
 * return : status (0:ok,0>:error,out of range)
 * notes  : before calling, call loaddatump() to set parameter table
 *-----------------------------------------------------------------------------*/
-extern int tokyo2jgd(double *pos)
+int tokyo2jgd(double *pos)
 {
     double post[2],dpos[2];
     
@@ -115,7 +115,7 @@ extern int tokyo2jgd(double *pos)
 * return : status (0:ok,0>:error,out of range)
 * notes  : before calling, call loaddatump() to set parameter table
 *-----------------------------------------------------------------------------*/
-extern int jgd2tokyo(double *pos)
+int jgd2tokyo(double *pos)
 {
     double posj[2],dpos[2];
     int i;

--- a/src/download.c
+++ b/src/download.c
@@ -42,7 +42,7 @@ typedef struct {                    /* download paths type */
 } paths_t;
 
 /* execute command with test timeout -----------------------------------------*/
-extern int execcmd_to(const char *cmd)
+int execcmd_to(const char *cmd)
 {
 #ifdef WIN32
     PROCESS_INFORMATION info;
@@ -672,7 +672,7 @@ static int print_total(const url_t *url, const char **stas, int nsta, int *nc,
 *        %r -> rrrr    : station name
 *        %{env} -> env : environment variable
 *-----------------------------------------------------------------------------*/
-extern int dl_readurls(const char *file, const char **types, int ntype, url_t *urls,
+int dl_readurls(const char *file, const char **types, int ntype, url_t *urls,
                        int nmax)
 {
     FILE *fp;
@@ -716,7 +716,7 @@ extern int dl_readurls(const char *file, const char **types, int ntype, url_t *u
 *    (1) station list file contains station names separated by spaces.
 *    (2) strings after # in a line are treated as comments
 *-----------------------------------------------------------------------------*/
-extern int dl_readstas(const char *file, char **stas, int nmax)
+int dl_readstas(const char *file, char **stas, int nmax)
 {
     FILE *fp;
     char buff[4096],*p;
@@ -772,7 +772,7 @@ extern int dl_readstas(const char *file, char **stas, int nmax)
 *          remote file-list. The secondary matched or the following files are
 *          not downloaded.
 *-----------------------------------------------------------------------------*/
-extern int dl_exec(gtime_t ts, gtime_t te, double ti, int seqnos, int seqnoe,
+int dl_exec(gtime_t ts, gtime_t te, double ti, int seqnos, int seqnoe,
                    const url_t *urls, int nurl, const char **stas, int nsta,
                    const char *dir, const char *usr, const char *pwd,
                    const char *proxy, int opts, char *msg, FILE *fp)
@@ -839,7 +839,7 @@ extern int dl_exec(gtime_t ts, gtime_t te, double ti, int seqnos, int seqnoe,
 *          FILE   *fp       IO  log test result file pointer
 * return : status (1:ok,0:error,-1:aborted)
 *-----------------------------------------------------------------------------*/
-extern void dl_test(gtime_t ts, gtime_t te, double ti, const url_t *urls,
+void dl_test(gtime_t ts, gtime_t te, double ti, const url_t *urls,
                     int nurl, const char **stas, int nsta, const char *dir,
                     int ncol, int datefmt, FILE *fp)
 {

--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -146,7 +146,7 @@ static double var_urassr(int ura)
 * return : none
 * notes  : see ref [1],[7],[8]
 *-----------------------------------------------------------------------------*/
-extern void alm2pos(gtime_t time, const alm_t *alm, double *rs, double *dts)
+void alm2pos(gtime_t time, const alm_t *alm, double *rs, double *dts)
 {
     double tk,M,E,Ek,sinE,cosE,u,r,i,O,x,y,sinO,cosO,cosi,mu;
     int n;
@@ -188,7 +188,7 @@ extern void alm2pos(gtime_t time, const alm_t *alm, double *rs, double *dts)
 * notes  : see ref [1],[7],[8]
 *          satellite clock does not include relativity correction and tdg
 *-----------------------------------------------------------------------------*/
-extern double eph2clk(gtime_t time, const eph_t *eph)
+double eph2clk(gtime_t time, const eph_t *eph)
 {
     double t,ts;
     int i;
@@ -219,7 +219,7 @@ extern double eph2clk(gtime_t time, const eph_t *eph)
 *          satellite clock includes relativity correction without code bias
 *          (tgd or bgd)
 *-----------------------------------------------------------------------------*/
-extern void eph2pos(gtime_t time, const eph_t *eph, double *rs, double *dts,
+void eph2pos(gtime_t time, const eph_t *eph, double *rs, double *dts,
                     double *var)
 {
     double tk,M,E,Ek,sinE,cosE,u,r,i,O,sin2u,cos2u,x,y,sinO,cosO,cosi,mu,omge;
@@ -328,7 +328,7 @@ static void glorbit(double t, double *x, const double *acc)
 * return : satellite clock bias (s)
 * notes  : see ref [2]
 *-----------------------------------------------------------------------------*/
-extern double geph2clk(gtime_t time, const geph_t *geph)
+double geph2clk(gtime_t time, const geph_t *geph)
 {
     double t,ts;
     int i;
@@ -355,7 +355,7 @@ extern double geph2clk(gtime_t time, const geph_t *geph)
 * return : none
 * notes  : see ref [2]
 *-----------------------------------------------------------------------------*/
-extern void geph2pos(gtime_t time, const geph_t *geph, double *rs, double *dts,
+void geph2pos(gtime_t time, const geph_t *geph, double *rs, double *dts,
                      double *var)
 {
     double t,tt,x[6];
@@ -388,7 +388,7 @@ extern void geph2pos(gtime_t time, const geph_t *geph, double *rs, double *dts,
 * return : satellite clock bias (s)
 * notes  : see ref [3]
 *-----------------------------------------------------------------------------*/
-extern double seph2clk(gtime_t time, const seph_t *seph)
+double seph2clk(gtime_t time, const seph_t *seph)
 {
     char tstr[40];
     trace(4,"seph2clk: time=%s sat=%2d\n",time2str(time,tstr,3),seph->sat);
@@ -410,7 +410,7 @@ extern double seph2clk(gtime_t time, const seph_t *seph)
 * return : none
 * notes  : see ref [3]
 *-----------------------------------------------------------------------------*/
-extern void seph2pos(gtime_t time, const seph_t *seph, double *rs, double *dts,
+void seph2pos(gtime_t time, const seph_t *seph, double *rs, double *dts,
                      double *var)
 {
     double t;
@@ -734,7 +734,7 @@ static int satpos_ssr(gtime_t time, gtime_t teph, int sat, const nav_t *nav,
 * notes  : satellite position is referenced to antenna phase center
 *          satellite clock does not include code bias correction (tgd or bgd)
 *-----------------------------------------------------------------------------*/
-extern int satpos(gtime_t time, gtime_t teph, int sat, int ephopt,
+int satpos(gtime_t time, gtime_t teph, int sat, int ephopt,
                   const nav_t *nav, double *rs, double *dts, double *var,
                   int *svh)
 {
@@ -778,7 +778,7 @@ extern int satpos(gtime_t time, gtime_t teph, int sat, int ephopt,
 *          any pseudorange and broadcast ephemeris are always needed to get
 *          signal transmission time
 *-----------------------------------------------------------------------------*/
-extern void satposs(gtime_t teph, const obsd_t *obs, int n, const nav_t *nav,
+void satposs(gtime_t teph, const obsd_t *obs, int n, const nav_t *nav,
                     int ephopt, double *rs, double *dts, double *var, int *svh)
 {
     gtime_t time[2*MAXOBS]={{0}};
@@ -858,7 +858,7 @@ extern void satposs(gtime_t teph, const obsd_t *obs, int n, const nav_t *nav,
 *                                 others : undefined
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void setseleph(int sys, int sel)
+void setseleph(int sys, int sel)
 {
     switch (sys) {
         case SYS_GPS: eph_sel[0]=sel; break;
@@ -876,7 +876,7 @@ extern void setseleph(int sys, int sel)
 * return : selected ephemeris
 *            refer setseleph()
 *-----------------------------------------------------------------------------*/
-extern int getseleph(int sys)
+int getseleph(int sys)
 {
     switch (sys) {
         case SYS_GPS: return eph_sel[0];

--- a/src/geoid.c
+++ b/src/geoid.c
@@ -196,7 +196,7 @@ static double geoidh_gsi(const double *pos)
 *          gsigeome_ver4 : GSI geoid 2000 1.0x1.5" (japanese area)
 *          (byte-order of binary files must be compatible to cpu)
 *-----------------------------------------------------------------------------*/
-extern int opengeoid(int model, const char *file)
+int opengeoid(int model, const char *file)
 {
     trace(3,"opengeoid: model=%d file=%s\n",model,file);
     
@@ -221,7 +221,7 @@ extern int opengeoid(int model, const char *file)
 * args   : none
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void closegeoid(void)
+void closegeoid(void)
 {
     trace(3,"closegoid:\n");
     
@@ -237,7 +237,7 @@ extern void closegeoid(void)
 *          geoid model before calling the function. If the external geoid model
 *          is not open, the function uses embedded geoid model.
 *-----------------------------------------------------------------------------*/
-extern double geoidh(const double *pos)
+double geoidh(const double *pos)
 {
     double posd[2],h;
     

--- a/src/gis.c
+++ b/src/gis.c
@@ -306,7 +306,7 @@ static int gis_read_record(FILE *fp, FILE *fp_idx, int type, double *bound,
 * notes  : only support point, multipoint, polyline and polygon.
 *          only support lat-lon for map projection.
 *-----------------------------------------------------------------------------*/
-extern int gis_read(const char *file, gis_t *gis, int layer)
+int gis_read(const char *file, gis_t *gis, int layer)
 {
     FILE *fp,*fp_idx;
     char path[1024],*p;
@@ -358,7 +358,7 @@ extern int gis_read(const char *file, gis_t *gis, int layer)
 * args   : gis_t  *gis      IO  gis data
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void gis_free(gis_t *gis)
+void gis_free(gis_t *gis)
 {
     gisd_t *data,*next;
     int i;

--- a/src/ionex.c
+++ b/src/ionex.c
@@ -283,7 +283,7 @@ static void combtec(nav_t *nav)
 * return : none
 * notes  : see ref [1]
 *-----------------------------------------------------------------------------*/
-extern void readtec(const char *file, nav_t *nav, int opt)
+void readtec(const char *file, nav_t *nav, int opt)
 {
     FILE *fp;
     double dcb[MAXSAT]={0},rms[MAXSAT]={0};
@@ -433,7 +433,7 @@ static int iondelay(gtime_t time, const tec_t *tec, const double *pos,
 * notes  : before calling the function, read tec grid data by calling readtec()
 *          return ok with delay=0 and var=VAR_NOTEC if el<MIN_EL or h<MIN_HGT
 *-----------------------------------------------------------------------------*/
-extern int iontec(gtime_t time, const nav_t *nav, const double *pos,
+int iontec(gtime_t time, const nav_t *nav, const double *pos,
                   const double *azel, int opt, double *delay, double *var)
 {
     double dels[2],vars[2],a,tt;
@@ -496,7 +496,7 @@ extern int iontec(gtime_t time, const nav_t *nav, const double *pos,
 * return : status (1:ok, 0:error)
 * notes  : delay is positive for code (L1 scale), i.e. corrected = meas - delay
 *-----------------------------------------------------------------------------*/
-extern int ionvtec(gtime_t time, const nav_t *nav, const double *pos,
+int ionvtec(gtime_t time, const nav_t *nav, const double *pos,
                    const double *azel, double freq, double *delay, double *var)
 {
     const double re=6371.0; /* fallback single-layer height (km) */

--- a/src/lambda.c
+++ b/src/lambda.c
@@ -177,7 +177,7 @@ static int search(int n, int m, const double *L, const double *D,
 * return : status (0:ok,other:error)
 * notes  : matrix stored by column-major order (fortran convension)
 *-----------------------------------------------------------------------------*/
-extern int lambda(int n, int m, const double *a, const double *Q, double *F,
+int lambda(int n, int m, const double *a, const double *Q, double *F,
                   double *s)
 {
     int info;
@@ -211,7 +211,7 @@ extern int lambda(int n, int m, const double *a, const double *Q, double *F,
 *          double *Z     O  lambda reduction matrix (n x n)
 * return : status (0:ok,other:error)
 *-----------------------------------------------------------------------------*/
-extern int lambda_reduction(int n, const double *Q, double *Z)
+int lambda_reduction(int n, const double *Q, double *Z)
 {
     double *L,*D;
     int i,j,info;
@@ -244,7 +244,7 @@ extern int lambda_reduction(int n, const double *Q, double *Z)
 *          double *s     O  sum of squared residulas of fixed solutions (1 x m)
 * return : status (0:ok,other:error)
 *-----------------------------------------------------------------------------*/
-extern int lambda_search(int n, int m, const double *a, const double *Q,
+int lambda_search(int n, int m, const double *a, const double *Q,
                          double *F, double *s)
 {
     double *L,*D;

--- a/src/options.c
+++ b/src/options.c
@@ -261,7 +261,7 @@ static int str2enum(const char *str, const char *comment, int *val) {
 *                              (terminated with table[i].name="")
 * return : option record (NULL: not found)
 *-----------------------------------------------------------------------------*/
-extern opt_t *searchopt(const char *name, const opt_t *opts)
+opt_t *searchopt(const char *name, const opt_t *opts)
 {
     int i;
     
@@ -278,7 +278,7 @@ extern opt_t *searchopt(const char *name, const opt_t *opts)
 *          char   *str      I  option value string
 * return : status (1:ok,0:error)
 *-----------------------------------------------------------------------------*/
-extern int str2opt(opt_t *opt, const char *str)
+int str2opt(opt_t *opt, const char *str)
 {
     switch (opt->format) {
         case 0: *(int    *)opt->var=atoi(str); break;
@@ -295,7 +295,7 @@ extern int str2opt(opt_t *opt, const char *str)
 *          char   *str      O  option value string
 * return : length of output string
 *-----------------------------------------------------------------------------*/
-extern int opt2str(const opt_t *opt, char *str)
+int opt2str(const opt_t *opt, char *str)
 {
     char *p=str;
     
@@ -315,7 +315,7 @@ extern int opt2str(const opt_t *opt, char *str)
 *          char   *buff     O  option string
 * return : length of output string
 *-----------------------------------------------------------------------------*/
-extern int opt2buf(const opt_t *opt, char *buff)
+int opt2buf(const opt_t *opt, char *buff)
 {
     char *p=buff;
     int n;
@@ -337,7 +337,7 @@ extern int opt2buf(const opt_t *opt, char *buff)
 *                              (terminated with table[i].name="")
 * return : status (1:ok,0:error)
 *-----------------------------------------------------------------------------*/
-extern int loadopts(const char *file, opt_t *opts)
+int loadopts(const char *file, opt_t *opts)
 {
     FILE *fp;
     opt_t *opt;
@@ -382,7 +382,7 @@ extern int loadopts(const char *file, opt_t *opts)
 *                              (terminated with table[i].name="")
 * return : status (1:ok,0:error)
 *-----------------------------------------------------------------------------*/
-extern int saveopts(const char *file, const char *mode, const char *comment,
+int saveopts(const char *file, const char *mode, const char *comment,
                     const opt_t *opts)
 {
     FILE *fp;
@@ -516,7 +516,7 @@ static void sysopts2buff(void)
 * args   : none
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void resetsysopts(void)
+void resetsysopts(void)
 {
     int i,j;
     
@@ -548,7 +548,7 @@ extern void resetsysopts(void)
 * return : none
 * notes  : to load system options, use loadopts() before calling the function
 *-----------------------------------------------------------------------------*/
-extern void getsysopts(prcopt_t *popt, solopt_t *sopt, filopt_t *fopt)
+void getsysopts(prcopt_t *popt, solopt_t *sopt, filopt_t *fopt)
 {
     trace(3,"getsysopts:\n");
     
@@ -565,7 +565,7 @@ extern void getsysopts(prcopt_t *popt, solopt_t *sopt, filopt_t *fopt)
 * return : none
 * notes  : to save system options, use saveopts() after calling the function
 *-----------------------------------------------------------------------------*/
-extern void setsysopts(const prcopt_t *prcopt, const solopt_t *solopt,
+void setsysopts(const prcopt_t *prcopt, const solopt_t *solopt,
                        const filopt_t *filopt)
 {
     trace(3,"setsysopts:\n");

--- a/src/pntpos.c
+++ b/src/pntpos.c
@@ -201,7 +201,7 @@ static double prange(const obsd_t *obs, const nav_t *nav, const prcopt_t *opt,
 *          double *var      O   ionospheric delay (L1) variance (m^2)
 * return : status(1:ok,0:error)
 *-----------------------------------------------------------------------------*/
-extern int ionocorr(gtime_t time, const nav_t *nav, int sat, const double *pos,
+int ionocorr(gtime_t time, const nav_t *nav, int sat, const double *pos,
                     const double *azel, int ionoopt, double *ion, double *var)
 {
     int err=0;
@@ -248,7 +248,7 @@ extern int ionocorr(gtime_t time, const nav_t *nav, int sat, const double *pos,
 *          double *var      O   tropospheric delay variance (m^2)
 * return : status(1:ok,0:error)
 *-----------------------------------------------------------------------------*/
-extern int tropcorr(gtime_t time, const nav_t *nav, const double *pos,
+int tropcorr(gtime_t time, const nav_t *nav, const double *pos,
                     const double *azel, int tropopt, double *trp, double *var)
 {
     (void)nav;
@@ -643,7 +643,7 @@ static void estvel(const obsd_t *obs, int n, const double *rs, const double *dts
 *          char   *msg      O   error message for error exit
 * return : status(1:ok,0:error)
 *-----------------------------------------------------------------------------*/
-extern int pntpos(const obsd_t *obs, int n, const nav_t *nav,
+int pntpos(const obsd_t *obs, int n, const nav_t *nav,
                   const prcopt_t *opt, sol_t *sol, double *azel, ssat_t *ssat,
                   char *msg)
 {

--- a/src/postpos.c
+++ b/src/postpos.c
@@ -1378,7 +1378,7 @@ static int execses_b(gtime_t ts, gtime_t te, double ti, const prcopt_t *popt,
 *
 *          ssr corrections are valid only for forward estimation.
 *-----------------------------------------------------------------------------*/
-extern int postpos(gtime_t ts, gtime_t te, double ti, double tu,
+int postpos(gtime_t ts, gtime_t te, double ti, double tu,
                    const prcopt_t *popt, const solopt_t *sopt,
                    const filopt_t *fopt, const char **infile, int n, const char *outfile,
                    const char *rov, const char *base)

--- a/src/ppp.c
+++ b/src/ppp.c
@@ -124,7 +124,7 @@ static double STD(rtk_t *rtk, int i)
     return SQRT(rtk->P[i+i*rtk->nx]);
 }
 /* write solution status for PPP ---------------------------------------------*/
-extern int pppoutstat(rtk_t *rtk, char *buff, int level)
+int pppoutstat(rtk_t *rtk, char *buff, int level)
 {
     ssat_t *ssat;
     double tow,pos[3],vel[3],acc[3],*x;
@@ -246,7 +246,7 @@ static double yaw_nominal(double beta, double mu)
     return atan2(-tan(beta),sin(mu))+PI;
 }
 /* yaw-angle of satellite ----------------------------------------------------*/
-extern int yaw_angle(int sat, const char *type, int opt, double beta, double mu,
+int yaw_angle(int sat, const char *type, int opt, double beta, double mu,
                      double *yaw)
 {
     (void)sat;
@@ -1129,7 +1129,7 @@ static int ppp_res(int post, const obsd_t *obs, int n, const double *rs,
     return post>0?stat:nv;
 }
 /* number of estimated states ------------------------------------------------*/
-extern int pppnx(const prcopt_t *opt)
+int pppnx(const prcopt_t *opt)
 {
     return NX(opt);
 }
@@ -1218,7 +1218,7 @@ static int test_hold_amb(rtk_t *rtk)
     return ++rtk->nfix>=rtk->opt.minfix;
 }
 /* precise point positioning -------------------------------------------------*/
-extern void pppos(rtk_t *rtk, const obsd_t *obs, int n, const nav_t *nav)
+void pppos(rtk_t *rtk, const obsd_t *obs, int n, const nav_t *nav)
 {
     const prcopt_t *opt=&rtk->opt;
     double *rs,*dts,*var,*v,*H,*R,*azel,*xp,*Pp,dr[3]={0},std[3];

--- a/src/ppp_ar.c
+++ b/src/ppp_ar.c
@@ -14,7 +14,7 @@
 #include "rtklib.h"
 
 /* ambiguity resolution in ppp -----------------------------------------------*/
-extern int ppp_ar(rtk_t *rtk, const obsd_t *obs, int n, int *exc,
+int ppp_ar(rtk_t *rtk, const obsd_t *obs, int n, int *exc,
                   const nav_t *nav, const double *azel, double *x, double *P)
 {
     (void)rtk; (void)obs; (void)n; (void)exc; (void)nav; (void)azel; (void)x; (void)P;

--- a/src/preceph.c
+++ b/src/preceph.c
@@ -309,7 +309,7 @@ static void combpeph(nav_t *nav, int opt)
 *          function
 *          only files with extensions of .sp3, .SP3, .eph* and .EPH* are read
 *-----------------------------------------------------------------------------*/
-extern void readsp3(const char *file, nav_t *nav, int opt)
+void readsp3(const char *file, nav_t *nav, int opt)
 {
     FILE *fp;
     gtime_t time={0};
@@ -359,7 +359,7 @@ extern void readsp3(const char *file, nav_t *nav, int opt)
 * return : status (1:ok,0:error)
 * notes  : only support antex format for the antenna parameter file
 *-----------------------------------------------------------------------------*/
-extern int readsap(const char *file, const gtime_t time, nav_t *nav) {
+int readsap(const char *file, const gtime_t time, nav_t *nav) {
   char tstr[40];
   trace(3, "readsap : file=%s time=%s\n", file, time2str(time, tstr, 0));
 
@@ -443,7 +443,7 @@ static int sys2ix(int sys)
 *       mode:  0=DCB or pseudo-DCB
 *              1=OSB or pseudo-OSB
 * ----------------------------------------------------------------------------*/
-extern double code2bias(const nav_t *nav, int sys, int sat, int code, int mode) {
+double code2bias(const nav_t *nav, int sys, int sat, int code, int mode) {
     int sys_ix,frq_ix,code_ix;
     double bias=0;
 
@@ -520,7 +520,7 @@ static int readbiaf(const char *file, nav_t *nav)
          : currently only support P1-P2, P1-C1 bias in DCB file
          : currently only supports satellite biases in BIA/BSX files
 *-----------------------------------------------------------------------------*/
-extern int readdcb(const char *file, nav_t *nav, const sta_t *sta)
+int readdcb(const char *file, nav_t *nav, const sta_t *sta)
 {
     int i,j,k,n,dcb_ok=0;
     char *efiles[MAXEXFILE]={0};
@@ -708,7 +708,7 @@ static int pephclk1(gtime_t time, int sat, const nav_t *nav, double *dts,
 // Return : 1 in success; 0 on failure.
 //
 // Note: the dts and varc outputs are not modified on failure.
-extern int pephclk(gtime_t time, int sat, const nav_t *nav, double *dts, double *varc) {
+int pephclk(gtime_t time, int sat, const nav_t *nav, double *dts, double *varc) {
 
   if (pephclk1(time, sat, nav, dts, varc)) return 1;
   double rs[3], dts2;
@@ -735,7 +735,7 @@ extern int pephclk(gtime_t time, int sat, const nav_t *nav, double *dts, double 
 *            BDS      : B1I-B2I
 *            NavIC    : L5-S
 *-----------------------------------------------------------------------------*/
-extern void satantoff(gtime_t time, const double *rs, int sat, const nav_t *nav,
+void satantoff(gtime_t time, const double *rs, int sat, const nav_t *nav,
                       double *dant)
 {
     const pcv_t *pcv=nav->pcvs+sat-1;
@@ -812,7 +812,7 @@ extern void satantoff(gtime_t time, const double *rs, int sat, const nav_t *nav,
 *          nav->nc must be set by calling readsp3(), readrnx() or readrnxt()
 *          if precise clocks are not set, clocks in sp3 are used instead
 *-----------------------------------------------------------------------------*/
-extern int peph2pos(gtime_t time, int sat, const nav_t *nav, int opt,
+int peph2pos(gtime_t time, int sat, const nav_t *nav, int opt,
                     double *rs, double *dts, double *var)
 {
     gtime_t time_tt;

--- a/src/rcv/binex.c
+++ b/src/rcv/binex.c
@@ -1199,7 +1199,7 @@ static int sync_bnx(uint8_t *buff, uint8_t data)
 *          -GALINAV : select I/NAV for Galileo ephemeris (default: all)
 *          -GALFNAV : select F/NAV for Galileo ephemeris (default: all)
 *-----------------------------------------------------------------------------*/
-extern int input_bnx(raw_t *raw, uint8_t data)
+int input_bnx(raw_t *raw, uint8_t data)
 {
     uint32_t len;
     int len_h,len_c;
@@ -1238,7 +1238,7 @@ extern int input_bnx(raw_t *raw, uint8_t data)
 *          FILE   *fp       I   file pointer
 * return : status(-2: end of file, -1...9: same as above)
 *-----------------------------------------------------------------------------*/
-extern int input_bnxf(raw_t *raw, FILE *fp)
+int input_bnxf(raw_t *raw, FILE *fp)
 {
     uint32_t len;
     int i,data,len_h,len_c;

--- a/src/rcv/comnav.c
+++ b/src/rcv/comnav.c
@@ -1082,7 +1082,7 @@ static int sync_cnav(unsigned char *buff, unsigned char data)
 *          -GALFNAV: use F/NAV for GAL ephemeris
 *
 *-----------------------------------------------------------------------------*/
-extern int input_cnav(raw_t *raw, unsigned char data)
+int input_cnav(raw_t *raw, unsigned char data)
 {
     trace(5,"input_cnav: data=%02x\n",data);
     
@@ -1111,7 +1111,7 @@ extern int input_cnav(raw_t *raw, unsigned char data)
 *          FILE   *fp    I      file pointer
 * return : status(-2: end of file, -1...9: same as above)
 *-----------------------------------------------------------------------------*/
-extern int input_cnavf(raw_t *raw, FILE *fp)
+int input_cnavf(raw_t *raw, FILE *fp)
 {
     int i,data;
     

--- a/src/rcv/crescent.c
+++ b/src/rcv/crescent.c
@@ -570,7 +570,7 @@ static int sync_cres(uint8_t *buff, uint8_t data)
 *          -ENAGLO      : enable glonass messages
 *
 *-----------------------------------------------------------------------------*/
-extern int input_cres(raw_t *raw, uint8_t data)
+int input_cres(raw_t *raw, uint8_t data)
 {
     trace(5,"input_cres: data=%02x\n",data);
     
@@ -601,7 +601,7 @@ extern int input_cres(raw_t *raw, uint8_t data)
 *          FILE   *fp    I      file pointer
 * return : status(-2: end of file, -1...9: same as above)
 *-----------------------------------------------------------------------------*/
-extern int input_cresf(raw_t *raw, FILE *fp)
+int input_cresf(raw_t *raw, FILE *fp)
 {
     int i,data;
     

--- a/src/rcv/javad.c
+++ b/src/rcv/javad.c
@@ -1806,7 +1806,7 @@ static void clearbuff(raw_t *raw)
 *          -GALINAV: select F/NAV for Galileo ephemeris (default: all)
 *          -GALFNAV: select F/NAV for Galileo ephemeris (default: all)
 *-----------------------------------------------------------------------------*/
-extern int input_javad(raw_t *raw, uint8_t data)
+int input_javad(raw_t *raw, uint8_t data)
 {
     int len,stat;
     
@@ -1855,7 +1855,7 @@ static int endfile(raw_t *raw)
 *          FILE   *fp    I      file pointer
 * return : status(-2: end of file, -1...9: same as above)
 *-----------------------------------------------------------------------------*/
-extern int input_javadf(raw_t *raw, FILE *fp)
+int input_javadf(raw_t *raw, FILE *fp)
 {
     int i,data,len,stat;
     

--- a/src/rcv/novatel.c
+++ b/src/rcv/novatel.c
@@ -1380,7 +1380,7 @@ static int sync_oem3(uint8_t *buff, uint8_t data)
 *          -GALFNAV: select F/NAV for Galileo ephemeris (default: all)
 *          -GLOBIAS=bias: GLONASS code-phase bias (m)
 *-----------------------------------------------------------------------------*/
-extern int input_oem4(raw_t *raw, uint8_t data)
+int input_oem4(raw_t *raw, uint8_t data)
 {
     trace(5,"input_oem4: data=%02x\n",data);
     
@@ -1408,7 +1408,7 @@ extern int input_oem4(raw_t *raw, uint8_t data)
 *          uint8_t data     I   stream data (1 byte)
 * return : same as above
 *-----------------------------------------------------------------------------*/
-extern int input_oem3(raw_t *raw, uint8_t data)
+int input_oem3(raw_t *raw, uint8_t data)
 {
     trace(5,"input_oem3: data=%02x\n",data);
     
@@ -1436,7 +1436,7 @@ extern int input_oem3(raw_t *raw, uint8_t data)
 *          FILE   *fp       I   file pointer
 * return : status(-2: end of file, -1...9: same as above)
 *-----------------------------------------------------------------------------*/
-extern int input_oem4f(raw_t *raw, FILE *fp)
+int input_oem4f(raw_t *raw, FILE *fp)
 {
     int i,data;
     
@@ -1470,7 +1470,7 @@ extern int input_oem4f(raw_t *raw, FILE *fp)
 *          FILE   *fp       I   file pointer
 * return : status(-2: end of file, -1...9: same as above)
 *-----------------------------------------------------------------------------*/
-extern int input_oem3f(raw_t *raw, FILE *fp)
+int input_oem3f(raw_t *raw, FILE *fp)
 {
     int i,data;
     

--- a/src/rcv/nvs.c
+++ b/src/rcv/nvs.c
@@ -453,7 +453,7 @@ static int decode_nvs(raw_t *raw)
 *          -TADJ=tint : adjust time tags to multiples of tint (sec)
 *
 *-----------------------------------------------------------------------------*/
-extern int input_nvs(raw_t *raw, uint8_t data)
+int input_nvs(raw_t *raw, uint8_t data)
 {
     trace(5,"input_nvs: data=%02x\n",data);
     
@@ -501,7 +501,7 @@ extern int input_nvs(raw_t *raw, uint8_t data)
 *          FILE   *fp   I     file pointer
 * return : status(-2: end of file, -1...9: same as above)
 *-----------------------------------------------------------------------------*/
-extern int input_nvsf(raw_t *raw, FILE *fp)
+int input_nvsf(raw_t *raw, FILE *fp)
 {
     int i,data, odd=0;
     
@@ -558,7 +558,7 @@ extern int input_nvsf(raw_t *raw, FILE *fp)
 * return : length of binary message (0: error)
 * note   : see reference [1][2] for details.
 *-----------------------------------------------------------------------------*/
-extern int gen_nvs(const char *msg, uint8_t *buff)
+int gen_nvs(const char *msg, uint8_t *buff)
 {
     uint8_t *q=buff;
     char mbuff[1024],*args[32],*p;

--- a/src/rcv/nvs.c
+++ b/src/rcv/nvs.c
@@ -452,7 +452,7 @@ static int decode_nvs(raw_t *raw)
 *          -TADJ=tint : adjust time tags to multiples of tint (sec)
 *
 *-----------------------------------------------------------------------------*/
-extern int input_nvs(raw_t *raw, uint8_t data)
+int input_nvs(raw_t *raw, uint8_t data)
 {
     trace(5,"input_nvs: data=%02x\n",data);
     
@@ -500,7 +500,7 @@ extern int input_nvs(raw_t *raw, uint8_t data)
 *          FILE   *fp   I     file pointer
 * return : status(-2: end of file, -1...9: same as above)
 *-----------------------------------------------------------------------------*/
-extern int input_nvsf(raw_t *raw, FILE *fp)
+int input_nvsf(raw_t *raw, FILE *fp)
 {
     int i,data, odd=0;
     
@@ -557,7 +557,7 @@ extern int input_nvsf(raw_t *raw, FILE *fp)
 * return : length of binary message (0: error)
 * note   : see reference [1][2] for details.
 *-----------------------------------------------------------------------------*/
-extern int gen_nvs(const char *msg, uint8_t *buff)
+int gen_nvs(const char *msg, uint8_t *buff)
 {
     uint8_t *q=buff;
     char mbuff[1024],*args[32],*p;

--- a/src/rcv/septentrio.c
+++ b/src/rcv/septentrio.c
@@ -90,7 +90,7 @@ typedef struct {
   int8_t meas3_freqAssignment[MEAS3_SYS_MAX][MEAS3_SAT_MAX][MEAS3_SIG_MAX];
 } sbf_t;
 
-extern void free_sbf(raw_t *raw) {
+void free_sbf(raw_t *raw) {
   if (raw->format != STRFMT_SEPT) return;
   sbf_t *sbf = (sbf_t *)raw->rcv_data;
   if (sbf) {
@@ -99,7 +99,7 @@ extern void free_sbf(raw_t *raw) {
   }
 }
 
-extern int init_sbf(raw_t *raw) {
+int init_sbf(raw_t *raw) {
   if (raw->format != STRFMT_SEPT) return 0;
   sbf_t *sbf = (sbf_t *)calloc(1, sizeof(sbf_t));
   if (!sbf) {
@@ -4136,7 +4136,7 @@ static int sync_sbf(unsigned char *buff, unsigned char data)
 *          -NO_MEAS3: ignore range measurements version 3 blocks
 *          -RCVSTDS : save receiver stdevs to unused RINEX fields
 *-----------------------------------------------------------------------------*/
-extern int input_sbf(raw_t *raw, unsigned char data)
+int input_sbf(raw_t *raw, unsigned char data)
 {
     trace(5, "input_sbf: data=%02x\n",data);
 
@@ -4164,7 +4164,7 @@ extern int input_sbf(raw_t *raw, unsigned char data)
 *          FILE   *fp    I      file pointer
 * return : status(-2: end of file, -1...9: same as above)
 *-----------------------------------------------------------------------------*/
-extern int input_sbff(raw_t *raw, FILE *fp)
+int input_sbff(raw_t *raw, FILE *fp)
 {
     int i, data;
     trace(4, "input_sbff:\n");

--- a/src/rcv/skytraq.c
+++ b/src/rcv/skytraq.c
@@ -793,7 +793,7 @@ static int sync_stq(uint8_t *buff, uint8_t data)
 *          -INVCP     : inverse polarity of carrier-phase
 *
 *-----------------------------------------------------------------------------*/
-extern int input_stq(raw_t *raw, uint8_t data)
+int input_stq(raw_t *raw, uint8_t data)
 {
     trace(5,"input_stq: data=%02x\n",data);
     
@@ -824,7 +824,7 @@ extern int input_stq(raw_t *raw, uint8_t data)
 *          FILE   *fp       I   file pointer
 * return : status(-2: end of file, -1...9: same as above)
 *-----------------------------------------------------------------------------*/
-extern int input_stqf(raw_t *raw, FILE *fp)
+int input_stqf(raw_t *raw, FILE *fp)
 {
     int i,data;
     
@@ -865,7 +865,7 @@ extern int input_stqf(raw_t *raw, FILE *fp)
 * return : length of binary message (0: error)
 * note   : see reference [1][2][3][4] for details.
 *-----------------------------------------------------------------------------*/
-extern int gen_stq(const char *msg, uint8_t *buff)
+int gen_stq(const char *msg, uint8_t *buff)
 {
     const char *hz[]={"1Hz","2Hz","4Hz","5Hz","10Hz","20Hz",""};
     uint8_t *q=buff;

--- a/src/rcv/swiftnav.c
+++ b/src/rcv/swiftnav.c
@@ -1421,7 +1421,7 @@ static int sync_sbp(uint8_t *buff, uint8_t data) {
  *                  2: input ephemeris, 3: input sbas message,
  *                  9: input ion/utc parameter)
  *-----------------------------------------------------------------------------*/
-extern int input_sbp(raw_t *raw, uint8_t data) {
+int input_sbp(raw_t *raw, uint8_t data) {
   trace(5, "input_sbp: data=%02x\n", data);
 
   if (raw->nbyte == 0) {
@@ -1463,7 +1463,7 @@ static int endfile(raw_t *raw) {
  *          FILE   *fp    I      file pointer
  * return : status(-2: end of file, -1...9: same as above)
  *-----------------------------------------------------------------------------*/
-extern int input_sbpf(raw_t *raw, FILE *fp) {
+int input_sbpf(raw_t *raw, FILE *fp) {
   int i, data, stat;
 
   trace(4, "input_sbpf:\n");
@@ -1513,7 +1513,7 @@ extern int input_sbpf(raw_t *raw, FILE *fp) {
  *          FILE   *fp    I      file pointer
  * return : status(-2: end of file, -1...9: same as above)
  *-----------------------------------------------------------------------------*/
-extern int input_sbpjsonf(raw_t *raw, FILE *fp) {
+int input_sbpjsonf(raw_t *raw, FILE *fp) {
   const char JSON_MSGTYPE_FIELD[] = "\"msg_type\":";
   const char JSON_SENDER_FIELD[] = "\"sender\":";
   const char JSON_PAYLOAD_FIELD[] = "\"payload\":";

--- a/src/rcv/tersus.c
+++ b/src/rcv/tersus.c
@@ -725,7 +725,7 @@ static int sync_tersus(unsigned char *buff, unsigned char data)
 *
 *          -EPHALL : input all ephemerides
 *-----------------------------------------------------------------------------*/
-extern int input_tersus(raw_t *raw, unsigned char data)
+int input_tersus(raw_t *raw, unsigned char data)
 {
     trace(5,"input_tersus: data=%02x\n",data);
     
@@ -754,7 +754,7 @@ extern int input_tersus(raw_t *raw, unsigned char data)
 *          FILE   *fp    I      file pointer
 * return : status(-2: end of file, -1...9: same as above)
 *-----------------------------------------------------------------------------*/
-extern int input_tersusf(raw_t *raw, FILE *fp)
+int input_tersusf(raw_t *raw, FILE *fp)
 {
     int i,data;
     

--- a/src/rcv/ublox.c
+++ b/src/rcv/ublox.c
@@ -1433,7 +1433,7 @@ static int sync_ubx(uint8_t *buff, uint8_t data)
 *          documented and not supported by u-blox.
 *          Users can use these messages by their own risk.
 *-----------------------------------------------------------------------------*/
-extern int input_ubx(raw_t *raw, uint8_t data)
+int input_ubx(raw_t *raw, uint8_t data)
 {
     trace(5,"input_ubx: data=%02x\n",data);
     
@@ -1463,7 +1463,7 @@ extern int input_ubx(raw_t *raw, uint8_t data)
 *          FILE   *fp    I      file pointer
 * return : status(-2: end of file, -1...9: same as above)
 *-----------------------------------------------------------------------------*/
-extern int input_ubxf(raw_t *raw, FILE *fp)
+int input_ubxf(raw_t *raw, FILE *fp)
 {
     int i,data;
     
@@ -1544,7 +1544,7 @@ static int stoi(const char *s)
 *          the following messages are not supported:
 *             CFG-DOSC,CFG-ESRC
 *-----------------------------------------------------------------------------*/
-extern int gen_ubx(const char *msg, uint8_t *buff)
+int gen_ubx(const char *msg, uint8_t *buff)
 {
     const char *cmd[]={
         "PRT","USB","MSG","NMEA","RATE","CFG","TP","NAV2","DAT","INF",

--- a/src/rcv/ublox.c
+++ b/src/rcv/ublox.c
@@ -1434,7 +1434,7 @@ static int sync_ubx(uint8_t *buff, uint8_t data)
 *          documented and not supported by u-blox.
 *          Users can use these messages by their own risk.
 *-----------------------------------------------------------------------------*/
-extern int input_ubx(raw_t *raw, uint8_t data)
+int input_ubx(raw_t *raw, uint8_t data)
 {
     trace(5,"input_ubx: data=%02x\n",data);
     
@@ -1464,7 +1464,7 @@ extern int input_ubx(raw_t *raw, uint8_t data)
 *          FILE   *fp    I      file pointer
 * return : status(-2: end of file, -1...9: same as above)
 *-----------------------------------------------------------------------------*/
-extern int input_ubxf(raw_t *raw, FILE *fp)
+int input_ubxf(raw_t *raw, FILE *fp)
 {
     int i,data;
     
@@ -1545,7 +1545,7 @@ static int stoi(const char *s)
 *          the following messages are not supported:
 *             CFG-DOSC,CFG-ESRC
 *-----------------------------------------------------------------------------*/
-extern int gen_ubx(const char *msg, uint8_t *buff)
+int gen_ubx(const char *msg, uint8_t *buff)
 {
     const char *cmd[]={
         "PRT","USB","MSG","NMEA","RATE","CFG","TP","NAV2","DAT","INF",

--- a/src/rcv/unicore.c
+++ b/src/rcv/unicore.c
@@ -886,7 +886,7 @@ static int decode_unicore(raw_t* raw)
 *                  2: input ephemeris, 3: input sbas message,
 *                  9: input ion/utc parameter)
 */
-extern int input_unicore(raw_t* raw, uint8_t data)
+int input_unicore(raw_t* raw, uint8_t data)
 {
     trace(5, "input_unicore: data=%02x\n", data);
 
@@ -915,7 +915,7 @@ extern int input_unicore(raw_t* raw, uint8_t data)
 *          FILE   *fp       I   file pointer
 * return : status(-2: end of file, -1...9: same as above)
 *-----------------------------------------------------------------------------*/
-extern int input_unicoref(raw_t* raw, FILE* fp)
+int input_unicoref(raw_t* raw, FILE* fp)
 {
     int i, data;
 

--- a/src/rcv/unicore.c
+++ b/src/rcv/unicore.c
@@ -887,7 +887,7 @@ static int decode_unicore(raw_t* raw)
 *                  2: input ephemeris, 3: input sbas message,
 *                  9: input ion/utc parameter)
 */
-extern int input_unicore(raw_t* raw, uint8_t data)
+int input_unicore(raw_t* raw, uint8_t data)
 {
     trace(5, "input_unicore: data=%02x\n", data);
 
@@ -916,7 +916,7 @@ extern int input_unicore(raw_t* raw, uint8_t data)
 *          FILE   *fp       I   file pointer
 * return : status(-2: end of file, -1...9: same as above)
 *-----------------------------------------------------------------------------*/
-extern int input_unicoref(raw_t* raw, FILE* fp)
+int input_unicoref(raw_t* raw, FILE* fp)
 {
     int i, data;
 

--- a/src/rcvraw.c
+++ b/src/rcvraw.c
@@ -239,7 +239,7 @@ static int decode_irn_utc(const uint8_t *buff, double *utc)
 *                                 utc[8]  : A2
 * return : status (1:ok,0:error)
 *-----------------------------------------------------------------------------*/
-extern int decode_irn_nav(const uint8_t *buff, eph_t *eph, double *ion,
+int decode_irn_nav(const uint8_t *buff, eph_t *eph, double *ion,
                           double *utc)
 {
     trace(4,"decode_irn_nav:\n");
@@ -389,7 +389,7 @@ static int decode_gal_inav_utc(const uint8_t *buff, double *utc)
 *                                 utc[4-7]: dt_LS,WN_LSF,DN,dt_LSF
 * return : status (1:ok,0:error)
 *-----------------------------------------------------------------------------*/
-extern int decode_gal_inav(const uint8_t *buff, eph_t *eph, double *ion,
+int decode_gal_inav(const uint8_t *buff, eph_t *eph, double *ion,
                            double *utc)
 {
     trace(4,"decode_gal_inav:\n");
@@ -537,7 +537,7 @@ static int decode_gal_fnav_utc(const uint8_t *buff, double *utc)
 *                                 utc[4-7]: dt_LS,WN_LSF,DN,dt_LSF
 * return : status (1:ok,0:error)
 *-----------------------------------------------------------------------------*/
-extern int decode_gal_fnav(const uint8_t *buff, eph_t *eph, double *ion,
+int decode_gal_fnav(const uint8_t *buff, eph_t *eph, double *ion,
                            double *utc)
 {
     trace(4,"decode_gal_fnav:\n");
@@ -680,7 +680,7 @@ static int decode_bds_d1_utc(const uint8_t *buff, double *utc)
 *                                 utc[4-7]: dt_LS,WN_LSF,DN,dt_LSF
 * return : status (1:ok,0:error)
 *-----------------------------------------------------------------------------*/
-extern int decode_bds_d1(const uint8_t *buff, eph_t *eph, double *ion,
+int decode_bds_d1(const uint8_t *buff, eph_t *eph, double *ion,
                          double *utc)
 {
     trace(4,"decode_bds_d1:\n");
@@ -846,7 +846,7 @@ static int decode_bds_d2_utc(const uint8_t *buff, double *utc)
 *                                 utc[4-7]: dt_LS,WN_LSF,DN,dt_LSF
 * return : status (1:ok,0:error)
 *-----------------------------------------------------------------------------*/
-extern int decode_bds_d2(const uint8_t *buff, eph_t *eph, double *utc)
+int decode_bds_d2(const uint8_t *buff, eph_t *eph, double *utc)
 {
     trace(4,"decode_bds_d2:\n");
     
@@ -863,7 +863,7 @@ extern int decode_bds_d2(const uint8_t *buff, eph_t *eph, double *utc)
 *                                  buff[10]: string bit  5- 1 (0 padded)
 * return : status (1:ok,0:error)
 *-----------------------------------------------------------------------------*/
-extern int test_glostr(const uint8_t *buff)
+int test_glostr(const uint8_t *buff)
 {
     static const uint8_t xor_8bit[256]={ /* xor of 8 bits */
         0,1,1,0,1,0,0,1,1,0,0,1,0,1,1,0,1,0,0,1,0,1,1,0,0,1,1,0,1,0,0,1,
@@ -1003,7 +1003,7 @@ static int decode_glostr_utc(const uint8_t *buff, double *utc)
 * notes  : geph->tof should be set to frame time within 1/2 day before calling
 *          geph->frq is set to 0
 *-----------------------------------------------------------------------------*/
-extern int decode_glostr(const uint8_t *buff, geph_t *geph, double *utc)
+int decode_glostr(const uint8_t *buff, geph_t *geph, double *utc)
 {
     trace(4,"decode_glostr:\n");
     
@@ -1279,7 +1279,7 @@ static int decode_frame_utc(const uint8_t *buff, double *utc)
 * notes  : use CPU time to resolve modulo 1024 ambiguity of the week number
 *          see ref [1]
 *-----------------------------------------------------------------------------*/
-extern int decode_frame(const uint8_t *buff, int sys, eph_t *eph, alm_t *alm,
+int decode_frame(const uint8_t *buff, int sys, eph_t *eph, alm_t *alm,
                         double *ion, double *utc)
 {
     trace(4,"decode_frame:\n");
@@ -1297,7 +1297,7 @@ extern int decode_frame(const uint8_t *buff, int sys, eph_t *eph, alm_t *alm,
 *          int    format I      stream format (STRFMT_???)
 * return : status (1:ok,0:memory allocation error)
 *-----------------------------------------------------------------------------*/
-extern int init_raw(raw_t *raw, int format)
+int init_raw(raw_t *raw, int format)
 {
     gtime_t time0={0};
     obsd_t data0={{0}};
@@ -1396,7 +1396,7 @@ extern int init_raw(raw_t *raw, int format)
 * args   : raw_t  *raw   IO     receiver raw data control struct
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void free_raw(raw_t *raw)
+void free_raw(raw_t *raw)
 {
     trace(3,"free_raw:\n");
     
@@ -1423,7 +1423,7 @@ extern void free_raw(raw_t *raw)
 *                  2: input ephemeris, 3: input sbas message,
 *                  9: input ion/utc parameter)
 *-----------------------------------------------------------------------------*/
-extern int input_raw(raw_t *raw, int format, uint8_t data)
+int input_raw(raw_t *raw, int format, uint8_t data)
 {
     trace(5,"input_raw: format=%d data=0x%02x\n",format,data);
     
@@ -1451,7 +1451,7 @@ extern int input_raw(raw_t *raw, int format, uint8_t data)
 *          FILE   *fp    I      file pointer
 * return : status(-2: end of file/format error, -1...31: same as above)
 *-----------------------------------------------------------------------------*/
-extern int input_rawf(raw_t *raw, int format, FILE *fp)
+int input_rawf(raw_t *raw, int format, FILE *fp)
 {
     trace(4,"input_rawf: format=%d\n",format);
     

--- a/src/rinex.c
+++ b/src/rinex.c
@@ -1710,7 +1710,7 @@ static int readrnxfile(const char *file, gtime_t ts, gtime_t te, double tint,
 * Returns 1 on success, and 0 if omitted or truncated.
 * The comment is append from the first empty comment, and it is assumed that
 * comments are added without empty comments. */
-extern int rnxcomment(rnxopt_t *opt, const char *format, ...) {
+int rnxcomment(rnxopt_t *opt, const char *format, ...) {
     char buff[256];
     va_list ap;
     va_start(ap, format);
@@ -1779,7 +1779,7 @@ extern int rnxcomment(rnxopt_t *opt, const char *format, ...) {
 *                               (sys=G:GPS,R:GLO,E:GAL,J:QZS,C:BDS,I:IRN,S:SBS)
 *
 *-----------------------------------------------------------------------------*/
-extern int readrnxt(const char *file, int rcv, gtime_t ts, gtime_t te,
+int readrnxt(const char *file, int rcv, gtime_t ts, gtime_t te,
                     double tint, const char *opt, obs_t *obs, nav_t *nav,
                     sta_t *sta)
 {
@@ -1816,7 +1816,7 @@ extern int readrnxt(const char *file, int rcv, gtime_t ts, gtime_t te,
 
     return stat;
 }
-extern int readrnx(const char *file, int rcv, const char *opt, obs_t *obs,
+int readrnx(const char *file, int rcv, const char *opt, obs_t *obs,
                    nav_t *nav, sta_t *sta)
 {
     gtime_t t={0};
@@ -1872,7 +1872,7 @@ static void combpclk(nav_t *nav)
 *          nav_t *nav    IO     navigation data    (NULL: no input)
 * return : number of precise clock
 *-----------------------------------------------------------------------------*/
-extern int readrnxc(const char *file, nav_t *nav)
+int readrnxc(const char *file, nav_t *nav)
 {
     gtime_t t={0};
     int i,n,index=0,stat=1;
@@ -1912,7 +1912,7 @@ extern int readrnxc(const char *file, nav_t *nav)
 * args   : rnxctr_t *rnx IO     RINEX control struct
 * return : status (1:ok,0:memory allocation error)
 *-----------------------------------------------------------------------------*/
-extern int init_rnxctr(rnxctr_t *rnx)
+int init_rnxctr(rnxctr_t *rnx)
 {
     gtime_t time0={0};
     obsd_t data0={{0}};
@@ -1965,7 +1965,7 @@ extern int init_rnxctr(rnxctr_t *rnx)
 * args   : rnxctr_t *rnx IO  RINEX control struct
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void free_rnxctr(rnxctr_t *rnx)
+void free_rnxctr(rnxctr_t *rnx)
 {
     trace(3,"free_rnxctr:\n");
 
@@ -1981,7 +1981,7 @@ extern void free_rnxctr(rnxctr_t *rnx)
 * return : status (-2: end of file, 0: no message, 1: input observation data,
 *                   2: input navigation data)
 *-----------------------------------------------------------------------------*/
-extern int open_rnxctr(rnxctr_t *rnx, FILE *fp)
+int open_rnxctr(rnxctr_t *rnx, FILE *fp)
 {
     const char *rnxtypes="ONGLJHC";
     double ver;
@@ -2028,7 +2028,7 @@ extern int open_rnxctr(rnxctr_t *rnx, FILE *fp)
 *            rnx->nav.eph [sat-1]        : other ephemeris set1 (sat=sat-no)
 *            rnx->nav.eph [sat-1+MAXSAT] : other ephemeris set2 (sat=sat-no)
 *-----------------------------------------------------------------------------*/
-extern int input_rnxctr(rnxctr_t *rnx, FILE *fp)
+int input_rnxctr(rnxctr_t *rnx, FILE *fp)
 {
     eph_t eph={0};
     geph_t geph={0};
@@ -2277,7 +2277,7 @@ static char *igsanttype(const char *anttype, char buff[21]) {
 *          nav_t  *nav      I   navigation data
 * return : status (1:ok, 0:output error)
 *-----------------------------------------------------------------------------*/
-extern int outrnxobsh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
+int outrnxobsh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 {
     double ep[6],pos[3]={0},del[3]={0};
     char date[32],*sys,*tsys="GPS";
@@ -2469,7 +2469,7 @@ static void outrinexevent(FILE *fp, const rnxopt_t *opt, const obsd_t *obs,
 *          int    flag      I   epoch flag (0:ok,1:power failure,>1:event flag)
 * return : status (1:ok, 0:output error)
 *-----------------------------------------------------------------------------*/
-extern int outrnxobsb(FILE *fp, const rnxopt_t *opt, const obsd_t *obs, int n,
+int outrnxobsb(FILE *fp, const rnxopt_t *opt, const obsd_t *obs, int n,
                       int flag)
 {
     double epdiff,ep[6],dL;
@@ -2733,7 +2733,7 @@ static void out_leaps(FILE *fp, int sys, const rnxopt_t *opt, const nav_t *nav)
 *          nav_t  nav       I   navigation data (NULL: no input)
 * return : status (1:ok, 0:output error)
 *-----------------------------------------------------------------------------*/
-extern int outrnxnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
+int outrnxnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 {
     int i;
     char date[32],*sys;
@@ -2780,7 +2780,7 @@ extern int outrnxnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 *          eph_t  *eph      I   ephemeris
 * return : status (1:ok, 0:output error)
 *-----------------------------------------------------------------------------*/
-extern int outrnxnavb(FILE *fp, const rnxopt_t *opt, const eph_t *eph)
+int outrnxnavb(FILE *fp, const rnxopt_t *opt, const eph_t *eph)
 {
     double ep[6],ttr;
     int week,sys,prn;
@@ -2900,7 +2900,7 @@ extern int outrnxnavb(FILE *fp, const rnxopt_t *opt, const eph_t *eph)
 *          nav_t  nav       I   navigation data (NULL: no input)
 * return : status (1:ok, 0:output error)
 *-----------------------------------------------------------------------------*/
-extern int outrnxgnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
+int outrnxgnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 {
     int i;
     char date[32];
@@ -2936,7 +2936,7 @@ extern int outrnxgnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 *          geph_t  *geph    I   glonass ephemeris
 * return : status (1:ok, 0:output error)
 *-----------------------------------------------------------------------------*/
-extern int outrnxgnavb(FILE *fp, const rnxopt_t *opt, const geph_t *geph)
+int outrnxgnavb(FILE *fp, const rnxopt_t *opt, const geph_t *geph)
 {
     gtime_t toe;
     double ep[6],tof;
@@ -3002,7 +3002,7 @@ extern int outrnxgnavb(FILE *fp, const rnxopt_t *opt, const geph_t *geph)
 *          nav_t  nav       I   navigation data (NULL: no input)
 * return : status (1:ok, 0:output error)
 *-----------------------------------------------------------------------------*/
-extern int outrnxhnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
+int outrnxhnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 {
     int i;
     char date[32];
@@ -3038,7 +3038,7 @@ extern int outrnxhnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 *          seph_t  *seph    I   SBAS ephemeris
 * return : status (1:ok, 0:output error)
 *-----------------------------------------------------------------------------*/
-extern int outrnxhnavb(FILE *fp, const rnxopt_t *opt, const seph_t *seph)
+int outrnxhnavb(FILE *fp, const rnxopt_t *opt, const seph_t *seph)
 {
     double ep[6];
     int prn;
@@ -3092,7 +3092,7 @@ extern int outrnxhnavb(FILE *fp, const rnxopt_t *opt, const seph_t *seph)
 *          nav_t  nav       I   navigation data (NULL: no input)
 * return : status (1:ok, 0:output error)
 *-----------------------------------------------------------------------------*/
-extern int outrnxlnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
+int outrnxlnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 {
     int i;
     char date[32];
@@ -3126,7 +3126,7 @@ extern int outrnxlnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 *          nav_t  nav       I   navigation data (NULL: no input)
 * return : status (1:ok, 0:output error)
 *-----------------------------------------------------------------------------*/
-extern int outrnxqnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
+int outrnxqnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 {
     int i;
     char date[32];
@@ -3160,7 +3160,7 @@ extern int outrnxqnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 *          nav_t  nav       I   navigation data (NULL: no input)
 * return : status (1:ok, 0:output error)
 *-----------------------------------------------------------------------------*/
-extern int outrnxcnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
+int outrnxcnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 {
     int i;
     char date[32];
@@ -3194,7 +3194,7 @@ extern int outrnxcnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 *          nav_t  nav       I   navigation data (NULL: no input)
 * return : status (1:ok, 0:output error)
 *-----------------------------------------------------------------------------*/
-extern int outrnxinavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
+int outrnxinavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 {
     int i;
     char date[32];

--- a/src/rinex.c
+++ b/src/rinex.c
@@ -1708,7 +1708,7 @@ static int readrnxfile(const char *file, gtime_t ts, gtime_t te, double tint,
 * Returns 1 on success, and 0 if omitted or truncated.
 * The comment is append from the first empty comment, and it is assumed that
 * comments are added without empty comments. */
-extern int rnxcomment(rnxopt_t *opt, const char *format, ...) {
+int rnxcomment(rnxopt_t *opt, const char *format, ...) {
     char buff[256];
     va_list ap;
     va_start(ap, format);
@@ -1777,7 +1777,7 @@ extern int rnxcomment(rnxopt_t *opt, const char *format, ...) {
 *                               (sys=G:GPS,R:GLO,E:GAL,J:QZS,C:BDS,I:IRN,S:SBS)
 *
 *-----------------------------------------------------------------------------*/
-extern int readrnxt(const char *file, int rcv, gtime_t ts, gtime_t te,
+int readrnxt(const char *file, int rcv, gtime_t ts, gtime_t te,
                     double tint, const char *opt, obs_t *obs, nav_t *nav,
                     sta_t *sta)
 {
@@ -1814,7 +1814,7 @@ extern int readrnxt(const char *file, int rcv, gtime_t ts, gtime_t te,
 
     return stat;
 }
-extern int readrnx(const char *file, int rcv, const char *opt, obs_t *obs,
+int readrnx(const char *file, int rcv, const char *opt, obs_t *obs,
                    nav_t *nav, sta_t *sta)
 {
     gtime_t t={0};
@@ -1870,7 +1870,7 @@ static void combpclk(nav_t *nav)
 *          nav_t *nav    IO     navigation data    (NULL: no input)
 * return : number of precise clock
 *-----------------------------------------------------------------------------*/
-extern int readrnxc(const char *file, nav_t *nav)
+int readrnxc(const char *file, nav_t *nav)
 {
     gtime_t t={0};
     int i,n,index=0,stat=1;
@@ -1910,7 +1910,7 @@ extern int readrnxc(const char *file, nav_t *nav)
 * args   : rnxctr_t *rnx IO     RINEX control struct
 * return : status (1:ok,0:memory allocation error)
 *-----------------------------------------------------------------------------*/
-extern int init_rnxctr(rnxctr_t *rnx)
+int init_rnxctr(rnxctr_t *rnx)
 {
     gtime_t time0={0};
     obsd_t data0={{0}};
@@ -1963,7 +1963,7 @@ extern int init_rnxctr(rnxctr_t *rnx)
 * args   : rnxctr_t *rnx IO  RINEX control struct
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void free_rnxctr(rnxctr_t *rnx)
+void free_rnxctr(rnxctr_t *rnx)
 {
     trace(3,"free_rnxctr:\n");
 
@@ -1979,7 +1979,7 @@ extern void free_rnxctr(rnxctr_t *rnx)
 * return : status (-2: end of file, 0: no message, 1: input observation data,
 *                   2: input navigation data)
 *-----------------------------------------------------------------------------*/
-extern int open_rnxctr(rnxctr_t *rnx, FILE *fp)
+int open_rnxctr(rnxctr_t *rnx, FILE *fp)
 {
     const char *rnxtypes="ONGLJHC";
     double ver;
@@ -2026,7 +2026,7 @@ extern int open_rnxctr(rnxctr_t *rnx, FILE *fp)
 *            rnx->nav.eph [sat-1]        : other ephemeris set1 (sat=sat-no)
 *            rnx->nav.eph [sat-1+MAXSAT] : other ephemeris set2 (sat=sat-no)
 *-----------------------------------------------------------------------------*/
-extern int input_rnxctr(rnxctr_t *rnx, FILE *fp)
+int input_rnxctr(rnxctr_t *rnx, FILE *fp)
 {
     eph_t eph={0};
     geph_t geph={0};
@@ -2275,7 +2275,7 @@ static char *igsanttype(const char *anttype, char buff[21]) {
 *          nav_t  *nav      I   navigation data
 * return : status (1:ok, 0:output error)
 *-----------------------------------------------------------------------------*/
-extern int outrnxobsh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
+int outrnxobsh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 {
     double ep[6],pos[3]={0},del[3]={0};
     char date[32],*sys,*tsys="GPS";
@@ -2467,7 +2467,7 @@ static void outrinexevent(FILE *fp, const rnxopt_t *opt, const obsd_t *obs,
 *          int    flag      I   epoch flag (0:ok,1:power failure,>1:event flag)
 * return : status (1:ok, 0:output error)
 *-----------------------------------------------------------------------------*/
-extern int outrnxobsb(FILE *fp, const rnxopt_t *opt, const obsd_t *obs, int n,
+int outrnxobsb(FILE *fp, const rnxopt_t *opt, const obsd_t *obs, int n,
                       int flag)
 {
     double epdiff,ep[6],dL;
@@ -2731,7 +2731,7 @@ static void out_leaps(FILE *fp, int sys, const rnxopt_t *opt, const nav_t *nav)
 *          nav_t  nav       I   navigation data (NULL: no input)
 * return : status (1:ok, 0:output error)
 *-----------------------------------------------------------------------------*/
-extern int outrnxnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
+int outrnxnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 {
     int i;
     char date[32],*sys;
@@ -2778,7 +2778,7 @@ extern int outrnxnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 *          eph_t  *eph      I   ephemeris
 * return : status (1:ok, 0:output error)
 *-----------------------------------------------------------------------------*/
-extern int outrnxnavb(FILE *fp, const rnxopt_t *opt, const eph_t *eph)
+int outrnxnavb(FILE *fp, const rnxopt_t *opt, const eph_t *eph)
 {
     double ep[6],ttr;
     int week,sys,prn;
@@ -2898,7 +2898,7 @@ extern int outrnxnavb(FILE *fp, const rnxopt_t *opt, const eph_t *eph)
 *          nav_t  nav       I   navigation data (NULL: no input)
 * return : status (1:ok, 0:output error)
 *-----------------------------------------------------------------------------*/
-extern int outrnxgnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
+int outrnxgnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 {
     int i;
     char date[32];
@@ -2934,7 +2934,7 @@ extern int outrnxgnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 *          geph_t  *geph    I   glonass ephemeris
 * return : status (1:ok, 0:output error)
 *-----------------------------------------------------------------------------*/
-extern int outrnxgnavb(FILE *fp, const rnxopt_t *opt, const geph_t *geph)
+int outrnxgnavb(FILE *fp, const rnxopt_t *opt, const geph_t *geph)
 {
     gtime_t toe;
     double ep[6],tof;
@@ -3000,7 +3000,7 @@ extern int outrnxgnavb(FILE *fp, const rnxopt_t *opt, const geph_t *geph)
 *          nav_t  nav       I   navigation data (NULL: no input)
 * return : status (1:ok, 0:output error)
 *-----------------------------------------------------------------------------*/
-extern int outrnxhnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
+int outrnxhnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 {
     int i;
     char date[32];
@@ -3036,7 +3036,7 @@ extern int outrnxhnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 *          seph_t  *seph    I   SBAS ephemeris
 * return : status (1:ok, 0:output error)
 *-----------------------------------------------------------------------------*/
-extern int outrnxhnavb(FILE *fp, const rnxopt_t *opt, const seph_t *seph)
+int outrnxhnavb(FILE *fp, const rnxopt_t *opt, const seph_t *seph)
 {
     double ep[6];
     int prn;
@@ -3090,7 +3090,7 @@ extern int outrnxhnavb(FILE *fp, const rnxopt_t *opt, const seph_t *seph)
 *          nav_t  nav       I   navigation data (NULL: no input)
 * return : status (1:ok, 0:output error)
 *-----------------------------------------------------------------------------*/
-extern int outrnxlnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
+int outrnxlnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 {
     int i;
     char date[32];
@@ -3124,7 +3124,7 @@ extern int outrnxlnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 *          nav_t  nav       I   navigation data (NULL: no input)
 * return : status (1:ok, 0:output error)
 *-----------------------------------------------------------------------------*/
-extern int outrnxqnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
+int outrnxqnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 {
     int i;
     char date[32];
@@ -3158,7 +3158,7 @@ extern int outrnxqnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 *          nav_t  nav       I   navigation data (NULL: no input)
 * return : status (1:ok, 0:output error)
 *-----------------------------------------------------------------------------*/
-extern int outrnxcnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
+int outrnxcnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 {
     int i;
     char date[32];
@@ -3192,7 +3192,7 @@ extern int outrnxcnavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 *          nav_t  nav       I   navigation data (NULL: no input)
 * return : status (1:ok, 0:output error)
 *-----------------------------------------------------------------------------*/
-extern int outrnxinavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
+int outrnxinavh(FILE *fp, const rnxopt_t *opt, const nav_t *nav)
 {
     int i;
     char date[32];

--- a/src/rtcm.c
+++ b/src/rtcm.c
@@ -48,9 +48,9 @@
 #include "rtklib.h"
 
 /* function prototypes -------------------------------------------------------*/
-extern int decode_rtcm2(rtcm_t *rtcm);
-extern int decode_rtcm3(rtcm_t *rtcm);
-extern int encode_rtcm3(rtcm_t *rtcm, int type, int subtype, int sync);
+int decode_rtcm2(rtcm_t *rtcm);
+int decode_rtcm3(rtcm_t *rtcm);
+int encode_rtcm3(rtcm_t *rtcm, int type, int subtype, int sync);
 
 /* constants -----------------------------------------------------------------*/
 
@@ -63,7 +63,7 @@ extern int encode_rtcm3(rtcm_t *rtcm, int type, int subtype, int sync);
 * args   : rtcm_t *raw   IO     rtcm control struct
 * return : status (1:ok,0:memory allocation error)
 *-----------------------------------------------------------------------------*/
-extern int init_rtcm(rtcm_t *rtcm)
+int init_rtcm(rtcm_t *rtcm)
 {
     gtime_t time0={0};
     obsd_t data0={{0}};
@@ -138,7 +138,7 @@ extern int init_rtcm(rtcm_t *rtcm)
 * args   : rtcm_t *raw   IO     rtcm control struct
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void free_rtcm(rtcm_t *rtcm)
+void free_rtcm(rtcm_t *rtcm)
 {
     trace(3,"free_rtcm:\n");
     
@@ -161,7 +161,7 @@ extern void free_rtcm(rtcm_t *rtcm)
 *          supported msgs RTCM ver.2: 1,3,9,14,16,17,18,19,22
 *          refer [1] for RTCM ver.2
 *-----------------------------------------------------------------------------*/
-extern int input_rtcm2(rtcm_t *rtcm, uint8_t data)
+int input_rtcm2(rtcm_t *rtcm, uint8_t data)
 {
     uint8_t preamb;
     int i;
@@ -275,7 +275,7 @@ extern int input_rtcm2(rtcm_t *rtcm, uint8_t data)
 *            |<-- 8 --->|<- 6 -->|<-- 10 --->|<--- length x 8 --->|<-- 24 -->|
 *            
 *-----------------------------------------------------------------------------*/
-extern int input_rtcm3(rtcm_t *rtcm, uint8_t data)
+int input_rtcm3(rtcm_t *rtcm, uint8_t data)
 {
     trace(5,"input_rtcm3: data=%02x\n",data);
     
@@ -312,7 +312,7 @@ extern int input_rtcm3(rtcm_t *rtcm, uint8_t data)
 * return : status (-2: end of file, -1...10: same as above)
 * notes  : same as above
 *-----------------------------------------------------------------------------*/
-extern int input_rtcm2f(rtcm_t *rtcm, FILE *fp)
+int input_rtcm2f(rtcm_t *rtcm, FILE *fp)
 {
     int i,data=0,ret;
     
@@ -331,7 +331,7 @@ extern int input_rtcm2f(rtcm_t *rtcm, FILE *fp)
 * return : status (-2: end of file, -1...10: same as above)
 * notes  : same as above
 *-----------------------------------------------------------------------------*/
-extern int input_rtcm3f(rtcm_t *rtcm, FILE *fp)
+int input_rtcm3f(rtcm_t *rtcm, FILE *fp)
 {
     int i,data=0,ret;
     
@@ -356,7 +356,7 @@ extern int input_rtcm3f(rtcm_t *rtcm, FILE *fp)
 *          int    sync    I  sync flag (1:another message follows)
 * return : status (1:ok,0:error)
 *-----------------------------------------------------------------------------*/
-extern int gen_rtcm2(rtcm_t *rtcm, int type, int sync)
+int gen_rtcm2(rtcm_t *rtcm, int type, int sync)
 {
     trace(4,"gen_rtcm2: type=%d sync=%d\n",type,sync);
     
@@ -380,7 +380,7 @@ extern int gen_rtcm2(rtcm_t *rtcm, int type, int sync)
 *          ({nsat} = number of valid satellites, {nsig} = number of signals in
 *          the obs data) 
 *-----------------------------------------------------------------------------*/
-extern int gen_rtcm3(rtcm_t *rtcm, int type, int subtype, int sync)
+int gen_rtcm3(rtcm_t *rtcm, int type, int subtype, int sync)
 {
     uint32_t crc;
     int i=0;

--- a/src/rtcm2.c
+++ b/src/rtcm2.c
@@ -387,7 +387,7 @@ static int decode_type59(rtcm_t *rtcm)
     return 0;
 }
 /* decode rtcm ver.2 message -------------------------------------------------*/
-extern int decode_rtcm2(rtcm_t *rtcm)
+int decode_rtcm2(rtcm_t *rtcm)
 {
     double zcnt;
     int staid,seqno,stah,ret=0,type=getbitu(rtcm->buff,8,6);

--- a/src/rtcm3.c
+++ b/src/rtcm3.c
@@ -2723,7 +2723,7 @@ static int decode_type4076(rtcm_t *rtcm)
     return 0;
 }
 /* decode RTCM ver.3 message -------------------------------------------------*/
-extern int decode_rtcm3(rtcm_t *rtcm)
+int decode_rtcm3(rtcm_t *rtcm)
 {
     double tow;
     int ret=0,type=getbitu(rtcm->buff,24,12),week;

--- a/src/rtcm3e.c
+++ b/src/rtcm3e.c
@@ -2701,7 +2701,7 @@ static int encode_type4076(rtcm_t *rtcm, int subtype, int sync)
     return 0;
 }
 /* encode RTCM ver.3 message -------------------------------------------------*/
-extern int encode_rtcm3(rtcm_t *rtcm, int type, int subtype, int sync)
+int encode_rtcm3(rtcm_t *rtcm, int type, int subtype, int sync)
 {
     int ret=0;
     

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -385,7 +385,7 @@ static void fatalerr(const char *format, ...)
 * return : none
 * notes  : if malloc() failed in return : none
 *-----------------------------------------------------------------------------*/
-extern void add_fatal(fatalfunc_t *func)
+void add_fatal(fatalfunc_t *func)
 {
     fatalfunc=func;
 }
@@ -395,7 +395,7 @@ extern void add_fatal(fatalfunc_t *func)
 *          int    prn       I   satellite prn/slot number
 * return : satellite number (0:error)
 *-----------------------------------------------------------------------------*/
-extern int satno(int sys, int prn)
+int satno(int sys, int prn)
 {
     if (prn<=0) return 0;
     switch (sys) {
@@ -434,7 +434,7 @@ extern int satno(int sys, int prn)
 *          int    *prn      IO  satellite prn/slot number (NULL: no output)
 * return : satellite system (SYS_GPS,SYS_GLO,...)
 *-----------------------------------------------------------------------------*/
-extern int satsys(int sat, int *prn)
+int satsys(int sat, int *prn)
 {
     int sys=SYS_NONE;
     if (sat<=0||MAXSAT<sat) sat=0;
@@ -472,7 +472,7 @@ extern int satsys(int sat, int *prn)
 * return : satellite number (0: error)
 * notes  : 120-142 and 193-199 are also recognized as sbas and qzss
 *-----------------------------------------------------------------------------*/
-extern int satid2no(const char *id)
+int satid2no(const char *id)
 {
     int sys,prn;
     char code;
@@ -505,7 +505,7 @@ extern int satid2no(const char *id)
 *          char   *id       O   satellite id (Gnn,Rnn,Enn,Jnn,Cnn,Inn or nnn)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void satno2id(int sat, char id[8])
+void satno2id(int sat, char id[8])
 {
     int prn;
     switch (satsys(sat,&prn)) {
@@ -528,7 +528,7 @@ extern void satno2id(int sat, char id[8])
 *          prcopt_t *opt    I   processing options (NULL: not used)
 * return : status (1:excluded,0:not excluded)
 *-----------------------------------------------------------------------------*/
-extern int satexclude(int sat, double var, int svh, const prcopt_t *opt)
+int satexclude(int sat, double var, int svh, const prcopt_t *opt)
 {
     int sys=satsys(sat,NULL);
 
@@ -564,7 +564,7 @@ extern int satexclude(int sat, double var, int svh, const prcopt_t *opt)
 *          snrmask_t *mask  I   SNR mask
 * return : status (1:masked,0:unmasked)
 *-----------------------------------------------------------------------------*/
-extern int testsnr(int base, int idx, double el, double snr,
+int testsnr(int base, int idx, double el, double snr,
                    const snrmask_t *mask)
 {
     double minsnr,a;
@@ -586,7 +586,7 @@ extern int testsnr(int base, int idx, double el, double snr,
 * return : obs code (CODE_???)
 * notes  : obs codes are based on RINEX 3.04
 *-----------------------------------------------------------------------------*/
-extern uint8_t obs2code(const char *obs)
+uint8_t obs2code(const char *obs)
 {
     int i;
 
@@ -602,7 +602,7 @@ extern uint8_t obs2code(const char *obs)
 * return : obs code string ("1C","1P","1P",...)
 * notes  : obs codes are based on RINEX 3.04
 *-----------------------------------------------------------------------------*/
-extern const char *code2obs(uint8_t code)
+const char *code2obs(uint8_t code)
 {
     if (code<=CODE_NONE||MAXCODE<code) return "";
     return obscodes[code];
@@ -719,7 +719,7 @@ static int code2freq_IRN(uint8_t code, double *freq)
 *            BDS       B1    B2b   B2a   B3   B1C   B2ab
 *            NavIC     L5     S    L1     -     -     -
 *-----------------------------------------------------------------------------*/
-extern int code2idx(int sys, uint8_t code)
+int code2idx(int sys, uint8_t code)
 {
     double freq;
 
@@ -741,7 +741,7 @@ extern int code2idx(int sys, uint8_t code)
 *          int    fcn       I   frequency channel number for GLONASS
 * return : carrier frequency (Hz) (0.0: error)
 *-----------------------------------------------------------------------------*/
-extern double code2freq(int sys, uint8_t code, int fcn)
+double code2freq(int sys, uint8_t code, int fcn)
 {
     double freq=0.0;
 
@@ -763,7 +763,7 @@ extern double code2freq(int sys, uint8_t code, int fcn)
 *          nav_t  *nav_t    I   navigation data for GLONASS (NULL: not used)
 * return : carrier frequency (Hz) (0.0: error)
 *-----------------------------------------------------------------------------*/
-extern double sat2freq(int sat, uint8_t code, const nav_t *nav)
+double sat2freq(int sat, uint8_t code, const nav_t *nav)
 {
     int i,fcn=-8,sys,prn;
 
@@ -791,7 +791,7 @@ extern double sat2freq(int sat, uint8_t code, const nav_t *nav)
 *                               (higher priority precedes lower)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void setcodepri(int sys, int idx, const char *pri)
+void setcodepri(int sys, int idx, const char *pri)
 {
     trace(3,"setcodepri:sys=%d idx=%d pri=%s\n",sys,idx,pri);
 
@@ -811,7 +811,7 @@ extern void setcodepri(int sys, int idx, const char *pri)
 *          char   *opt      I   code options (NULL:no option)
 * return : priority (15:highest-1:lowest,0:error)
 *-----------------------------------------------------------------------------*/
-extern int getcodepri(int sys, uint8_t code, const char *opt)
+int getcodepri(int sys, uint8_t code, const char *opt)
 {
     const char *p,*optstr, *obs;
     char str[8]="";
@@ -845,14 +845,14 @@ extern int getcodepri(int sys, uint8_t code, const char *opt)
 *          int    len       I   bit length (bits) (len<=32)
 * return : extracted unsigned/signed bits
 *-----------------------------------------------------------------------------*/
-extern uint32_t getbitu(const uint8_t *buff, int pos, int len)
+uint32_t getbitu(const uint8_t *buff, int pos, int len)
 {
     uint32_t bits=0;
     int i;
     for (i=pos;i<pos+len;i++) bits=(bits<<1)+((buff[i/8]>>(7-i%8))&1u);
     return bits;
 }
-extern int32_t getbits(const uint8_t *buff, int pos, int len)
+int32_t getbits(const uint8_t *buff, int pos, int len)
 {
     uint32_t bits=getbitu(buff,pos,len);
     if (len<=0||32<=len||!(bits&(1u<<(len-1)))) return (int32_t)bits;
@@ -866,7 +866,7 @@ extern int32_t getbits(const uint8_t *buff, int pos, int len)
 *          [u]int32_t data  I   unsigned/signed data
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void setbitu(uint8_t *buff, int pos, int len, uint32_t data)
+void setbitu(uint8_t *buff, int pos, int len, uint32_t data)
 {
     uint32_t mask=1u<<(len-1);
     int i;
@@ -875,7 +875,7 @@ extern void setbitu(uint8_t *buff, int pos, int len, uint32_t data)
         if (data&mask) buff[i/8]|=1u<<(7-i%8); else buff[i/8]&=~(1u<<(7-i%8));
     }
 }
-extern void setbits(uint8_t *buff, int pos, int len, int32_t data)
+void setbits(uint8_t *buff, int pos, int len, int32_t data)
 {
     if (data<0) data|=1<<(len-1); else data&=~(1<<(len-1)); /* set sign bit */
     setbitu(buff,pos,len,(uint32_t)data);
@@ -887,7 +887,7 @@ extern void setbits(uint8_t *buff, int pos, int len, int32_t data)
 * return : crc-32 parity
 * notes  : see NovAtel OEMV firmware manual 1.7 32-bit CRC
 *-----------------------------------------------------------------------------*/
-extern uint32_t rtk_crc32(const uint8_t *buff, int len)
+uint32_t rtk_crc32(const uint8_t *buff, int len)
 {
     uint32_t crc=0;
     int i,j;
@@ -909,7 +909,7 @@ extern uint32_t rtk_crc32(const uint8_t *buff, int len)
 * return : crc-24Q parity
 * notes  : see reference [2] A.4.3.3 Parity
 *-----------------------------------------------------------------------------*/
-extern uint32_t rtk_crc24q(const uint8_t *buff, int len)
+uint32_t rtk_crc24q(const uint8_t *buff, int len)
 {
     uint32_t crc=0;
     int i;
@@ -926,7 +926,7 @@ extern uint32_t rtk_crc24q(const uint8_t *buff, int len)
 * return : crc-16 parity
 * notes  : see reference [10] A.3.
 *-----------------------------------------------------------------------------*/
-extern uint16_t rtk_crc16(const uint8_t *buff, int len)
+uint16_t rtk_crc16(const uint8_t *buff, int len)
 {
     uint16_t crc=0;
     int i;
@@ -947,7 +947,7 @@ extern uint16_t rtk_crc16(const uint8_t *buff, int len)
 * return : status (1:ok,0:parity error)
 * notes  : see reference [1] 20.3.5.2 user parity algorithm
 *-----------------------------------------------------------------------------*/
-extern int decode_word(uint32_t word, uint8_t *data)
+int decode_word(uint32_t word, uint8_t *data)
 {
     const uint32_t hamming[]={
         0xBB1F3480,0x5D8F9A40,0xAEC7CD00,0x5763E680,0x6BB1F340,0x8B7A89C0
@@ -973,7 +973,7 @@ extern int decode_word(uint32_t word, uint8_t *data)
 * args   : int    n,m       I   number of rows and columns of matrix
 * return : matrix pointer (if n<=0 or m<=0, return NULL)
 *-----------------------------------------------------------------------------*/
-extern double *mat(int n, int m)
+double *mat(int n, int m)
 {
     double *p;
 
@@ -988,7 +988,7 @@ extern double *mat(int n, int m)
 * args   : int    n,m       I   number of rows and columns of matrix
 * return : matrix pointer (if n<=0 or m<=0, return NULL)
 *-----------------------------------------------------------------------------*/
-extern int *imat(int n, int m)
+int *imat(int n, int m)
 {
     int *p;
 
@@ -1003,7 +1003,7 @@ extern int *imat(int n, int m)
 * args   : int    n,m       I   number of rows and columns of matrix
 * return : matrix pointer (if n<=0 or m<=0, return NULL)
 *-----------------------------------------------------------------------------*/
-extern double *zeros(int n, int m)
+double *zeros(int n, int m)
 {
     double *p;
 
@@ -1022,7 +1022,7 @@ extern double *zeros(int n, int m)
 * args   : int    n         I   number of rows and columns of matrix
 * return : matrix pointer (if n<=0, return NULL)
 *-----------------------------------------------------------------------------*/
-extern double *eye(int n)
+double *eye(int n)
 {
     double *p;
     int i;
@@ -1036,14 +1036,14 @@ extern double *eye(int n)
  * args   : double *a,*b     I   vectors a and b
  * return : a'*b
  *-----------------------------------------------------------------------------*/
-extern double dot2(const double* a, const double* b) { return a[0] * b[0] + a[1] * b[1]; }
+double dot2(const double* a, const double* b) { return a[0] * b[0] + a[1] * b[1]; }
 
 /* dot product -----------------------------------------------------------------
  * inner product of vectors of size 3
  * args   : double *a,*b     I   vectors a and b
  * return : a'*b
  *-----------------------------------------------------------------------------*/
-extern double dot3(const double* a, const double* b)
+double dot3(const double* a, const double* b)
 {
   return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
 }
@@ -1054,7 +1054,7 @@ extern double dot3(const double* a, const double* b)
 *          int    n         I   size of vector a,b
 * return : a'*b
 *-----------------------------------------------------------------------------*/
-extern double dot(const double *a, const double *b, int n)
+double dot(const double *a, const double *b, int n)
 {
     double c=0.0;
 
@@ -1068,7 +1068,7 @@ extern double dot(const double *a, const double *b, int n)
 *          int    n         I   size of vector a
 * return : || a ||
 *-----------------------------------------------------------------------------*/
-extern double norm(const double *a, int n)
+double norm(const double *a, int n)
 {
     return sqrt(dot(a,a,n));
 }
@@ -1078,7 +1078,7 @@ extern double norm(const double *a, int n)
 *          double *c        O   outer product (a x b) (3 x 1)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void cross3(const double *a, const double *b, double *c)
+void cross3(const double *a, const double *b, double *c)
 {
     c[0]=a[1]*b[2]-a[2]*b[1];
     c[1]=a[2]*b[0]-a[0]*b[2];
@@ -1090,7 +1090,7 @@ extern void cross3(const double *a, const double *b, double *c)
 *          double *b        O   normalized vector (3 x 1) || b || = 1
 * return : status (1:ok,0:error)
 *-----------------------------------------------------------------------------*/
-extern int normv3(const double *a, double *b)
+int normv3(const double *a, double *b)
 {
     double r;
     if ((r=norm(a,3))<=0.0) return 0;
@@ -1106,7 +1106,7 @@ extern int normv3(const double *a, double *b)
 *          int    n,m       I   number of rows and columns of matrix
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void matcpy(double *A, const double *B, int n, int m)
+void matcpy(double *A, const double *B, int n, int m)
 {
     memcpy(A,B,sizeof(double)*n*m);
 }
@@ -1122,7 +1122,7 @@ extern void matcpy(double *A, const double *B, int n, int m)
 *          double *C        O matrix C (n x k)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void matmul(const char *tr, int n, int k, int m,
+void matmul(const char *tr, int n, int k, int m,
                    const double *A, const double *B, double *C)
 {
     int lda=tr[0]=='T'?m:n,ldb=tr[1]=='T'?k:m;
@@ -1134,7 +1134,7 @@ extern void matmul(const char *tr, int n, int k, int m,
 /* multiply matrix (wrapper of blas dgemm) -------------------------------------
 * multiply matrix by matrix (C=C+A*B)
 *-----------------------------------------------------------------------------*/
-extern void matmulp(const char *tr, int n, int k, int m,
+void matmulp(const char *tr, int n, int k, int m,
                     const double *A, const double *B, double *C)
 {
     int lda=tr[0]=='T'?m:n,ldb=tr[1]=='T'?k:m;
@@ -1146,7 +1146,7 @@ extern void matmulp(const char *tr, int n, int k, int m,
 /* multiply matrix (wrapper of blas dgemm) -------------------------------------
 * multiply matrix by matrix (C=C-A*B)
 *-----------------------------------------------------------------------------*/
-extern void matmulm(const char *tr, int n, int k, int m,
+void matmulm(const char *tr, int n, int k, int m,
                     const double *A, const double *B, double *C)
 {
     int lda=tr[0]=='T'?m:n,ldb=tr[1]=='T'?k:m;
@@ -1161,7 +1161,7 @@ extern void matmulm(const char *tr, int n, int k, int m,
 *          int    n         I   size of matrix A
 * return : status (0:ok,0>:error)
 *-----------------------------------------------------------------------------*/
-extern int matinv(double *A, int n)
+int matinv(double *A, int n)
 {
     double *work;
     int info,lwork=n*16,*ipiv=imat(n,1);
@@ -1183,7 +1183,7 @@ extern int matinv(double *A, int n)
 * notes  : matrix stored by column-major order (fortran convention)
 *          X can be same as Y
 *-----------------------------------------------------------------------------*/
-extern int solve(const char *tr, const double *A, const double *Y, int n,
+int solve(const char *tr, const double *A, const double *Y, int n,
                  int m, double *X)
 {
     double *B=mat(n,n);
@@ -1200,7 +1200,7 @@ extern int solve(const char *tr, const double *A, const double *Y, int n,
 #else /* without LAPACK/BLAS or MKL */
 
 /* multiply matrix -----------------------------------------------------------*/
-extern void matmul(const char *tr, int n, int k, int m,
+void matmul(const char *tr, int n, int k, int m,
                    const double *A, const double *B, double *C)
 {
     int f=(tr[0]!='N')*2+(tr[1]!='N');
@@ -1244,7 +1244,7 @@ extern void matmul(const char *tr, int n, int k, int m,
           break;
     }
 }
-extern void matmulp(const char *tr, int n, int k, int m,
+void matmulp(const char *tr, int n, int k, int m,
                     const double *A, const double *B, double *C)
 {
     int f=(tr[0]!='N')*2+(tr[1]!='N');
@@ -1288,7 +1288,7 @@ extern void matmulp(const char *tr, int n, int k, int m,
           break;
     }
 }
-extern void matmulm(const char *tr, int n, int k, int m,
+void matmulm(const char *tr, int n, int k, int m,
                     const double *A, const double *B, double *C)
 {
     int f=(tr[0]!='N')*2+(tr[1]!='N');
@@ -1383,7 +1383,7 @@ static void lubksb(const double *A, int n, const int *indx, double *b)
     }
 }
 /* inverse of matrix ---------------------------------------------------------*/
-extern int matinv(double *A, int n)
+int matinv(double *A, int n)
 {
     double d,*B;
     int i,j,*indx;
@@ -1399,7 +1399,7 @@ extern int matinv(double *A, int n)
     return 0;
 }
 /* solve linear equation -----------------------------------------------------*/
-extern int solve(const char *tr, const double *A, const double *Y, int n,
+int solve(const char *tr, const double *A, const double *Y, int n,
                  int m, double *X)
 {
     double *B=mat(n,n);
@@ -1425,7 +1425,7 @@ extern int solve(const char *tr, const double *A, const double *Y, int n,
 * notes  : for weighted least square, replace A and y by A*w and w*y (w=W^(1/2))
 *          matrix stored by column-major order (fortran convention)
 *-----------------------------------------------------------------------------*/
-extern int lsq(const double *A, const double *y, int n, int m, double *x,
+int lsq(const double *A, const double *y, int n, int m, double *x,
                double *Q)
 {
     double *Ay;
@@ -1476,7 +1476,7 @@ static int filter_(const double *x, const double *P, const double *H,
     free(F); free(Q); free(K); free(I);
     return info;
 }
-extern int filter(double *x, double *P, const double *H, const double *v,
+int filter(double *x, double *P, const double *H, const double *v,
                   const double *R, int n, int m)
 {
     double *x_,*xp_,*P_,*Pp_,*H_;
@@ -1517,7 +1517,7 @@ extern int filter(double *x, double *P, const double *H, const double *v,
 * notes  : see reference [4] 5.2
 *          matrix stored by column-major order (fortran convention)
 *-----------------------------------------------------------------------------*/
-extern int smoother(const double *xf, const double *Qf, const double *xb,
+int smoother(const double *xf, const double *Qf, const double *xb,
                     const double *Qb, int n, double *xs, double *Qs)
 {
     double *invQf=mat(n,n),*invQb=mat(n,n),*xx=mat(n,1);
@@ -1545,7 +1545,7 @@ extern int smoother(const double *xf, const double *Qf, const double *xb,
 * return : none
 * notes  : matrix stored by column-major order (fortran convention)
 *-----------------------------------------------------------------------------*/
-extern void matfprint(const double A[], int n, int m, int p, int q, FILE *fp)
+void matfprint(const double A[], int n, int m, int p, int q, FILE *fp)
 {
     int i,j;
 
@@ -1554,12 +1554,12 @@ extern void matfprint(const double A[], int n, int m, int p, int q, FILE *fp)
         fprintf(fp,"\n");
     }
 }
-extern void matprint(const double A[], int n, int m, int p, int q)
+void matprint(const double A[], int n, int m, int p, int q)
 {
     matfprint(A,n,m,p,q,stdout);
 }
 /* set string without tail space ---------------------------------------------*/
-extern void setstr(char *dst, const char *src, int n)
+void setstr(char *dst, const char *src, int n)
 {
     char *p=dst;
     const char *q=src;
@@ -1573,7 +1573,7 @@ extern void setstr(char *dst, const char *src, int n)
 *          int    i,n       I   substring position and width
 * return : converted number (0.0:error)
 *-----------------------------------------------------------------------------*/
-extern double str2num(const char *s, int i, int n)
+double str2num(const char *s, int i, int n)
 {
     char str[256],*p=str;
 
@@ -1597,7 +1597,7 @@ extern double str2num(const char *s, int i, int n)
 *          gtime_t *t       O   gtime_t struct
 * return : status (0:ok,0>:error)
 *-----------------------------------------------------------------------------*/
-extern int str2time(const char *s, int i, int n, gtime_t *t)
+int str2time(const char *s, int i, int n, gtime_t *t)
 {
     double ep[6];
     char str[256],*p=str;
@@ -1617,7 +1617,7 @@ extern int str2time(const char *s, int i, int n, gtime_t *t)
 * return : gtime_t struct
 * notes  : proper in 1970-2037 or 1970-2099 (64bit time_t)
 *-----------------------------------------------------------------------------*/
-extern gtime_t epoch2time(const double *ep)
+gtime_t epoch2time(const double *ep)
 {
     const int doy[]={1,32,60,91,121,152,182,213,244,274,305,335};
     gtime_t time={0};
@@ -1639,7 +1639,7 @@ extern gtime_t epoch2time(const double *ep)
 * return : none
 * notes  : proper in 1970-2037 or 1970-2099 (64bit time_t)
 *-----------------------------------------------------------------------------*/
-extern void time2epoch(gtime_t t, double *ep)
+void time2epoch(gtime_t t, double *ep)
 {
     const int mday[]={ /* # of days in a month */
         31,28,31,30,31,30,31,31,30,31,30,31,31,28,31,30,31,30,31,31,30,31,30,31,
@@ -1657,7 +1657,7 @@ extern void time2epoch(gtime_t t, double *ep)
     ep[3]=sec/3600; ep[4]=sec%3600/60; ep[5]=sec%60+t.sec;
 }
 /* same as above but output limited to n decimals for formatted output */
-extern void time2epoch_n(gtime_t t, double *ep, int n)
+void time2epoch_n(gtime_t t, double *ep, int n)
 {
     if (n<0) n=0; else if (n>12) n=12;
     if (1.0-t.sec<0.5/pow(10.0,n)) {t.time++; t.sec=0.0;};
@@ -1669,7 +1669,7 @@ extern void time2epoch_n(gtime_t t, double *ep, int n)
 *          double sec       I   time of week in gps time (s)
 * return : gtime_t struct
 *-----------------------------------------------------------------------------*/
-extern gtime_t gpst2time(int week, double sec)
+gtime_t gpst2time(int week, double sec)
 {
     gtime_t t=epoch2time(gpst0);
 
@@ -1684,7 +1684,7 @@ extern gtime_t gpst2time(int week, double sec)
 *          int    *week     IO  week number in gps time (NULL: no output)
 * return : time of week in gps time (s)
 *-----------------------------------------------------------------------------*/
-extern double time2gpst(gtime_t t, int *week)
+double time2gpst(gtime_t t, int *week)
 {
     gtime_t t0=epoch2time(gpst0);
     time_t sec=t.time-t0.time;
@@ -1699,7 +1699,7 @@ extern double time2gpst(gtime_t t, int *week)
 *          double sec       I   time of week in gst (s)
 * return : gtime_t struct
 *-----------------------------------------------------------------------------*/
-extern gtime_t gst2time(int week, double sec)
+gtime_t gst2time(int week, double sec)
 {
     gtime_t t=epoch2time(gst0);
 
@@ -1714,7 +1714,7 @@ extern gtime_t gst2time(int week, double sec)
 *          int    *week     IO  week number in gst (NULL: no output)
 * return : time of week in gst (s)
 *-----------------------------------------------------------------------------*/
-extern double time2gst(gtime_t t, int *week)
+double time2gst(gtime_t t, int *week)
 {
     gtime_t t0=epoch2time(gst0);
     time_t sec=t.time-t0.time;
@@ -1729,7 +1729,7 @@ extern double time2gst(gtime_t t, int *week)
 *          double sec       I   time of week in bdt (s)
 * return : gtime_t struct
 *-----------------------------------------------------------------------------*/
-extern gtime_t bdt2time(int week, double sec)
+gtime_t bdt2time(int week, double sec)
 {
     gtime_t t=epoch2time(bdt0);
 
@@ -1744,7 +1744,7 @@ extern gtime_t bdt2time(int week, double sec)
 *          int    *week     IO  week number in bdt (NULL: no output)
 * return : time of week in bdt (s)
 *-----------------------------------------------------------------------------*/
-extern double time2bdt(gtime_t t, int *week)
+double time2bdt(gtime_t t, int *week)
 {
     gtime_t t0=epoch2time(bdt0);
     time_t sec=t.time-t0.time;
@@ -1759,7 +1759,7 @@ extern double time2bdt(gtime_t t, int *week)
 *          double sec       I   time to add (s)
 * return : gtime_t struct (t+sec)
 *-----------------------------------------------------------------------------*/
-extern gtime_t timeadd(gtime_t t, double sec)
+gtime_t timeadd(gtime_t t, double sec)
 {
     double tt;
 
@@ -1771,7 +1771,7 @@ extern gtime_t timeadd(gtime_t t, double sec)
 * args   : gtime_t t1,t2    I   gtime_t structs
 * return : time difference (t1-t2) (s)
 *-----------------------------------------------------------------------------*/
-extern double timediff(gtime_t t1, gtime_t t2)
+double timediff(gtime_t t1, gtime_t t2)
 {
     return difftime(t1.time,t2.time)+t1.sec-t2.sec;
 }
@@ -1782,7 +1782,7 @@ extern double timediff(gtime_t t1, gtime_t t2)
 *-----------------------------------------------------------------------------*/
 static double timeoffset_=0.0;        /* time offset (s) */
 
-extern gtime_t timeget(void)
+gtime_t timeget(void)
 {
     double ep[6]={0};
 #ifdef WIN32
@@ -1820,7 +1820,7 @@ extern gtime_t timeget(void)
 *          the time offset is reflected to only timeget()
 *          not reentrant
 *-----------------------------------------------------------------------------*/
-extern void timeset(gtime_t t)
+void timeset(gtime_t t)
 {
     timeoffset_+=timediff(t,timeget());
 }
@@ -1829,7 +1829,7 @@ extern void timeset(gtime_t t)
 * args   : none
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void timereset(void)
+void timereset(void)
 {
     timeoffset_=0.0;
 }
@@ -1889,7 +1889,7 @@ static int read_leaps_usno(FILE *fp)
 *          (2) The date and time indicate the start UTC time for the UTC-GPST
 *          (3) The date and time should be descending order.
 *-----------------------------------------------------------------------------*/
-extern int read_leaps(const char *file)
+int read_leaps(const char *file)
 {
     FILE *fp;
     int i,n;
@@ -1911,7 +1911,7 @@ extern int read_leaps(const char *file)
 * return : time expressed in utc
 * notes  : ignore slight time offset under 100 ns
 *-----------------------------------------------------------------------------*/
-extern gtime_t gpst2utc(gtime_t t)
+gtime_t gpst2utc(gtime_t t)
 {
     gtime_t tu;
     int i;
@@ -1928,7 +1928,7 @@ extern gtime_t gpst2utc(gtime_t t)
 * return : time expressed in gpstime
 * notes  : ignore slight time offset under 100 ns
 *-----------------------------------------------------------------------------*/
-extern gtime_t utc2gpst(gtime_t t)
+gtime_t utc2gpst(gtime_t t)
 {
     int i;
 
@@ -1945,7 +1945,7 @@ extern gtime_t utc2gpst(gtime_t t)
 *          no leap seconds in BDT
 *          ignore slight time offset under 100 ns
 *-----------------------------------------------------------------------------*/
-extern gtime_t gpst2bdt(gtime_t t)
+gtime_t gpst2bdt(gtime_t t)
 {
     return timeadd(t,-14.0);
 }
@@ -1955,7 +1955,7 @@ extern gtime_t gpst2bdt(gtime_t t)
 * return : time expressed in gpstime
 * notes  : see gpst2bdt()
 *-----------------------------------------------------------------------------*/
-extern gtime_t bdt2gpst(gtime_t t)
+gtime_t bdt2gpst(gtime_t t)
 {
     return timeadd(t,14.0);
 }
@@ -1975,7 +1975,7 @@ static double time2sec(gtime_t time, gtime_t *day)
 *          double ut1_utc   I   UT1-UTC (s)
 * return : gmst (rad)
 *-----------------------------------------------------------------------------*/
-extern double utc2gmst(gtime_t t, double ut1_utc)
+double utc2gmst(gtime_t t, double ut1_utc)
 {
     const double ep2000[]={2000,1,1,12,0,0};
     gtime_t tut,tut0;
@@ -1997,7 +1997,7 @@ extern double utc2gmst(gtime_t t, double ut1_utc)
 *          int    n         I   number of decimals
 * return : time string
 *-----------------------------------------------------------------------------*/
-extern char *time2str(gtime_t t, char s[40], int n)
+char *time2str(gtime_t t, char s[40], int n)
 {
     double ep[6];
 
@@ -2013,7 +2013,7 @@ extern char *time2str(gtime_t t, char s[40], int n)
 * args   : gtime_t t        I   gtime_t struct
 * return : day of year (days)
 *-----------------------------------------------------------------------------*/
-extern double time2doy(gtime_t t)
+double time2doy(gtime_t t)
 {
     double ep[6];
 
@@ -2026,7 +2026,7 @@ extern double time2doy(gtime_t t)
 * args   : int   week       I   not-adjusted gps week number (0-1023)
 * return : adjusted gps week number
 *-----------------------------------------------------------------------------*/
-extern int adjgpsweek(int week)
+int adjgpsweek(int week)
 {
     int w;
     (void)time2gpst(utc2gpst(timeget()),&w);
@@ -2038,7 +2038,7 @@ extern int adjgpsweek(int week)
 * args   : none
 * return : current tick in ms
 *-----------------------------------------------------------------------------*/
-extern uint32_t tickget(void)
+uint32_t tickget(void)
 {
 #ifdef WIN32
     return (uint32_t)timeGetTime();
@@ -2066,7 +2066,7 @@ extern uint32_t tickget(void)
 * args   : int   ms         I   milliseconds to sleep (<0:no sleep)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void sleepms(int ms)
+void sleepms(int ms)
 {
 #ifdef WIN32
     if (ms<5) Sleep(1); else Sleep(ms);
@@ -2085,7 +2085,7 @@ extern void sleepms(int ms)
 *          int    ndec      I   number of decimals of second
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void deg2dms(double deg, double *dms, int ndec)
+void deg2dms(double deg, double *dms, int ndec)
 {
     double sign=deg<0.0?-1.0:1.0,a=fabs(deg);
     double unit=pow(0.1,ndec);
@@ -2107,7 +2107,7 @@ extern void deg2dms(double deg, double *dms, int ndec)
 * args   : double *dms      I   degree-minute-second {deg,min,sec}
 * return : degree
 *-----------------------------------------------------------------------------*/
-extern double dms2deg(const double *dms)
+double dms2deg(const double *dms)
 {
     double sign=dms[0]<0.0?-1.0:1.0;
     return sign*(fabs(dms[0])+dms[1]/60.0+dms[2]/3600.0);
@@ -2119,7 +2119,7 @@ extern double dms2deg(const double *dms)
 * return : none
 * notes  : WGS84, ellipsoidal height
 *-----------------------------------------------------------------------------*/
-extern void ecef2pos(const double *r, double *pos)
+void ecef2pos(const double *r, double *pos)
 {
     double e2=FE_WGS84*(2.0-FE_WGS84),r2=dot2(r,r),z,zk,v=RE_WGS84,sinp;
 
@@ -2140,7 +2140,7 @@ extern void ecef2pos(const double *r, double *pos)
 * return : none
 * notes  : WGS84, ellipsoidal height
 *-----------------------------------------------------------------------------*/
-extern void pos2ecef(const double *pos, double *r)
+void pos2ecef(const double *pos, double *r)
 {
     double sinp=sin(pos[0]),cosp=cos(pos[0]),sinl=sin(pos[1]),cosl=cos(pos[1]);
     double e2=FE_WGS84*(2.0-FE_WGS84),v=RE_WGS84/sqrt(1.0-e2*sinp*sinp);
@@ -2156,7 +2156,7 @@ extern void pos2ecef(const double *pos, double *r)
 * return : none
 * notes  : matrix stored by column-major order (fortran convention)
 *-----------------------------------------------------------------------------*/
-extern void xyz2enu(const double *pos, double *E)
+void xyz2enu(const double *pos, double *E)
 {
     double sinp=sin(pos[0]),cosp=cos(pos[0]),sinl=sin(pos[1]),cosl=cos(pos[1]);
 
@@ -2171,7 +2171,7 @@ extern void xyz2enu(const double *pos, double *E)
 *          double *e        O   vector in local tangential coordinate {e,n,u}
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void ecef2enu(const double *pos, const double *r, double *e)
+void ecef2enu(const double *pos, const double *r, double *e)
 {
     double E[9];
 
@@ -2185,7 +2185,7 @@ extern void ecef2enu(const double *pos, const double *r, double *e)
 *          double *r        O   vector in ecef coordinate {x,y,z}
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void enu2ecef(const double *pos, const double *e, double *r)
+void enu2ecef(const double *pos, const double *e, double *r)
 {
     double E[9];
 
@@ -2199,7 +2199,7 @@ extern void enu2ecef(const double *pos, const double *e, double *r)
 *          double *Q        O   covariance in local tangential coordinate
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void covenu(const double *pos, const double *P, double *Q)
+void covenu(const double *pos, const double *P, double *Q)
 {
     double E[9],EP[9];
 
@@ -2214,7 +2214,7 @@ extern void covenu(const double *pos, const double *P, double *Q)
 *          double *P        O   covariance in xyz-ecef coordinate
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void covecef(const double *pos, const double *Q, double *P)
+void covecef(const double *pos, const double *Q, double *P)
 {
     double E[9],EQ[9];
 
@@ -2394,7 +2394,7 @@ static void nut_iau1980(double t, const double *f, double *dpsi, double *deps)
 * note   : see ref [3] chap 5
 *          not thread-safe
 *-----------------------------------------------------------------------------*/
-extern void eci2ecef(gtime_t tutc, const double *erpv, double *U, double *gmst)
+void eci2ecef(gtime_t tutc, const double *erpv, double *U, double *gmst)
 {
     const double ep2000[]={2000,1,1,12,0,0};
     static THREADLOCAL gtime_t tutc_ = {0, 0};
@@ -2614,7 +2614,7 @@ static int readantex(const char *file, pcvs_t *pcvs)
 *          see reference [3]
 *          only support non-azimuth-depedent parameters
 *-----------------------------------------------------------------------------*/
-extern int readpcv(const char *file, pcvs_t *pcvs)
+int readpcv(const char *file, pcvs_t *pcvs)
 {
     pcv_t *pcv;
     char *ext;
@@ -2646,7 +2646,7 @@ extern int readpcv(const char *file, pcvs_t *pcvs)
 *          pcvs_t *pcvs       IO  antenna parameters
 * return : antenna parameter (NULL: no antenna)
 *-----------------------------------------------------------------------------*/
-extern pcv_t *searchpcv(int sat, const char *type, gtime_t time,
+pcv_t *searchpcv(int sat, const char *type, gtime_t time,
                         const pcvs_t *pcvs)
 {
     pcv_t *pcv;
@@ -2696,7 +2696,7 @@ extern pcv_t *searchpcv(int sat, const char *type, gtime_t time,
 *                               (all 0 if search error)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void readpos(const char *file, const char *rcv, double *pos)
+void readpos(const char *file, const char *rcv, double *pos)
 {
     static double poss[2048][3];
     static char stas[2048][16];
@@ -2753,7 +2753,7 @@ static int readblqrecord(FILE *fp, double odisp[2][11][3])
 *          double odisp[2][11][3] O   ocean tide loading parameters
 * return : status (1:ok,0:file open error)
 *-----------------------------------------------------------------------------*/
-extern int readblq(const char *file, const char *sta, double odisp[2][11][3])
+int readblq(const char *file, const char *sta, double odisp[2][11][3])
 {
     FILE *fp;
     char buff[256],staname[17]="",name[17],*p;
@@ -2789,7 +2789,7 @@ extern int readblq(const char *file, const char *sta, double odisp[2][11][3])
 *          erp_t  *erp        O   earth rotation parameters
 * return : number of files read.
 *-----------------------------------------------------------------------------*/
-extern int readerp(const char *file, erp_t *erp) {
+int readerp(const char *file, erp_t *erp) {
   trace(3, "readerp: file=%s\n", file);
 
   char *efiles[MAXEXFILE];
@@ -2910,7 +2910,7 @@ extern int readerp(const char *file, erp_t *erp) {
 *          double *erpv       O   erp values {xp,yp,ut1_utc,lod} (rad,rad,s,s/d)
 * return : status (1:ok,0:error)
 *-----------------------------------------------------------------------------*/
-extern int geterp(const erp_t *erp, gtime_t time, double *erpv)
+int geterp(const erp_t *erp, gtime_t time, double *erpv)
 {
     const double ep[]={2000,1,1,12,0,0};
     double mjd,day,a;
@@ -3084,7 +3084,7 @@ static void uniqseph(nav_t *nav)
 * args   : nav_t *nav    IO     navigation data
 * return : number of epochs
 *-----------------------------------------------------------------------------*/
-extern void uniqnav(nav_t *nav)
+void uniqnav(nav_t *nav)
 {
     trace(3,"uniqnav: neph=%d ngeph=%d nseph=%d\n",nav->n,nav->ng,nav->ns);
 
@@ -3107,7 +3107,7 @@ static int cmpobs(const void *p1, const void *p2)
 * args   : obs_t *obs    IO     observation data
 * return : number of epochs
 *-----------------------------------------------------------------------------*/
-extern int sortobs(obs_t *obs)
+int sortobs(obs_t *obs)
 {
     int i,j,n;
 
@@ -3142,7 +3142,7 @@ extern int sortobs(obs_t *obs)
 *          double  tint  I      time interval (s) (0.0:no screen by tint)
 * return : 1:on condition, 0:not on condition
 *-----------------------------------------------------------------------------*/
-extern int screent(gtime_t time, gtime_t ts, gtime_t te, double tint)
+int screent(gtime_t time, gtime_t ts, gtime_t te, double tint)
 {
     return (tint<=0.0||fmod(time2gpst(time,NULL)+DTTOL,tint)<=DTTOL*2.0)&&
            (ts.time==0||timediff(time,ts)>=-DTTOL)&&
@@ -3154,7 +3154,7 @@ extern int screent(gtime_t time, gtime_t ts, gtime_t te, double tint)
 *          nav_t   nav   O/I    navigation data
 * return : status (1:ok,0:no file)
 *-----------------------------------------------------------------------------*/
-extern int readnav(const char *file, nav_t *nav)
+int readnav(const char *file, nav_t *nav)
 {
     FILE *fp;
     eph_t eph0={0};
@@ -3221,7 +3221,7 @@ extern int readnav(const char *file, nav_t *nav)
     fclose(fp);
     return 1;
 }
-extern int savenav(const char *file, const nav_t *nav)
+int savenav(const char *file, const nav_t *nav)
 {
     FILE *fp;
     int i;
@@ -3276,7 +3276,7 @@ extern int savenav(const char *file, const nav_t *nav)
 * args   : obs_t *obs    IO     observation data
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void freeobs(obs_t *obs)
+void freeobs(obs_t *obs)
 {
     free(obs->data); obs->data=NULL; obs->n=obs->nmax=0;
 }
@@ -3290,7 +3290,7 @@ extern void freeobs(obs_t *obs)
 *                                0x40: tec data)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void freenav(nav_t *nav, int opt)
+void freenav(nav_t *nav, int opt)
 {
     if (opt&0x01) {free(nav->eph ); nav->eph =NULL; nav->n =nav->nmax =0;}
     if (opt&0x02) {free(nav->geph); nav->geph=NULL; nav->ng=nav->ngmax=0;}
@@ -3306,7 +3306,7 @@ extern void freenav(nav_t *nav, int opt)
 * args   : char   *cmd      I   command line
 * return : execution status (0:ok,0>:error)
 *-----------------------------------------------------------------------------*/
-extern int execcmd(const char *cmd)
+int execcmd(const char *cmd)
 {
 #ifdef WIN32
     PROCESS_INFORMATION info;
@@ -3339,7 +3339,7 @@ extern int execcmd(const char *cmd)
 * return : number of expanded file paths
 * notes  : the order of expanded files is alphabetical order
 *-----------------------------------------------------------------------------*/
-extern int expath(const char *path, char *paths[], int nmax)
+int expath(const char *path, char *paths[], int nmax)
 {
     int i,j,n=0;
     char tmp[1024];
@@ -3450,7 +3450,7 @@ static int mkdir_r(const char *dir)
 * return : none
 * notes  : recursively.
 *-----------------------------------------------------------------------------*/
-extern void createdir(const char *path)
+void createdir(const char *path)
 {
     char buff[1024],*p;
 
@@ -3507,7 +3507,7 @@ static int repstr(char *str, const char *pat, const char *rep)
 *              %r -> rrrr : rover id
 *              %b -> bbbb : base station id
 *-----------------------------------------------------------------------------*/
-extern int reppath(const char *path, char *rpath, gtime_t time, const char *rov,
+int reppath(const char *path, char *rpath, gtime_t time, const char *rov,
                    const char *base)
 {
     double ep[6],ep0[6]={2000,1,1,0,0,0};
@@ -3563,7 +3563,7 @@ extern int reppath(const char *path, char *rpath, gtime_t time, const char *rov,
 * notes  : see reppath() for replacements of keywords.
 *          minimum interval of time replaced is 900s.
 *-----------------------------------------------------------------------------*/
-extern int reppaths(const char *path, char *rpath[], int nmax, gtime_t ts,
+int reppaths(const char *path, char *rpath[], int nmax, gtime_t ts,
                     gtime_t te, const char *rov, const char *base)
 {
     gtime_t time;
@@ -3596,7 +3596,7 @@ extern int reppaths(const char *path, char *rpath[], int nmax, gtime_t ts,
 * return : geometric distance (m) (0>:error/no satellite position)
 * notes  : distance includes sagnac effect correction
 *-----------------------------------------------------------------------------*/
-extern double geodist(const double *rs, const double *rr, double *e)
+double geodist(const double *rs, const double *rr, double *e)
 {
     double r;
     int i;
@@ -3615,7 +3615,7 @@ extern double geodist(const double *rs, const double *rr, double *e)
 *                               (0.0<=azel[0]<2*pi,-pi/2<=azel[1]<=pi/2)
 * return : elevation angle (rad)
 *-----------------------------------------------------------------------------*/
-extern double satazel(const double *pos, const double *e, double *azel)
+double satazel(const double *pos, const double *e, double *azel)
 {
     double az=0.0,el=PI/2.0,enu[3];
 
@@ -3639,7 +3639,7 @@ extern double satazel(const double *pos, const double *e, double *azel)
 *-----------------------------------------------------------------------------*/
 #define SQRT(x)     ((x)<0.0||(x)!=(x)?0.0:sqrt(x))
 
-extern void dops(int ns, const double *azel, double elmin, double *dop)
+void dops(int ns, const double *azel, double elmin, double *dop)
 {
     double H[4*MAXSAT],Q[16],cosel,sinel;
     int i,n;
@@ -3672,7 +3672,7 @@ extern void dops(int ns, const double *azel, double elmin, double *dop)
 *          double *azel     I   azimuth/elevation angle {az,el} (rad)
 * return : ionospheric delay (L1) (m)
 *-----------------------------------------------------------------------------*/
-extern double ionmodel(gtime_t t, const double *ion, const double *pos,
+double ionmodel(gtime_t t, const double *ion, const double *pos,
                        const double *azel)
 {
     const double ion_default[]={ /* 2004/1/1 */
@@ -3719,7 +3719,7 @@ extern double ionmodel(gtime_t t, const double *ion, const double *pos,
 *          double *azel     I   azimuth/elevation angle {az,el} (rad)
 * return : ionospheric mapping function
 *-----------------------------------------------------------------------------*/
-extern double ionmapf(const double *pos, const double *azel)
+double ionmapf(const double *pos, const double *azel)
 {
     if (pos[2]>=HION) return 1.0;
     return 1.0/cos(asin((RE_WGS84+pos[2])/(RE_WGS84+HION)*sin(PI/2.0-azel[1])));
@@ -3735,7 +3735,7 @@ extern double ionmapf(const double *pos, const double *azel)
 * notes  : see ref [2], only valid on the earth surface
 *          fixing bug on ref [2] A.4.4.10.1 A-22,23
 *-----------------------------------------------------------------------------*/
-extern double ionppp(const double *pos, const double *azel, double re,
+double ionppp(const double *pos, const double *azel, double re,
                      double hion, double *posp)
 {
     double cosaz,r,rp,ap,sinap,tanap;
@@ -3762,7 +3762,7 @@ extern double ionppp(const double *pos, const double *azel, double re,
     return 1.0/sqrt(1.0-rp*rp);
 }
 /* select iono-free linear combination (L1/L2 or L1/L5) ----------------------*/
-extern int seliflc(int optnf,int sys)
+int seliflc(int optnf,int sys)
 {
     /* use L1/L5 for GPS,GAL,BDS if L5 is enabled */
     return((optnf==2||sys==SYS_GLO)?1:2);
@@ -3775,7 +3775,7 @@ extern int seliflc(int optnf,int sys)
 *          double humi      I   relative humidity
 * return : tropospheric delay (m)
 *-----------------------------------------------------------------------------*/
-extern double tropmodel(gtime_t time, const double *pos, const double *azel,
+double tropmodel(gtime_t time, const double *pos, const double *azel,
                         double humi)
 {
     (void)time;
@@ -3868,7 +3868,7 @@ static double nmf(gtime_t time, const double pos[], const double azel[],
 *          paper is obtained from:
 *          ftp://web.haystack.edu/pub/aen/nmf/NMF_JGR.pdf
 *-----------------------------------------------------------------------------*/
-extern double tropmapf(gtime_t time, const double pos[], const double azel[],
+double tropmapf(gtime_t time, const double pos[], const double azel[],
                        double *mapfw)
 {
 #ifdef IERS_MODEL
@@ -3916,7 +3916,7 @@ static double interpvar(double ang, const double *var)
 * return : none
 * notes  : current version does not support azimuth dependent terms
 *-----------------------------------------------------------------------------*/
-extern void antmodel(const pcv_t *pcv, const double *del, const double *azel,
+void antmodel(const pcv_t *pcv, const double *del, const double *azel,
                      int opt, double *dant)
 {
     double e[3],off[3],cosel=cos(azel[1]);
@@ -3942,7 +3942,7 @@ extern void antmodel(const pcv_t *pcv, const double *del, const double *azel,
 *          double *dant     O   range offsets for each frequency (m)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void antmodel_s(const pcv_t *pcv, double nadir, double *dant)
+void antmodel_s(const pcv_t *pcv, double nadir, double *dant)
 {
     int i;
 
@@ -4079,7 +4079,7 @@ static void moonpos_eci(gtime_t tutc, const double *erpv, double *rmoon) {
  *          double *gmst     O   GMST (rad)
  * Return : none
  *----------------------------------------------------------------------------*/
-extern void sunmoonpos(gtime_t tutc, const double *erpv, double *rsun, double *rmoon,
+void sunmoonpos(gtime_t tutc, const double *erpv, double *rsun, double *rmoon,
                        double *gmst) {
   char tstr[40];
   trace(4, "sunmoonpos: tutc=%s\n", time2str(tutc, tstr, 3));
@@ -4111,7 +4111,7 @@ extern void sunmoonpos(gtime_t tutc, const double *erpv, double *rsun, double *r
 * note   : creates uncompressed file in temporary directory
 *          gzip, tar and crx2rnx commands have to be installed in commands path
 *-----------------------------------------------------------------------------*/
-extern int rtk_uncompress(const char *file, char *uncfile)
+int rtk_uncompress(const char *file, char *uncfile)
 {
     int stat=0;
     char *p,cmd[64+2048]="",tmpfile[1024]="",buff[1024],*fname,*dir="";
@@ -4182,7 +4182,7 @@ extern int rtk_uncompress(const char *file, char *uncfile)
     return stat;
 }
 /* station position from file ------------------------------------------------*/
-extern int getstapos(const char *file, const char *name, double *r)
+int getstapos(const char *file, const char *name, double *r)
 {
     trace(3, "getstapos: file=%s name=%s\n", file, name);
 
@@ -4294,8 +4294,8 @@ extern int getstapos(const char *file, const char *name, double *r)
 }
 /* dummy application functions for shared library ----------------------------*/
 #if defined(WIN_DLL) || defined(DLL)
-extern int showmsg(const char *format,...) {return 0;}
-extern void settspan(gtime_t ts, gtime_t te) {}
-extern void settime(gtime_t time) {}
+int showmsg(const char *format,...) {return 0;}
+void settspan(gtime_t ts, gtime_t te) {}
+void settime(gtime_t time) {}
 #endif
 

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -385,7 +385,7 @@ static void fatalerr(const char *format, ...)
 * return : none
 * notes  : if malloc() failed in return : none
 *-----------------------------------------------------------------------------*/
-extern void add_fatal(fatalfunc_t *func)
+void add_fatal(fatalfunc_t *func)
 {
     fatalfunc=func;
 }
@@ -395,7 +395,7 @@ extern void add_fatal(fatalfunc_t *func)
 *          int    prn       I   satellite prn/slot number
 * return : satellite number (0:error)
 *-----------------------------------------------------------------------------*/
-extern int satno(int sys, int prn)
+int satno(int sys, int prn)
 {
     if (prn<=0) return 0;
     switch (sys) {
@@ -434,7 +434,7 @@ extern int satno(int sys, int prn)
 *          int    *prn      IO  satellite prn/slot number (NULL: no output)
 * return : satellite system (SYS_GPS,SYS_GLO,...)
 *-----------------------------------------------------------------------------*/
-extern int satsys(int sat, int *prn)
+int satsys(int sat, int *prn)
 {
     int sys=SYS_NONE;
     if (sat<=0||MAXSAT<sat) sat=0;
@@ -472,7 +472,7 @@ extern int satsys(int sat, int *prn)
 * return : satellite number (0: error)
 * notes  : 120-142 and 193-199 are also recognized as sbas and qzss
 *-----------------------------------------------------------------------------*/
-extern int satid2no(const char *id)
+int satid2no(const char *id)
 {
     int sys,prn;
     char code;
@@ -505,7 +505,7 @@ extern int satid2no(const char *id)
 *          char   *id       O   satellite id (Gnn,Rnn,Enn,Jnn,Cnn,Inn or nnn)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void satno2id(int sat, char id[8])
+void satno2id(int sat, char id[8])
 {
     int prn;
     switch (satsys(sat,&prn)) {
@@ -528,7 +528,7 @@ extern void satno2id(int sat, char id[8])
 *          prcopt_t *opt    I   processing options (NULL: not used)
 * return : status (1:excluded,0:not excluded)
 *-----------------------------------------------------------------------------*/
-extern int satexclude(int sat, double var, int svh, const prcopt_t *opt)
+int satexclude(int sat, double var, int svh, const prcopt_t *opt)
 {
     int sys=satsys(sat,NULL);
 
@@ -564,7 +564,7 @@ extern int satexclude(int sat, double var, int svh, const prcopt_t *opt)
 *          snrmask_t *mask  I   SNR mask
 * return : status (1:masked,0:unmasked)
 *-----------------------------------------------------------------------------*/
-extern int testsnr(int base, int idx, double el, double snr,
+int testsnr(int base, int idx, double el, double snr,
                    const snrmask_t *mask)
 {
     double minsnr,a;
@@ -586,7 +586,7 @@ extern int testsnr(int base, int idx, double el, double snr,
 * return : obs code (CODE_???)
 * notes  : obs codes are based on RINEX 3.04
 *-----------------------------------------------------------------------------*/
-extern uint8_t obs2code(const char *obs)
+uint8_t obs2code(const char *obs)
 {
     int i;
 
@@ -602,7 +602,7 @@ extern uint8_t obs2code(const char *obs)
 * return : obs code string ("1C","1P","1P",...)
 * notes  : obs codes are based on RINEX 3.04
 *-----------------------------------------------------------------------------*/
-extern const char *code2obs(uint8_t code)
+const char *code2obs(uint8_t code)
 {
     if (code<=CODE_NONE||MAXCODE<code) return "";
     return obscodes[code];
@@ -719,7 +719,7 @@ static int code2freq_IRN(uint8_t code, double *freq)
 *            BDS       B1    B2b   B2a   B3   B1C   B2ab
 *            NavIC     L5     S    L1     -     -     -
 *-----------------------------------------------------------------------------*/
-extern int code2idx(int sys, uint8_t code)
+int code2idx(int sys, uint8_t code)
 {
     double freq;
 
@@ -741,7 +741,7 @@ extern int code2idx(int sys, uint8_t code)
 *          int    fcn       I   frequency channel number for GLONASS
 * return : carrier frequency (Hz) (0.0: error)
 *-----------------------------------------------------------------------------*/
-extern double code2freq(int sys, uint8_t code, int fcn)
+double code2freq(int sys, uint8_t code, int fcn)
 {
     double freq=0.0;
 
@@ -763,7 +763,7 @@ extern double code2freq(int sys, uint8_t code, int fcn)
 *          nav_t  *nav_t    I   navigation data for GLONASS (NULL: not used)
 * return : carrier frequency (Hz) (0.0: error)
 *-----------------------------------------------------------------------------*/
-extern double sat2freq(int sat, uint8_t code, const nav_t *nav)
+double sat2freq(int sat, uint8_t code, const nav_t *nav)
 {
     int i,fcn=-8,sys,prn;
 
@@ -791,7 +791,7 @@ extern double sat2freq(int sat, uint8_t code, const nav_t *nav)
 *                               (higher priority precedes lower)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void setcodepri(int sys, int idx, const char *pri)
+void setcodepri(int sys, int idx, const char *pri)
 {
     trace(3,"setcodepri:sys=%d idx=%d pri=%s\n",sys,idx,pri);
 
@@ -811,7 +811,7 @@ extern void setcodepri(int sys, int idx, const char *pri)
 *          char   *opt      I   code options (NULL:no option)
 * return : priority (15:highest-1:lowest,0:error)
 *-----------------------------------------------------------------------------*/
-extern int getcodepri(int sys, uint8_t code, const char *opt)
+int getcodepri(int sys, uint8_t code, const char *opt)
 {
     const char *p,*optstr, *obs;
     char str[8]="";
@@ -845,14 +845,14 @@ extern int getcodepri(int sys, uint8_t code, const char *opt)
 *          int    len       I   bit length (bits) (len<=32)
 * return : extracted unsigned/signed bits
 *-----------------------------------------------------------------------------*/
-extern uint32_t getbitu(const uint8_t *buff, int pos, int len)
+uint32_t getbitu(const uint8_t *buff, int pos, int len)
 {
     uint32_t bits=0;
     int i;
     for (i=pos;i<pos+len;i++) bits=(bits<<1)+((buff[i/8]>>(7-i%8))&1u);
     return bits;
 }
-extern int32_t getbits(const uint8_t *buff, int pos, int len)
+int32_t getbits(const uint8_t *buff, int pos, int len)
 {
     uint32_t bits=getbitu(buff,pos,len);
     if (len<=0||32<=len||!(bits&(1u<<(len-1)))) return (int32_t)bits;
@@ -866,7 +866,7 @@ extern int32_t getbits(const uint8_t *buff, int pos, int len)
 *          [u]int32_t data  I   unsigned/signed data
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void setbitu(uint8_t *buff, int pos, int len, uint32_t data)
+void setbitu(uint8_t *buff, int pos, int len, uint32_t data)
 {
     uint32_t mask=1u<<(len-1);
     int i;
@@ -875,7 +875,7 @@ extern void setbitu(uint8_t *buff, int pos, int len, uint32_t data)
         if (data&mask) buff[i/8]|=1u<<(7-i%8); else buff[i/8]&=~(1u<<(7-i%8));
     }
 }
-extern void setbits(uint8_t *buff, int pos, int len, int32_t data)
+void setbits(uint8_t *buff, int pos, int len, int32_t data)
 {
     if (data<0) data|=1<<(len-1); else data&=~(1<<(len-1)); /* set sign bit */
     setbitu(buff,pos,len,(uint32_t)data);
@@ -887,7 +887,7 @@ extern void setbits(uint8_t *buff, int pos, int len, int32_t data)
 * return : crc-32 parity
 * notes  : see NovAtel OEMV firmware manual 1.7 32-bit CRC
 *-----------------------------------------------------------------------------*/
-extern uint32_t rtk_crc32(const uint8_t *buff, int len)
+uint32_t rtk_crc32(const uint8_t *buff, int len)
 {
     uint32_t crc=0;
     int i,j;
@@ -909,7 +909,7 @@ extern uint32_t rtk_crc32(const uint8_t *buff, int len)
 * return : crc-24Q parity
 * notes  : see reference [2] A.4.3.3 Parity
 *-----------------------------------------------------------------------------*/
-extern uint32_t rtk_crc24q(const uint8_t *buff, int len)
+uint32_t rtk_crc24q(const uint8_t *buff, int len)
 {
     uint32_t crc=0;
     int i;
@@ -926,7 +926,7 @@ extern uint32_t rtk_crc24q(const uint8_t *buff, int len)
 * return : crc-16 parity
 * notes  : see reference [10] A.3.
 *-----------------------------------------------------------------------------*/
-extern uint16_t rtk_crc16(const uint8_t *buff, int len)
+uint16_t rtk_crc16(const uint8_t *buff, int len)
 {
     uint16_t crc=0;
     int i;
@@ -947,7 +947,7 @@ extern uint16_t rtk_crc16(const uint8_t *buff, int len)
 * return : status (1:ok,0:parity error)
 * notes  : see reference [1] 20.3.5.2 user parity algorithm
 *-----------------------------------------------------------------------------*/
-extern int decode_word(uint32_t word, uint8_t *data)
+int decode_word(uint32_t word, uint8_t *data)
 {
     const uint32_t hamming[]={
         0xBB1F3480,0x5D8F9A40,0xAEC7CD00,0x5763E680,0x6BB1F340,0x8B7A89C0
@@ -973,7 +973,7 @@ extern int decode_word(uint32_t word, uint8_t *data)
 * args   : int    n,m       I   number of rows and columns of matrix
 * return : matrix pointer (if n<=0 or m<=0, return NULL)
 *-----------------------------------------------------------------------------*/
-extern double *mat(int n, int m)
+double *mat(int n, int m)
 {
     double *p;
 
@@ -988,7 +988,7 @@ extern double *mat(int n, int m)
 * args   : int    n,m       I   number of rows and columns of matrix
 * return : matrix pointer (if n<=0 or m<=0, return NULL)
 *-----------------------------------------------------------------------------*/
-extern int *imat(int n, int m)
+int *imat(int n, int m)
 {
     int *p;
 
@@ -1003,7 +1003,7 @@ extern int *imat(int n, int m)
 * args   : int    n,m       I   number of rows and columns of matrix
 * return : matrix pointer (if n<=0 or m<=0, return NULL)
 *-----------------------------------------------------------------------------*/
-extern double *zeros(int n, int m)
+double *zeros(int n, int m)
 {
     double *p;
 
@@ -1022,7 +1022,7 @@ extern double *zeros(int n, int m)
 * args   : int    n         I   number of rows and columns of matrix
 * return : matrix pointer (if n<=0, return NULL)
 *-----------------------------------------------------------------------------*/
-extern double *eye(int n)
+double *eye(int n)
 {
     double *p;
     int i;
@@ -1036,14 +1036,14 @@ extern double *eye(int n)
  * args   : double *a,*b     I   vectors a and b
  * return : a'*b
  *-----------------------------------------------------------------------------*/
-extern double dot2(const double* a, const double* b) { return a[0] * b[0] + a[1] * b[1]; }
+double dot2(const double* a, const double* b) { return a[0] * b[0] + a[1] * b[1]; }
 
 /* dot product -----------------------------------------------------------------
  * inner product of vectors of size 3
  * args   : double *a,*b     I   vectors a and b
  * return : a'*b
  *-----------------------------------------------------------------------------*/
-extern double dot3(const double* a, const double* b)
+double dot3(const double* a, const double* b)
 {
   return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
 }
@@ -1054,7 +1054,7 @@ extern double dot3(const double* a, const double* b)
 *          int    n         I   size of vector a,b
 * return : a'*b
 *-----------------------------------------------------------------------------*/
-extern double dot(const double *a, const double *b, int n)
+double dot(const double *a, const double *b, int n)
 {
     double c=0.0;
 
@@ -1068,7 +1068,7 @@ extern double dot(const double *a, const double *b, int n)
 *          int    n         I   size of vector a
 * return : || a ||
 *-----------------------------------------------------------------------------*/
-extern double norm(const double *a, int n)
+double norm(const double *a, int n)
 {
     return sqrt(dot(a,a,n));
 }
@@ -1078,7 +1078,7 @@ extern double norm(const double *a, int n)
 *          double *c        O   outer product (a x b) (3 x 1)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void cross3(const double *a, const double *b, double *c)
+void cross3(const double *a, const double *b, double *c)
 {
     c[0]=a[1]*b[2]-a[2]*b[1];
     c[1]=a[2]*b[0]-a[0]*b[2];
@@ -1090,7 +1090,7 @@ extern void cross3(const double *a, const double *b, double *c)
 *          double *b        O   normalized vector (3 x 1) || b || = 1
 * return : status (1:ok,0:error)
 *-----------------------------------------------------------------------------*/
-extern int normv3(const double *a, double *b)
+int normv3(const double *a, double *b)
 {
     double r;
     if ((r=norm(a,3))<=0.0) return 0;
@@ -1106,7 +1106,7 @@ extern int normv3(const double *a, double *b)
 *          int    n,m       I   number of rows and columns of matrix
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void matcpy(double *A, const double *B, int n, int m)
+void matcpy(double *A, const double *B, int n, int m)
 {
     memcpy(A,B,sizeof(double)*n*m);
 }
@@ -1122,7 +1122,7 @@ extern void matcpy(double *A, const double *B, int n, int m)
 *          double *C        O matrix C (n x k)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void matmul(const char *tr, int n, int k, int m,
+void matmul(const char *tr, int n, int k, int m,
                    const double *A, const double *B, double *C)
 {
     int lda=tr[0]=='T'?m:n,ldb=tr[1]=='T'?k:m;
@@ -1134,7 +1134,7 @@ extern void matmul(const char *tr, int n, int k, int m,
 /* multiply matrix (wrapper of blas dgemm) -------------------------------------
 * multiply matrix by matrix (C=C+A*B)
 *-----------------------------------------------------------------------------*/
-extern void matmulp(const char *tr, int n, int k, int m,
+void matmulp(const char *tr, int n, int k, int m,
                     const double *A, const double *B, double *C)
 {
     int lda=tr[0]=='T'?m:n,ldb=tr[1]=='T'?k:m;
@@ -1146,7 +1146,7 @@ extern void matmulp(const char *tr, int n, int k, int m,
 /* multiply matrix (wrapper of blas dgemm) -------------------------------------
 * multiply matrix by matrix (C=C-A*B)
 *-----------------------------------------------------------------------------*/
-extern void matmulm(const char *tr, int n, int k, int m,
+void matmulm(const char *tr, int n, int k, int m,
                     const double *A, const double *B, double *C)
 {
     int lda=tr[0]=='T'?m:n,ldb=tr[1]=='T'?k:m;
@@ -1161,7 +1161,7 @@ extern void matmulm(const char *tr, int n, int k, int m,
 *          int    n         I   size of matrix A
 * return : status (0:ok,0>:error)
 *-----------------------------------------------------------------------------*/
-extern int matinv(double *A, int n)
+int matinv(double *A, int n)
 {
     double *work;
     int info,lwork=n*16,*ipiv=imat(n,1);
@@ -1183,7 +1183,7 @@ extern int matinv(double *A, int n)
 * notes  : matrix stored by column-major order (fortran convention)
 *          X can be same as Y
 *-----------------------------------------------------------------------------*/
-extern int solve(const char *tr, const double *A, const double *Y, int n,
+int solve(const char *tr, const double *A, const double *Y, int n,
                  int m, double *X)
 {
     double *B=mat(n,n);
@@ -1200,7 +1200,7 @@ extern int solve(const char *tr, const double *A, const double *Y, int n,
 #else /* without LAPACK/BLAS or MKL */
 
 /* multiply matrix -----------------------------------------------------------*/
-extern void matmul(const char *tr, int n, int k, int m,
+void matmul(const char *tr, int n, int k, int m,
                    const double *A, const double *B, double *C)
 {
     int f=(tr[0]!='N')*2+(tr[1]!='N');
@@ -1244,7 +1244,7 @@ extern void matmul(const char *tr, int n, int k, int m,
           break;
     }
 }
-extern void matmulp(const char *tr, int n, int k, int m,
+void matmulp(const char *tr, int n, int k, int m,
                     const double *A, const double *B, double *C)
 {
     int f=(tr[0]!='N')*2+(tr[1]!='N');
@@ -1288,7 +1288,7 @@ extern void matmulp(const char *tr, int n, int k, int m,
           break;
     }
 }
-extern void matmulm(const char *tr, int n, int k, int m,
+void matmulm(const char *tr, int n, int k, int m,
                     const double *A, const double *B, double *C)
 {
     int f=(tr[0]!='N')*2+(tr[1]!='N');
@@ -1383,7 +1383,7 @@ static void lubksb(const double *A, int n, const int *indx, double *b)
     }
 }
 /* inverse of matrix ---------------------------------------------------------*/
-extern int matinv(double *A, int n)
+int matinv(double *A, int n)
 {
     double d,*B;
     int i,j,*indx;
@@ -1399,7 +1399,7 @@ extern int matinv(double *A, int n)
     return 0;
 }
 /* solve linear equation -----------------------------------------------------*/
-extern int solve(const char *tr, const double *A, const double *Y, int n,
+int solve(const char *tr, const double *A, const double *Y, int n,
                  int m, double *X)
 {
     double *B=mat(n,n);
@@ -1425,7 +1425,7 @@ extern int solve(const char *tr, const double *A, const double *Y, int n,
 * notes  : for weighted least square, replace A and y by A*w and w*y (w=W^(1/2))
 *          matrix stored by column-major order (fortran convention)
 *-----------------------------------------------------------------------------*/
-extern int lsq(const double *A, const double *y, int n, int m, double *x,
+int lsq(const double *A, const double *y, int n, int m, double *x,
                double *Q)
 {
     double *Ay;
@@ -1476,7 +1476,7 @@ static int filter_(const double *x, const double *P, const double *H,
     free(F); free(Q); free(K); free(I);
     return info;
 }
-extern int filter(double *x, double *P, const double *H, const double *v,
+int filter(double *x, double *P, const double *H, const double *v,
                   const double *R, int n, int m)
 {
     double *x_,*xp_,*P_,*Pp_,*H_;
@@ -1517,7 +1517,7 @@ extern int filter(double *x, double *P, const double *H, const double *v,
 * notes  : see reference [4] 5.2
 *          matrix stored by column-major order (fortran convention)
 *-----------------------------------------------------------------------------*/
-extern int smoother(const double *xf, const double *Qf, const double *xb,
+int smoother(const double *xf, const double *Qf, const double *xb,
                     const double *Qb, int n, double *xs, double *Qs)
 {
     double *invQf=mat(n,n),*invQb=mat(n,n),*xx=mat(n,1);
@@ -1545,7 +1545,7 @@ extern int smoother(const double *xf, const double *Qf, const double *xb,
 * return : none
 * notes  : matrix stored by column-major order (fortran convention)
 *-----------------------------------------------------------------------------*/
-extern void matfprint(const double A[], int n, int m, int p, int q, FILE *fp)
+void matfprint(const double A[], int n, int m, int p, int q, FILE *fp)
 {
     int i,j;
 
@@ -1554,12 +1554,12 @@ extern void matfprint(const double A[], int n, int m, int p, int q, FILE *fp)
         fprintf(fp,"\n");
     }
 }
-extern void matprint(const double A[], int n, int m, int p, int q)
+void matprint(const double A[], int n, int m, int p, int q)
 {
     matfprint(A,n,m,p,q,stdout);
 }
 /* set string without tail space ---------------------------------------------*/
-extern void setstr(char *dst, const char *src, int n)
+void setstr(char *dst, const char *src, int n)
 {
     char *p=dst;
     const char *q=src;
@@ -1573,7 +1573,7 @@ extern void setstr(char *dst, const char *src, int n)
 *          int    i,n       I   substring position and width
 * return : converted number (0.0:error)
 *-----------------------------------------------------------------------------*/
-extern double str2num(const char *s, int i, int n)
+double str2num(const char *s, int i, int n)
 {
     char str[256],*p=str;
 
@@ -1597,7 +1597,7 @@ extern double str2num(const char *s, int i, int n)
 *          gtime_t *t       O   gtime_t struct
 * return : status (0:ok,0>:error)
 *-----------------------------------------------------------------------------*/
-extern int str2time(const char *s, size_t i, size_t n, gtime_t *t)
+int str2time(const char *s, size_t i, size_t n, gtime_t *t)
 {
     char str[256];
 
@@ -1617,7 +1617,7 @@ extern int str2time(const char *s, size_t i, size_t n, gtime_t *t)
 * return : gtime_t struct
 * notes  : proper in 1970-2037 or 1970-2099 (64bit time_t)
 *-----------------------------------------------------------------------------*/
-extern gtime_t epoch2time(const double *ep)
+gtime_t epoch2time(const double *ep)
 {
     const int doy[]={1,32,60,91,121,152,182,213,244,274,305,335};
     gtime_t time={0};
@@ -1639,7 +1639,7 @@ extern gtime_t epoch2time(const double *ep)
 * return : none
 * notes  : proper in 1970-2037 or 1970-2099 (64bit time_t)
 *-----------------------------------------------------------------------------*/
-extern void time2epoch(gtime_t t, double *ep)
+void time2epoch(gtime_t t, double *ep)
 {
     const int mday[]={ /* # of days in a month */
         31,28,31,30,31,30,31,31,30,31,30,31,31,28,31,30,31,30,31,31,30,31,30,31,
@@ -1657,7 +1657,7 @@ extern void time2epoch(gtime_t t, double *ep)
     ep[3]=sec/3600; ep[4]=sec%3600/60; ep[5]=sec%60+t.sec;
 }
 /* same as above but output limited to n decimals for formatted output */
-extern void time2epoch_n(gtime_t t, double *ep, int n)
+void time2epoch_n(gtime_t t, double *ep, int n)
 {
     if (n<0) n=0; else if (n>12) n=12;
     if (1.0-t.sec<0.5/pow(10.0,n)) {t.time++; t.sec=0.0;};
@@ -1669,7 +1669,7 @@ extern void time2epoch_n(gtime_t t, double *ep, int n)
 *          double sec       I   time of week in gps time (s)
 * return : gtime_t struct
 *-----------------------------------------------------------------------------*/
-extern gtime_t gpst2time(int week, double sec)
+gtime_t gpst2time(int week, double sec)
 {
     gtime_t t=epoch2time(gpst0);
 
@@ -1684,7 +1684,7 @@ extern gtime_t gpst2time(int week, double sec)
 *          int    *week     IO  week number in gps time (NULL: no output)
 * return : time of week in gps time (s)
 *-----------------------------------------------------------------------------*/
-extern double time2gpst(gtime_t t, int *week)
+double time2gpst(gtime_t t, int *week)
 {
     gtime_t t0=epoch2time(gpst0);
     time_t sec=t.time-t0.time;
@@ -1699,7 +1699,7 @@ extern double time2gpst(gtime_t t, int *week)
 *          double sec       I   time of week in gst (s)
 * return : gtime_t struct
 *-----------------------------------------------------------------------------*/
-extern gtime_t gst2time(int week, double sec)
+gtime_t gst2time(int week, double sec)
 {
     gtime_t t=epoch2time(gst0);
 
@@ -1714,7 +1714,7 @@ extern gtime_t gst2time(int week, double sec)
 *          int    *week     IO  week number in gst (NULL: no output)
 * return : time of week in gst (s)
 *-----------------------------------------------------------------------------*/
-extern double time2gst(gtime_t t, int *week)
+double time2gst(gtime_t t, int *week)
 {
     gtime_t t0=epoch2time(gst0);
     time_t sec=t.time-t0.time;
@@ -1729,7 +1729,7 @@ extern double time2gst(gtime_t t, int *week)
 *          double sec       I   time of week in bdt (s)
 * return : gtime_t struct
 *-----------------------------------------------------------------------------*/
-extern gtime_t bdt2time(int week, double sec)
+gtime_t bdt2time(int week, double sec)
 {
     gtime_t t=epoch2time(bdt0);
 
@@ -1744,7 +1744,7 @@ extern gtime_t bdt2time(int week, double sec)
 *          int    *week     IO  week number in bdt (NULL: no output)
 * return : time of week in bdt (s)
 *-----------------------------------------------------------------------------*/
-extern double time2bdt(gtime_t t, int *week)
+double time2bdt(gtime_t t, int *week)
 {
     gtime_t t0=epoch2time(bdt0);
     time_t sec=t.time-t0.time;
@@ -1759,7 +1759,7 @@ extern double time2bdt(gtime_t t, int *week)
 *          double sec       I   time to add (s)
 * return : gtime_t struct (t+sec)
 *-----------------------------------------------------------------------------*/
-extern gtime_t timeadd(gtime_t t, double sec)
+gtime_t timeadd(gtime_t t, double sec)
 {
     double tt;
 
@@ -1771,7 +1771,7 @@ extern gtime_t timeadd(gtime_t t, double sec)
 * args   : gtime_t t1,t2    I   gtime_t structs
 * return : time difference (t1-t2) (s)
 *-----------------------------------------------------------------------------*/
-extern double timediff(gtime_t t1, gtime_t t2)
+double timediff(gtime_t t1, gtime_t t2)
 {
     return difftime(t1.time,t2.time)+t1.sec-t2.sec;
 }
@@ -1782,7 +1782,7 @@ extern double timediff(gtime_t t1, gtime_t t2)
 *-----------------------------------------------------------------------------*/
 static double timeoffset_=0.0;        /* time offset (s) */
 
-extern gtime_t timeget(void)
+gtime_t timeget(void)
 {
     double ep[6]={0};
 #ifdef WIN32
@@ -1820,7 +1820,7 @@ extern gtime_t timeget(void)
 *          the time offset is reflected to only timeget()
 *          not reentrant
 *-----------------------------------------------------------------------------*/
-extern void timeset(gtime_t t)
+void timeset(gtime_t t)
 {
     timeoffset_+=timediff(t,timeget());
 }
@@ -1829,7 +1829,7 @@ extern void timeset(gtime_t t)
 * args   : none
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void timereset(void)
+void timereset(void)
 {
     timeoffset_=0.0;
 }
@@ -1889,7 +1889,7 @@ static int read_leaps_usno(FILE *fp)
 *          (2) The date and time indicate the start UTC time for the UTC-GPST
 *          (3) The date and time should be descending order.
 *-----------------------------------------------------------------------------*/
-extern int read_leaps(const char *file)
+int read_leaps(const char *file)
 {
     FILE *fp;
     int i,n;
@@ -1911,7 +1911,7 @@ extern int read_leaps(const char *file)
 * return : time expressed in utc
 * notes  : ignore slight time offset under 100 ns
 *-----------------------------------------------------------------------------*/
-extern gtime_t gpst2utc(gtime_t t)
+gtime_t gpst2utc(gtime_t t)
 {
     gtime_t tu;
     int i;
@@ -1928,7 +1928,7 @@ extern gtime_t gpst2utc(gtime_t t)
 * return : time expressed in gpstime
 * notes  : ignore slight time offset under 100 ns
 *-----------------------------------------------------------------------------*/
-extern gtime_t utc2gpst(gtime_t t)
+gtime_t utc2gpst(gtime_t t)
 {
     int i;
 
@@ -1945,7 +1945,7 @@ extern gtime_t utc2gpst(gtime_t t)
 *          no leap seconds in BDT
 *          ignore slight time offset under 100 ns
 *-----------------------------------------------------------------------------*/
-extern gtime_t gpst2bdt(gtime_t t)
+gtime_t gpst2bdt(gtime_t t)
 {
     return timeadd(t,-14.0);
 }
@@ -1955,7 +1955,7 @@ extern gtime_t gpst2bdt(gtime_t t)
 * return : time expressed in gpstime
 * notes  : see gpst2bdt()
 *-----------------------------------------------------------------------------*/
-extern gtime_t bdt2gpst(gtime_t t)
+gtime_t bdt2gpst(gtime_t t)
 {
     return timeadd(t,14.0);
 }
@@ -1975,7 +1975,7 @@ static double time2sec(gtime_t time, gtime_t *day)
 *          double ut1_utc   I   UT1-UTC (s)
 * return : gmst (rad)
 *-----------------------------------------------------------------------------*/
-extern double utc2gmst(gtime_t t, double ut1_utc)
+double utc2gmst(gtime_t t, double ut1_utc)
 {
     const double ep2000[]={2000,1,1,12,0,0};
     gtime_t tut,tut0;
@@ -1997,7 +1997,7 @@ extern double utc2gmst(gtime_t t, double ut1_utc)
 *          int    n         I   number of decimals
 * return : time string
 *-----------------------------------------------------------------------------*/
-extern char *time2str(gtime_t t, char s[40], int n)
+char *time2str(gtime_t t, char s[40], int n)
 {
     double ep[6];
 
@@ -2013,7 +2013,7 @@ extern char *time2str(gtime_t t, char s[40], int n)
 * args   : gtime_t t        I   gtime_t struct
 * return : day of year (days)
 *-----------------------------------------------------------------------------*/
-extern double time2doy(gtime_t t)
+double time2doy(gtime_t t)
 {
     double ep[6];
 
@@ -2026,7 +2026,7 @@ extern double time2doy(gtime_t t)
 * args   : int   week       I   not-adjusted gps week number (0-1023)
 * return : adjusted gps week number
 *-----------------------------------------------------------------------------*/
-extern int adjgpsweek(int week)
+int adjgpsweek(int week)
 {
     int w;
     (void)time2gpst(utc2gpst(timeget()),&w);
@@ -2038,7 +2038,7 @@ extern int adjgpsweek(int week)
 * args   : none
 * return : current tick in ms
 *-----------------------------------------------------------------------------*/
-extern uint32_t tickget(void)
+uint32_t tickget(void)
 {
 #ifdef WIN32
     // To avoid needing all windows.h and lib WinMM for timeGetTime().
@@ -2067,7 +2067,7 @@ extern uint32_t tickget(void)
 * args   : int   ms         I   milliseconds to sleep (<0:no sleep)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void sleepms(int ms)
+void sleepms(int ms)
 {
 #ifdef WIN32
     if (ms<5) Sleep(1); else Sleep(ms);
@@ -2086,7 +2086,7 @@ extern void sleepms(int ms)
 *          int    ndec      I   number of decimals of second
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void deg2dms(double deg, double *dms, int ndec)
+void deg2dms(double deg, double *dms, int ndec)
 {
     double sign=deg<0.0?-1.0:1.0,a=fabs(deg);
     double unit=pow(0.1,ndec);
@@ -2108,7 +2108,7 @@ extern void deg2dms(double deg, double *dms, int ndec)
 * args   : double *dms      I   degree-minute-second {deg,min,sec}
 * return : degree
 *-----------------------------------------------------------------------------*/
-extern double dms2deg(const double *dms)
+double dms2deg(const double *dms)
 {
     double sign=dms[0]<0.0?-1.0:1.0;
     return sign*(fabs(dms[0])+dms[1]/60.0+dms[2]/3600.0);
@@ -2120,7 +2120,7 @@ extern double dms2deg(const double *dms)
 * return : none
 * notes  : WGS84, ellipsoidal height
 *-----------------------------------------------------------------------------*/
-extern void ecef2pos(const double *r, double *pos)
+void ecef2pos(const double *r, double *pos)
 {
     double e2=FE_WGS84*(2.0-FE_WGS84),r2=dot2(r,r),z,zk,v=RE_WGS84,sinp;
 
@@ -2141,7 +2141,7 @@ extern void ecef2pos(const double *r, double *pos)
 * return : none
 * notes  : WGS84, ellipsoidal height
 *-----------------------------------------------------------------------------*/
-extern void pos2ecef(const double *pos, double *r)
+void pos2ecef(const double *pos, double *r)
 {
     double sinp=sin(pos[0]),cosp=cos(pos[0]),sinl=sin(pos[1]),cosl=cos(pos[1]);
     double e2=FE_WGS84*(2.0-FE_WGS84),v=RE_WGS84/sqrt(1.0-e2*sinp*sinp);
@@ -2157,7 +2157,7 @@ extern void pos2ecef(const double *pos, double *r)
 * return : none
 * notes  : matrix stored by column-major order (fortran convention)
 *-----------------------------------------------------------------------------*/
-extern void xyz2enu(const double *pos, double *E)
+void xyz2enu(const double *pos, double *E)
 {
     double sinp=sin(pos[0]),cosp=cos(pos[0]),sinl=sin(pos[1]),cosl=cos(pos[1]);
 
@@ -2172,7 +2172,7 @@ extern void xyz2enu(const double *pos, double *E)
 *          double *e        O   vector in local tangential coordinate {e,n,u}
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void ecef2enu(const double *pos, const double *r, double *e)
+void ecef2enu(const double *pos, const double *r, double *e)
 {
     double E[9];
 
@@ -2186,7 +2186,7 @@ extern void ecef2enu(const double *pos, const double *r, double *e)
 *          double *r        O   vector in ecef coordinate {x,y,z}
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void enu2ecef(const double *pos, const double *e, double *r)
+void enu2ecef(const double *pos, const double *e, double *r)
 {
     double E[9];
 
@@ -2200,7 +2200,7 @@ extern void enu2ecef(const double *pos, const double *e, double *r)
 *          double *Q        O   covariance in local tangential coordinate
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void covenu(const double *pos, const double *P, double *Q)
+void covenu(const double *pos, const double *P, double *Q)
 {
     double E[9],EP[9];
 
@@ -2215,7 +2215,7 @@ extern void covenu(const double *pos, const double *P, double *Q)
 *          double *P        O   covariance in xyz-ecef coordinate
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void covecef(const double *pos, const double *Q, double *P)
+void covecef(const double *pos, const double *Q, double *P)
 {
     double E[9],EQ[9];
 
@@ -2395,7 +2395,7 @@ static void nut_iau1980(double t, const double *f, double *dpsi, double *deps)
 * note   : see ref [3] chap 5
 *          not thread-safe
 *-----------------------------------------------------------------------------*/
-extern void eci2ecef(gtime_t tutc, const double *erpv, double *U, double *gmst)
+void eci2ecef(gtime_t tutc, const double *erpv, double *U, double *gmst)
 {
     const double ep2000[]={2000,1,1,12,0,0};
     static THREADLOCAL gtime_t tutc_ = {0, 0};
@@ -2615,7 +2615,7 @@ static int readantex(const char *file, pcvs_t *pcvs)
 *          see reference [3]
 *          only support non-azimuth-depedent parameters
 *-----------------------------------------------------------------------------*/
-extern int readpcv(const char *file, pcvs_t *pcvs)
+int readpcv(const char *file, pcvs_t *pcvs)
 {
     pcv_t *pcv;
     char *ext;
@@ -2647,7 +2647,7 @@ extern int readpcv(const char *file, pcvs_t *pcvs)
 *          pcvs_t *pcvs       IO  antenna parameters
 * return : antenna parameter (NULL: no antenna)
 *-----------------------------------------------------------------------------*/
-extern pcv_t *searchpcv(int sat, const char *type, gtime_t time,
+pcv_t *searchpcv(int sat, const char *type, gtime_t time,
                         const pcvs_t *pcvs)
 {
     pcv_t *pcv;
@@ -2697,7 +2697,7 @@ extern pcv_t *searchpcv(int sat, const char *type, gtime_t time,
 *                               (all 0 if search error)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void readpos(const char *file, const char *rcv, double *pos)
+void readpos(const char *file, const char *rcv, double *pos)
 {
   trace(3, "readpos: file=%s\n", file);
 
@@ -2766,7 +2766,7 @@ static int readblqrecord(FILE *fp, double odisp[2][11][3])
 *          double odisp[2][11][3] O   ocean tide loading parameters
 * return : status (1:ok,0:file open error)
 *-----------------------------------------------------------------------------*/
-extern int readblq(const char *file, const char *sta, double odisp[2][11][3])
+int readblq(const char *file, const char *sta, double odisp[2][11][3])
 {
     FILE *fp;
     char buff[256],staname[17]="",name[17],*p;
@@ -2802,7 +2802,7 @@ extern int readblq(const char *file, const char *sta, double odisp[2][11][3])
 *          erp_t  *erp        O   earth rotation parameters
 * return : number of files read.
 *-----------------------------------------------------------------------------*/
-extern int readerp(const char *file, erp_t *erp) {
+int readerp(const char *file, erp_t *erp) {
   trace(3, "readerp: file=%s\n", file);
 
   char *efiles[MAXEXFILE];
@@ -2923,7 +2923,7 @@ extern int readerp(const char *file, erp_t *erp) {
 *          double *erpv       O   erp values {xp,yp,ut1_utc,lod} (rad,rad,s,s/d)
 * return : status (1:ok,0:error)
 *-----------------------------------------------------------------------------*/
-extern int geterp(const erp_t *erp, gtime_t time, double *erpv)
+int geterp(const erp_t *erp, gtime_t time, double *erpv)
 {
     const double ep[]={2000,1,1,12,0,0};
     double mjd,day,a;
@@ -3097,7 +3097,7 @@ static void uniqseph(nav_t *nav)
 * args   : nav_t *nav    IO     navigation data
 * return : number of epochs
 *-----------------------------------------------------------------------------*/
-extern void uniqnav(nav_t *nav)
+void uniqnav(nav_t *nav)
 {
     trace(3,"uniqnav: neph=%d ngeph=%d nseph=%d\n",nav->n,nav->ng,nav->ns);
 
@@ -3120,7 +3120,7 @@ static int cmpobs(const void *p1, const void *p2)
 * args   : obs_t *obs    IO     observation data
 * return : number of epochs
 *-----------------------------------------------------------------------------*/
-extern int sortobs(obs_t *obs)
+int sortobs(obs_t *obs)
 {
     int i,j,n;
 
@@ -3155,7 +3155,7 @@ extern int sortobs(obs_t *obs)
 *          double  tint  I      time interval (s) (0.0:no screen by tint)
 * return : 1:on condition, 0:not on condition
 *-----------------------------------------------------------------------------*/
-extern int screent(gtime_t time, gtime_t ts, gtime_t te, double tint)
+int screent(gtime_t time, gtime_t ts, gtime_t te, double tint)
 {
     return (tint<=0.0||fmod(time2gpst(time,NULL)+DTTOL,tint)<=DTTOL*2.0)&&
            (ts.time==0||timediff(time,ts)>=-DTTOL)&&
@@ -3167,7 +3167,7 @@ extern int screent(gtime_t time, gtime_t ts, gtime_t te, double tint)
 *          nav_t   nav   O/I    navigation data
 * return : status (1:ok,0:no file)
 *-----------------------------------------------------------------------------*/
-extern int readnav(const char *file, nav_t *nav)
+int readnav(const char *file, nav_t *nav)
 {
     FILE *fp;
     eph_t eph0={0};
@@ -3234,7 +3234,7 @@ extern int readnav(const char *file, nav_t *nav)
     fclose(fp);
     return 1;
 }
-extern int savenav(const char *file, const nav_t *nav)
+int savenav(const char *file, const nav_t *nav)
 {
     FILE *fp;
     int i;
@@ -3289,7 +3289,7 @@ extern int savenav(const char *file, const nav_t *nav)
 * args   : obs_t *obs    IO     observation data
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void freeobs(obs_t *obs)
+void freeobs(obs_t *obs)
 {
     free(obs->data); obs->data=NULL; obs->n=obs->nmax=0;
 }
@@ -3303,7 +3303,7 @@ extern void freeobs(obs_t *obs)
 *                                0x40: tec data)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void freenav(nav_t *nav, int opt)
+void freenav(nav_t *nav, int opt)
 {
     if (opt&0x01) {free(nav->eph ); nav->eph =NULL; nav->n =nav->nmax =0;}
     if (opt&0x02) {free(nav->geph); nav->geph=NULL; nav->ng=nav->ngmax=0;}
@@ -3319,7 +3319,7 @@ extern void freenav(nav_t *nav, int opt)
 * args   : char   *cmd      I   command line
 * return : execution status (0:ok,0>:error)
 *-----------------------------------------------------------------------------*/
-extern int execcmd(const char *cmd)
+int execcmd(const char *cmd)
 {
 #ifdef WIN32
     PROCESS_INFORMATION info;
@@ -3352,7 +3352,7 @@ extern int execcmd(const char *cmd)
 * return : number of expanded file paths
 * notes  : the order of expanded files is alphabetical order
 *-----------------------------------------------------------------------------*/
-extern int expath(const char *path, char *paths[], int nmax)
+int expath(const char *path, char *paths[], int nmax)
 {
     int i,j,n=0;
     char tmp[1024];
@@ -3463,7 +3463,7 @@ static int mkdir_r(const char *dir)
 * return : none
 * notes  : recursively.
 *-----------------------------------------------------------------------------*/
-extern void createdir(const char *path)
+void createdir(const char *path)
 {
     char buff[1024],*p;
 
@@ -3520,7 +3520,7 @@ static int repstr(char *str, const char *pat, const char *rep)
 *              %r -> rrrr : rover id
 *              %b -> bbbb : base station id
 *-----------------------------------------------------------------------------*/
-extern int reppath(const char *path, char *rpath, gtime_t time, const char *rov,
+int reppath(const char *path, char *rpath, gtime_t time, const char *rov,
                    const char *base)
 {
     double ep[6],ep0[6]={2000,1,1,0,0,0};
@@ -3576,7 +3576,7 @@ extern int reppath(const char *path, char *rpath, gtime_t time, const char *rov,
 * notes  : see reppath() for replacements of keywords.
 *          minimum interval of time replaced is 900s.
 *-----------------------------------------------------------------------------*/
-extern int reppaths(const char *path, char *rpath[], int nmax, gtime_t ts,
+int reppaths(const char *path, char *rpath[], int nmax, gtime_t ts,
                     gtime_t te, const char *rov, const char *base)
 {
     gtime_t time;
@@ -3609,7 +3609,7 @@ extern int reppaths(const char *path, char *rpath[], int nmax, gtime_t ts,
 * return : geometric distance (m) (0>:error/no satellite position)
 * notes  : distance includes sagnac effect correction
 *-----------------------------------------------------------------------------*/
-extern double geodist(const double *rs, const double *rr, double *e)
+double geodist(const double *rs, const double *rr, double *e)
 {
     double r;
     int i;
@@ -3628,7 +3628,7 @@ extern double geodist(const double *rs, const double *rr, double *e)
 *                               (0.0<=azel[0]<2*pi,-pi/2<=azel[1]<=pi/2)
 * return : elevation angle (rad)
 *-----------------------------------------------------------------------------*/
-extern double satazel(const double *pos, const double *e, double *azel)
+double satazel(const double *pos, const double *e, double *azel)
 {
     double az=0.0,el=PI/2.0,enu[3];
 
@@ -3652,7 +3652,7 @@ extern double satazel(const double *pos, const double *e, double *azel)
 *-----------------------------------------------------------------------------*/
 #define SQRT(x)     ((x)<0.0||(x)!=(x)?0.0:sqrt(x))
 
-extern void dops(int ns, const double *azel, double elmin, double *dop)
+void dops(int ns, const double *azel, double elmin, double *dop)
 {
     double H[4*MAXSAT],Q[16],cosel,sinel;
     int i,n;
@@ -3685,7 +3685,7 @@ extern void dops(int ns, const double *azel, double elmin, double *dop)
 *          double *azel     I   azimuth/elevation angle {az,el} (rad)
 * return : ionospheric delay (L1) (m)
 *-----------------------------------------------------------------------------*/
-extern double ionmodel(gtime_t t, const double *ion, const double *pos,
+double ionmodel(gtime_t t, const double *ion, const double *pos,
                        const double *azel)
 {
     const double ion_default[]={ /* 2004/1/1 */
@@ -3732,7 +3732,7 @@ extern double ionmodel(gtime_t t, const double *ion, const double *pos,
 *          double *azel     I   azimuth/elevation angle {az,el} (rad)
 * return : ionospheric mapping function
 *-----------------------------------------------------------------------------*/
-extern double ionmapf(const double *pos, const double *azel)
+double ionmapf(const double *pos, const double *azel)
 {
     if (pos[2]>=HION) return 1.0;
     return 1.0/cos(asin((RE_WGS84+pos[2])/(RE_WGS84+HION)*sin(PI/2.0-azel[1])));
@@ -3748,7 +3748,7 @@ extern double ionmapf(const double *pos, const double *azel)
 * notes  : see ref [2], only valid on the earth surface
 *          fixing bug on ref [2] A.4.4.10.1 A-22,23
 *-----------------------------------------------------------------------------*/
-extern double ionppp(const double *pos, const double *azel, double re,
+double ionppp(const double *pos, const double *azel, double re,
                      double hion, double *posp)
 {
     double cosaz,r,rp,ap,sinap,tanap;
@@ -3775,7 +3775,7 @@ extern double ionppp(const double *pos, const double *azel, double re,
     return 1.0/sqrt(1.0-rp*rp);
 }
 /* select iono-free linear combination (L1/L2 or L1/L5) ----------------------*/
-extern int seliflc(int optnf,int sys)
+int seliflc(int optnf,int sys)
 {
     /* use L1/L5 for GPS,GAL,BDS if L5 is enabled */
     return((optnf==2||sys==SYS_GLO)?1:2);
@@ -3788,7 +3788,7 @@ extern int seliflc(int optnf,int sys)
 *          double humi      I   relative humidity
 * return : tropospheric delay (m)
 *-----------------------------------------------------------------------------*/
-extern double tropmodel(gtime_t time, const double *pos, const double *azel,
+double tropmodel(gtime_t time, const double *pos, const double *azel,
                         double humi)
 {
     (void)time;
@@ -3881,7 +3881,7 @@ static double nmf(gtime_t time, const double pos[], const double azel[],
 *          paper is obtained from:
 *          ftp://web.haystack.edu/pub/aen/nmf/NMF_JGR.pdf
 *-----------------------------------------------------------------------------*/
-extern double tropmapf(gtime_t time, const double pos[], const double azel[],
+double tropmapf(gtime_t time, const double pos[], const double azel[],
                        double *mapfw)
 {
 #ifdef IERS_MODEL
@@ -3929,7 +3929,7 @@ static double interpvar(double ang, const double *var)
 * return : none
 * notes  : current version does not support azimuth dependent terms
 *-----------------------------------------------------------------------------*/
-extern void antmodel(const pcv_t *pcv, const double *del, const double *azel,
+void antmodel(const pcv_t *pcv, const double *del, const double *azel,
                      int opt, double *dant)
 {
     double e[3],off[3],cosel=cos(azel[1]);
@@ -3955,7 +3955,7 @@ extern void antmodel(const pcv_t *pcv, const double *del, const double *azel,
 *          double *dant     O   range offsets for each frequency (m)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void antmodel_s(const pcv_t *pcv, double nadir, double *dant)
+void antmodel_s(const pcv_t *pcv, double nadir, double *dant)
 {
     int i;
 
@@ -4092,7 +4092,7 @@ static void moonpos_eci(gtime_t tutc, const double *erpv, double *rmoon) {
  *          double *gmst     O   GMST (rad)
  * Return : none
  *----------------------------------------------------------------------------*/
-extern void sunmoonpos(gtime_t tutc, const double *erpv, double *rsun, double *rmoon,
+void sunmoonpos(gtime_t tutc, const double *erpv, double *rsun, double *rmoon,
                        double *gmst) {
   char tstr[40];
   trace(4, "sunmoonpos: tutc=%s\n", time2str(tutc, tstr, 3));
@@ -4124,7 +4124,7 @@ extern void sunmoonpos(gtime_t tutc, const double *erpv, double *rsun, double *r
 * note   : creates uncompressed file in temporary directory
 *          gzip, tar and crx2rnx commands have to be installed in commands path
 *-----------------------------------------------------------------------------*/
-extern int rtk_uncompress(const char *file, char *uncfile)
+int rtk_uncompress(const char *file, char *uncfile)
 {
     int stat=0;
     char *p,cmd[64+2048]="",tmpfile[1024]="",buff[1024],*fname,*dir="";
@@ -4195,7 +4195,7 @@ extern int rtk_uncompress(const char *file, char *uncfile)
     return stat;
 }
 /* station position from file ------------------------------------------------*/
-extern int getstapos(const char *file, const char *name, double *r)
+int getstapos(const char *file, const char *name, double *r)
 {
     trace(3, "getstapos: file=%s name=%s\n", file, name);
 
@@ -4307,8 +4307,8 @@ extern int getstapos(const char *file, const char *name, double *r)
 }
 /* dummy application functions for shared library ----------------------------*/
 #if defined(WIN_DLL) || defined(DLL)
-extern int showmsg(const char *format,...) {return 0;}
-extern void settspan(gtime_t ts, gtime_t te) {}
-extern void settime(gtime_t time) {}
+int showmsg(const char *format,...) {return 0;}
+void settspan(gtime_t ts, gtime_t te) {}
+void settime(gtime_t time) {}
 #endif
 

--- a/src/rtkpos.c
+++ b/src/rtkpos.c
@@ -179,7 +179,7 @@ static gtime_t time_stat={0};    /* rtk status file time */
 *          lambda   : wavelength
 *
 *-----------------------------------------------------------------------------*/
-extern int rtkopenstat(const char *file, int level)
+int rtkopenstat(const char *file, int level)
 {
     gtime_t time=utc2gpst(timeget());
     char path[1024];
@@ -204,7 +204,7 @@ extern int rtkopenstat(const char *file, int level)
 * args   : none
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void rtkclosestat(void)
+void rtkclosestat(void)
 {
     trace(3,"rtkclosestat:\n");
 
@@ -214,7 +214,7 @@ extern void rtkclosestat(void)
     statlevel=0;
 }
 /* Write solution status to buffer -------------------------------------------*/
-extern int rtkoutstat(rtk_t *rtk, int level, char *buff)
+int rtkoutstat(rtk_t *rtk, int level, char *buff)
 {
     if (level<=0||rtk->sol.stat==SOLQ_NONE) {
         return 0;
@@ -2238,7 +2238,7 @@ static int relpos(rtk_t *rtk, const obsd_t *obs, int nu, int nr,
 *          prcopt_t *opt    I   positioning options (see rtklib.h)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void rtkinit(rtk_t *rtk, const prcopt_t *opt)
+void rtkinit(rtk_t *rtk, const prcopt_t *opt)
 {
     sol_t sol0={{0}};
     ambc_t ambc0={{{0}}};
@@ -2276,7 +2276,7 @@ extern void rtkinit(rtk_t *rtk, const prcopt_t *opt)
 * args   : rtk_t    *rtk    IO  rtk control/result struct
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void rtkfree(rtk_t *rtk)
+void rtkfree(rtk_t *rtk)
 {
     trace(3,"rtkfree :\n");
 
@@ -2343,7 +2343,7 @@ extern void rtkfree(rtk_t *rtk)
 * notes  : before calling function, base station position rtk->sol.rb[] should
 *          be properly set for relative mode except for moving-baseline
 *-----------------------------------------------------------------------------*/
-extern int rtkpos(rtk_t *rtk, const obsd_t *obs, int n, const nav_t *nav)
+int rtkpos(rtk_t *rtk, const obsd_t *obs, int n, const nav_t *nav)
 {
     prcopt_t *opt=&rtk->opt;
     sol_t solb={{0}};

--- a/src/rtkpos.c
+++ b/src/rtkpos.c
@@ -179,7 +179,7 @@ static gtime_t time_stat={0};    /* rtk status file time */
 *          lambda   : wavelength
 *
 *-----------------------------------------------------------------------------*/
-extern int rtkopenstat(const char *file, int level)
+int rtkopenstat(const char *file, int level)
 {
     gtime_t time=utc2gpst(timeget());
     char path[1024];
@@ -204,7 +204,7 @@ extern int rtkopenstat(const char *file, int level)
 * args   : none
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void rtkclosestat(void)
+void rtkclosestat(void)
 {
     trace(3,"rtkclosestat:\n");
 
@@ -214,7 +214,7 @@ extern void rtkclosestat(void)
     statlevel=0;
 }
 /* Write solution status to buffer -------------------------------------------*/
-extern int rtkoutstat(rtk_t *rtk, int level, char *buff)
+int rtkoutstat(rtk_t *rtk, int level, char *buff)
 {
     if (level<=0||rtk->sol.stat==SOLQ_NONE) {
         return 0;
@@ -2323,7 +2323,7 @@ static int relpos(rtk_t *rtk, const obsd_t *obs, int nu, int nr,
 *          prcopt_t *opt    I   positioning options (see rtklib.h)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void rtkinit(rtk_t *rtk, const prcopt_t *opt)
+void rtkinit(rtk_t *rtk, const prcopt_t *opt)
 {
     sol_t sol0={{0}};
     ambc_t ambc0={{{0}}};
@@ -2361,7 +2361,7 @@ extern void rtkinit(rtk_t *rtk, const prcopt_t *opt)
 * args   : rtk_t    *rtk    IO  rtk control/result struct
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void rtkfree(rtk_t *rtk)
+void rtkfree(rtk_t *rtk)
 {
     trace(3,"rtkfree :\n");
 
@@ -2428,7 +2428,7 @@ extern void rtkfree(rtk_t *rtk)
 * notes  : before calling function, base station position rtk->sol.rb[] should
 *          be properly set for relative mode except for moving-baseline
 *-----------------------------------------------------------------------------*/
-extern int rtkpos(rtk_t *rtk, const obsd_t *obs, int n, const nav_t *nav)
+int rtkpos(rtk_t *rtk, const obsd_t *obs, int n, const nav_t *nav)
 {
     prcopt_t *opt=&rtk->opt;
     sol_t solb={{0}};

--- a/src/rtksvr.c
+++ b/src/rtksvr.c
@@ -780,7 +780,7 @@ static void *rtksvrthread(void *arg)
 * args   : rtksvr_t *svr    IO rtk server
 * return : status (0:error,1:ok)
 *-----------------------------------------------------------------------------*/
-extern int rtksvrinit(rtksvr_t *svr)
+int rtksvrinit(rtksvr_t *svr)
 {
     gtime_t time0={0};
     sol_t  sol0 ={{0}};
@@ -872,7 +872,7 @@ extern int rtksvrinit(rtksvr_t *svr)
 * args   : rtksvr_t *svr    IO rtk server
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void rtksvrfree(rtksvr_t *svr)
+void rtksvrfree(rtksvr_t *svr)
 {
     int i,j;
     
@@ -889,8 +889,8 @@ extern void rtksvrfree(rtksvr_t *svr)
 * args   : rtksvr_t *svr    IO rtk server
 * return : status (1:ok 0:error)
 *-----------------------------------------------------------------------------*/
-extern void rtksvrlock  (rtksvr_t *svr) {rtklib_lock  (&svr->lock);}
-extern void rtksvrunlock(rtksvr_t *svr) {rtklib_unlock(&svr->lock);}
+void rtksvrlock  (rtksvr_t *svr) {rtklib_lock  (&svr->lock);}
+void rtksvrunlock(rtksvr_t *svr) {rtklib_unlock(&svr->lock);}
 
 /* start rtk server ------------------------------------------------------------
 * start rtk server thread
@@ -937,7 +937,7 @@ extern void rtksvrunlock(rtksvr_t *svr) {rtklib_unlock(&svr->lock);}
 *          char   *errmsg   O  error message
 * return : status (1:ok 0:error)
 *-----------------------------------------------------------------------------*/
-extern int rtksvrstart(rtksvr_t *svr, int cycle, int buffsize, int *strs,
+int rtksvrstart(rtksvr_t *svr, int cycle, int buffsize, int *strs,
                        const char **paths, int *formats, int navsel, const char **cmds,
                        const char **cmds_periodic, const char **rcvopts, int nmeacycle,
                        int nmeareq, const double *nmeapos, prcopt_t *prcopt,
@@ -1080,7 +1080,7 @@ extern int rtksvrstart(rtksvr_t *svr, int cycle, int buffsize, int *strs,
 *                              cmds[2]=input stream ephem (NULL: no command)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void rtksvrstop(rtksvr_t *svr, const char **cmds)
+void rtksvrstop(rtksvr_t *svr, const char **cmds)
 {
     int i;
     
@@ -1115,7 +1115,7 @@ extern void rtksvrstop(rtksvr_t *svr, const char **cmds)
 *          solopt_t *solopt I  solution options
 * return : status (1:ok 0:error)
 *-----------------------------------------------------------------------------*/
-extern int rtksvropenstr(rtksvr_t *svr, int index, int str, const char *path,
+int rtksvropenstr(rtksvr_t *svr, int index, int str, const char *path,
                          const solopt_t *solopt, const prcopt_t *prcopt)
 {
     tracet(3,"rtksvropenstr: index=%d str=%d path=%s\n",index,str,path);
@@ -1150,7 +1150,7 @@ extern int rtksvropenstr(rtksvr_t *svr, int index, int str, const char *path,
 *                               6:log base station,7:log correction)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void rtksvrclosestr(rtksvr_t *svr, int index)
+void rtksvrclosestr(rtksvr_t *svr, int index)
 {
     tracet(3,"rtksvrclosestr: index=%d\n",index);
     
@@ -1175,7 +1175,7 @@ extern void rtksvrclosestr(rtksvr_t *svr, int index)
 *          int     *vsat    O  valid satellite flag
 * return : number of satellites
 *-----------------------------------------------------------------------------*/
-extern int rtksvrostat(rtksvr_t *svr, int rcv, gtime_t *time, int sat[MAXSAT],
+int rtksvrostat(rtksvr_t *svr, int rcv, gtime_t *time, int sat[MAXSAT],
                        double *az, double *el, int snr[MAXSAT][NFREQ], int vsat[MAXSAT][NFREQ])
 {
     tracet(4,"rtksvrostat: rcv=%d\n",rcv);
@@ -1208,7 +1208,7 @@ extern int rtksvrostat(rtksvr_t *svr, int rcv, gtime_t *time, int sat[MAXSAT],
 *          char    *msg     O  status messages
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void rtksvrsstat(rtksvr_t *svr, int *sstat, char *msg)
+void rtksvrsstat(rtksvr_t *svr, int *sstat, char *msg)
 {
     int i;
     char s[MAXSTRMSG],*p=msg;
@@ -1229,7 +1229,7 @@ extern void rtksvrsstat(rtksvr_t *svr, int *sstat, char *msg)
 *          char    *comment I  comment string
 * return : status (1:ok 0:error)
 *-----------------------------------------------------------------------------*/
-extern int rtksvrmark(rtksvr_t *svr, const char *name, const char *comment)
+int rtksvrmark(rtksvr_t *svr, const char *name, const char *comment)
 {
     char buff[MAXSOLMSG+1],tstr[40],*p,*q;
     double tow,pos[3];

--- a/src/rtksvr.c
+++ b/src/rtksvr.c
@@ -780,7 +780,7 @@ static void *rtksvrthread(void *arg)
 * args   : rtksvr_t *svr    IO rtk server
 * return : status (0:error,1:ok)
 *-----------------------------------------------------------------------------*/
-extern int rtksvrinit(rtksvr_t *svr)
+int rtksvrinit(rtksvr_t *svr)
 {
     gtime_t time0={0};
     sol_t  sol0 ={{0}};
@@ -872,7 +872,7 @@ extern int rtksvrinit(rtksvr_t *svr)
 * args   : rtksvr_t *svr    IO rtk server
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void rtksvrfree(rtksvr_t *svr)
+void rtksvrfree(rtksvr_t *svr)
 {
     int i,j;
     
@@ -889,8 +889,8 @@ extern void rtksvrfree(rtksvr_t *svr)
 * args   : rtksvr_t *svr    IO rtk server
 * return : status (1:ok 0:error)
 *-----------------------------------------------------------------------------*/
-extern void rtksvrlock  (rtksvr_t *svr) {rtklib_lock  (&svr->lock);}
-extern void rtksvrunlock(rtksvr_t *svr) {rtklib_unlock(&svr->lock);}
+void rtksvrlock  (rtksvr_t *svr) {rtklib_lock  (&svr->lock);}
+void rtksvrunlock(rtksvr_t *svr) {rtklib_unlock(&svr->lock);}
 
 /* start rtk server ------------------------------------------------------------
 * start rtk server thread
@@ -937,7 +937,7 @@ extern void rtksvrunlock(rtksvr_t *svr) {rtklib_unlock(&svr->lock);}
 *          char   *errmsg   O  error message
 * return : status (1:ok 0:error)
 *-----------------------------------------------------------------------------*/
-extern int rtksvrstart(rtksvr_t *svr, int cycle, int buffsize, int *strs,
+int rtksvrstart(rtksvr_t *svr, int cycle, int buffsize, int *strs,
                        const char **paths, int *formats, int navsel, const char **cmds,
                        const char **cmds_periodic, const char **rcvopts, int nmeacycle,
                        int nmeareq, const double *nmeapos, prcopt_t *prcopt,
@@ -1080,7 +1080,7 @@ extern int rtksvrstart(rtksvr_t *svr, int cycle, int buffsize, int *strs,
 *                              cmds[2]=input stream ephem (NULL: no command)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void rtksvrstop(rtksvr_t *svr, const char **cmds)
+void rtksvrstop(rtksvr_t *svr, const char **cmds)
 {
     int i;
     
@@ -1115,7 +1115,7 @@ extern void rtksvrstop(rtksvr_t *svr, const char **cmds)
 *          solopt_t *solopt I  solution options
 * return : status (1:ok 0:error)
 *-----------------------------------------------------------------------------*/
-extern int rtksvropenstr(rtksvr_t *svr, int index, int str, const char *path,
+int rtksvropenstr(rtksvr_t *svr, int index, int str, const char *path,
                          const solopt_t *solopt, const prcopt_t *prcopt)
 {
     tracet(3,"rtksvropenstr: index=%d str=%d path=%s\n",index,str,path);
@@ -1150,7 +1150,7 @@ extern int rtksvropenstr(rtksvr_t *svr, int index, int str, const char *path,
 *                               6:log base station,7:log correction)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void rtksvrclosestr(rtksvr_t *svr, int index)
+void rtksvrclosestr(rtksvr_t *svr, int index)
 {
     tracet(3,"rtksvrclosestr: index=%d\n",index);
     
@@ -1175,8 +1175,8 @@ extern void rtksvrclosestr(rtksvr_t *svr, int index)
 *          int     *vsat    O  valid satellite flag
 * return : number of satellites
 *-----------------------------------------------------------------------------*/
-extern int rtksvrostat(rtksvr_t *svr, int rcv, gtime_t *time, int sat[MAXSAT],
-                       double *az, double *el, double snr[MAXSAT][NFREQ], int vsat[MAXSAT][NFREQ])
+int rtksvrostat(rtksvr_t *svr, int rcv, gtime_t *time, int sat[MAXSAT],
+                double *az, double *el, double snr[MAXSAT][NFREQ], int vsat[MAXSAT][NFREQ])
 {
     tracet(4,"rtksvrostat: rcv=%d\n",rcv);
     
@@ -1208,7 +1208,7 @@ extern int rtksvrostat(rtksvr_t *svr, int rcv, gtime_t *time, int sat[MAXSAT],
 *          char    *msg     O  status messages
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void rtksvrsstat(rtksvr_t *svr, int *sstat, char *msg)
+void rtksvrsstat(rtksvr_t *svr, int *sstat, char *msg)
 {
     int i;
     char s[MAXSTRMSG],*p=msg;
@@ -1229,7 +1229,7 @@ extern void rtksvrsstat(rtksvr_t *svr, int *sstat, char *msg)
 *          char    *comment I  comment string
 * return : status (1:ok 0:error)
 *-----------------------------------------------------------------------------*/
-extern int rtksvrmark(rtksvr_t *svr, const char *name, const char *comment)
+int rtksvrmark(rtksvr_t *svr, const char *name, const char *comment)
 {
     char buff[MAXSOLMSG+1],tstr[40],*p,*q;
     double tow,pos[3];

--- a/src/sbas.c
+++ b/src/sbas.c
@@ -423,7 +423,7 @@ static int decode_sbstype26(const sbsmsg_t *msg, sbsion_t *sbsion)
 *               seph[prn-MINPRNSBS+1]          : sat prn current epehmeris 
 *               seph[prn-MINPRNSBS+1+MAXPRNSBS]: sat prn previous epehmeris 
 *-----------------------------------------------------------------------------*/
-extern int sbsupdatecorr(const sbsmsg_t *msg, nav_t *nav)
+int sbsupdatecorr(const sbsmsg_t *msg, nav_t *nav)
 {
     int type=getbitu(msg->msg,8,6),stat=-1;
     
@@ -544,7 +544,7 @@ static int cmpmsgs(const void *p1, const void *p2)
 *          to read. others are skipped
 *          .sbs, .SBS, .ems, .EMS
 *-----------------------------------------------------------------------------*/
-extern int sbsreadmsgt(const char *file, int sel, gtime_t ts, gtime_t te,
+int sbsreadmsgt(const char *file, int sel, gtime_t ts, gtime_t te,
                        sbs_t *sbs)
 {
     char *efiles[MAXEXFILE]={0},*ext;
@@ -576,7 +576,7 @@ extern int sbsreadmsgt(const char *file, int sel, gtime_t ts, gtime_t te,
     }
     return sbs->n;
 }
-extern int sbsreadmsg(const char *file, int sel, sbs_t *sbs)
+int sbsreadmsg(const char *file, int sel, sbs_t *sbs)
 {
     gtime_t ts={0},te={0};
     
@@ -590,7 +590,7 @@ extern int sbsreadmsg(const char *file, int sel, sbs_t *sbs)
 *          sbsmsg_t *sbsmsg I   sbas messages
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void sbsoutmsg(FILE *fp, sbsmsg_t *sbsmsg)
+void sbsoutmsg(FILE *fp, sbsmsg_t *sbsmsg)
 {
     int i,prn=sbsmsg->prn,type=sbsmsg->msg[1]>>2;
     
@@ -667,7 +667,7 @@ static void searchigp(gtime_t time, const double *pos, const sbsion_t *ion,
 *          in navigation data (nav->sbsion) must be set by callig 
 *          sbsupdatecorr()
 *-----------------------------------------------------------------------------*/
-extern int sbsioncorr(gtime_t time, const nav_t *nav, const double *pos,
+int sbsioncorr(gtime_t time, const nav_t *nav, const double *pos,
                       const double *azel, double *delay, double *var)
 {
     const double re=6378.1363,hion=350.0;
@@ -753,7 +753,7 @@ static void getmet(double lat, double *met)
  *          double   *var    O   variance of tropospheric error (m^2)
  * Return : slant tropospheric delay (m)
  *----------------------------------------------------------------------------*/
-extern double sbstropcorr(gtime_t time, const double *pos, const double *azel, double *var) {
+double sbstropcorr(gtime_t time, const double *pos, const double *azel, double *var) {
   const double k1 = 77.604, k2 = 382000.0, rd = 287.054, gm = 9.784, g = 9.80665;
 
   trace(4, "sbstropcorr: pos=%.3f %.3f azel=%.3f %.3f\n", pos[0] * R2D, pos[1] * R2D, azel[0] * R2D,
@@ -867,7 +867,7 @@ static int sbsfastcorr(gtime_t time, int sat, const sbssat_t *sbssat,
 *          sbas clock correction is usually based on L1C/A code. TGD or DCB has
 *          to be considered for other codes
 *-----------------------------------------------------------------------------*/
-extern int sbssatcorr(gtime_t time, int sat, const nav_t *nav, double *rs,
+int sbssatcorr(gtime_t time, int sat, const nav_t *nav, double *rs,
                       double *dts, double *var)
 {
     double drs[3]={0},dclk=0.0,prc=0.0;
@@ -900,7 +900,7 @@ extern int sbssatcorr(gtime_t time, int sat, const nav_t *nav, double *rs,
 *          sbsmsg_t *sbsmsg O   sbas message
 * return : status (1:ok,0:crc error)
 *-----------------------------------------------------------------------------*/
-extern int sbsdecodemsg(gtime_t time, int prn, const uint32_t *words,
+int sbsdecodemsg(gtime_t time, int prn, const uint32_t *words,
                         sbsmsg_t *sbsmsg)
 {
     int i,j;

--- a/src/solution.c
+++ b/src/solution.c
@@ -784,7 +784,7 @@ static void readsolopt(FILE *fp, solopt_t *opt)
 *          solbuf_t *solbuf IO solution buffer
 * return : status (1:solution received,0:no solution,-1:disconnect received)
 *-----------------------------------------------------------------------------*/
-extern int inputsol(uint8_t data, gtime_t ts, gtime_t te, double tint,
+int inputsol(uint8_t data, gtime_t ts, gtime_t te, double tint,
                     int qflag, const solopt_t *opt, solbuf_t *solbuf)
 {
     sol_t sol={{0}};
@@ -875,7 +875,7 @@ static int sort_solbuf(solbuf_t *solbuf)
 *          solbuf_t *solbuf O  solution buffer
 * return : status (1:ok,0:no data or error)
 *-----------------------------------------------------------------------------*/
-extern int readsolt(const char *files[], int nfile, gtime_t ts, gtime_t te,
+int readsolt(const char *files[], int nfile, gtime_t ts, gtime_t te,
                     double tint, int qflag, int mean, solbuf_t *solbuf)
 {
     FILE *fp;
@@ -923,7 +923,7 @@ extern int readsolt(const char *files[], int nfile, gtime_t ts, gtime_t te,
     }
     return sort_solbuf(solbuf);
 }
-extern int readsol(const char *files[], int nfile, solbuf_t *sol)
+int readsol(const char *files[], int nfile, solbuf_t *sol)
 {
     gtime_t time={0};
     
@@ -937,7 +937,7 @@ extern int readsol(const char *files[], int nfile, solbuf_t *sol)
 *          sol_t  *sol      I  solution data
 * return : status (1:ok,0:error)
 *-----------------------------------------------------------------------------*/
-extern int addsol(solbuf_t *solbuf, const sol_t *sol)
+int addsol(solbuf_t *solbuf, const sol_t *sol)
 {
     sol_t *solbuf_data;
     
@@ -972,7 +972,7 @@ extern int addsol(solbuf_t *solbuf, const sol_t *sol)
 *          int    index     I  index of solution (0...)
 * return : solution data pointer (NULL: no solution, out of range)
 *-----------------------------------------------------------------------------*/
-extern sol_t *getsol(solbuf_t *solbuf, int index)
+sol_t *getsol(solbuf_t *solbuf, int index)
 {
     trace(4,"getsol: index=%d\n",index);
     
@@ -989,7 +989,7 @@ extern sol_t *getsol(solbuf_t *solbuf, int index)
 *          int    nmax      I  initial number of solution data
 * return : status (1:ok,0:error)
 *-----------------------------------------------------------------------------*/
-extern void initsolbuf(solbuf_t *solbuf, int cyclic, int nmax)
+void initsolbuf(solbuf_t *solbuf, int cyclic, int nmax)
 {
     int i;
     
@@ -1019,7 +1019,7 @@ extern void initsolbuf(solbuf_t *solbuf, int cyclic, int nmax)
 * args   : solbuf_t *solbuf I  solution buffer
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void freesolbuf(solbuf_t *solbuf)
+void freesolbuf(solbuf_t *solbuf)
 {
     int i;
     
@@ -1032,7 +1032,7 @@ extern void freesolbuf(solbuf_t *solbuf)
         solbuf->rb[i]=0.0;
     }
 }
-extern void freesolstatbuf(solstatbuf_t *solstatbuf)
+void freesolstatbuf(solstatbuf_t *solstatbuf)
 {
     trace(3,"freesolstatbuf: n=%d\n",solstatbuf->n);
     
@@ -1164,7 +1164,7 @@ static int readsolstatdata(FILE *fp, gtime_t ts, gtime_t te, double tint,
 *          solstatbuf_t *statbuf O  solution status buffer
 * return : status (1:ok,0:no data or error)
 *-----------------------------------------------------------------------------*/
-extern int readsolstatt(const char *files[], int nfile, gtime_t ts, gtime_t te,
+int readsolstatt(const char *files[], int nfile, gtime_t ts, gtime_t te,
                         double tint, solstatbuf_t *statbuf)
 {
     FILE *fp;
@@ -1195,7 +1195,7 @@ extern int readsolstatt(const char *files[], int nfile, gtime_t ts, gtime_t te,
     }
     return sort_solstat(statbuf);
 }
-extern int readsolstat(const char *files[], int nfile, solstatbuf_t *statbuf)
+int readsolstat(const char *files[], int nfile, solstatbuf_t *statbuf)
 {
     gtime_t time={0};
     
@@ -1299,7 +1299,7 @@ static int outenu(uint8_t *buff, const char *s, const sol_t *sol,
     return (int)(p-(char *)buff);
 }
 /* output solution in the form of NMEA RMC sentence --------------------------*/
-extern int outnmea_rmc(uint8_t *buff, const sol_t *sol)
+int outnmea_rmc(uint8_t *buff, const sol_t *sol)
 {
     static double dirp=0.0;
     gtime_t time;
@@ -1344,7 +1344,7 @@ extern int outnmea_rmc(uint8_t *buff, const sol_t *sol)
     return (int)(p-(char *)buff);
 }
 /* output solution in the form of NMEA GGA sentence --------------------------*/
-extern int outnmea_gga(uint8_t *buff, const sol_t *sol)
+int outnmea_gga(uint8_t *buff, const sol_t *sol)
 {
     gtime_t time;
     double h,ep[6],pos[3],dms1[3],dms2[3],dop=1.0;
@@ -1378,7 +1378,7 @@ extern int outnmea_gga(uint8_t *buff, const sol_t *sol)
     return (int)(p-(char *)buff);
 }
 // Output NMEA GST sentence (Estimated error in position) ----------------------
-extern int outnmea_gst(uint8_t *buff, const sol_t *sol)
+int outnmea_gst(uint8_t *buff, const sol_t *sol)
 {
     trace(3,"outnmea_gst:\n");
 
@@ -1443,7 +1443,7 @@ extern int outnmea_gst(uint8_t *buff, const sol_t *sol)
     return (int)(p - (char *)buff);
 }
 /* output solution in the form of NMEA GSA sentences -------------------------*/
-extern int outnmea_gsa(uint8_t *buff, const sol_t *sol, const ssat_t *ssat)
+int outnmea_gsa(uint8_t *buff, const sol_t *sol, const ssat_t *ssat)
 {
     double azel[MAXSAT*2],dop[4];
     char *p=(char *)buff,*q,*s,sum;
@@ -1491,7 +1491,7 @@ extern int outnmea_gsa(uint8_t *buff, const sol_t *sol, const ssat_t *ssat)
     return (int)(p-(char *)buff);
 }
 /* output solution in the form of NMEA GSV sentences -------------------------*/
-extern int outnmea_gsv(uint8_t *buff, const sol_t *sol, const ssat_t *ssat)
+int outnmea_gsv(uint8_t *buff, const sol_t *sol, const ssat_t *ssat)
 {
     (void)sol;
     double az,el,snr;
@@ -1536,7 +1536,7 @@ extern int outnmea_gsv(uint8_t *buff, const sol_t *sol, const ssat_t *ssat)
 *          prcopt_t *opt    I   processing options
 * return : number of output bytes
 *-----------------------------------------------------------------------------*/
-extern int outprcopts(uint8_t *buff, const prcopt_t *opt)
+int outprcopts(uint8_t *buff, const prcopt_t *opt)
 {
     const int sys[]={
         SYS_GPS,SYS_GLO,SYS_GAL,SYS_QZS,SYS_CMP,SYS_IRN,SYS_SBS,0
@@ -1630,7 +1630,7 @@ extern int outprcopts(uint8_t *buff, const prcopt_t *opt)
 *          solopt_t *opt    I   solution options
 * return : number of output bytes
 *-----------------------------------------------------------------------------*/
-extern int outsolheads(uint8_t *buff, const solopt_t *opt)
+int outsolheads(uint8_t *buff, const solopt_t *opt)
 {
     const char *s1[]={"WGS84","Tokyo"},*s2[]={"ellipsoidal","geodetic"};
     const char *s3[]={"GPST","UTC ","JST "},*sep=opt2sep(opt);
@@ -1722,7 +1722,7 @@ static double sol_std(const sol_t *sol)
 *          solopt_t *opt    I   solution options
 * return : number of output bytes
 *-----------------------------------------------------------------------------*/
-extern int outsols(uint8_t *buff, const sol_t *sol, const double *rb,
+int outsols(uint8_t *buff, const sol_t *sol, const double *rb,
                    const solopt_t *opt)
 {
     gtime_t time,ts={0};
@@ -1780,7 +1780,7 @@ extern int outsols(uint8_t *buff, const sol_t *sol, const double *rb,
 * return : number of output bytes
 * notes  : only support nmea
 *-----------------------------------------------------------------------------*/
-extern int outsolexs(uint8_t *buff, const sol_t *sol, const ssat_t *ssat,
+int outsolexs(uint8_t *buff, const sol_t *sol, const ssat_t *ssat,
                      const solopt_t *opt)
 {
     gtime_t ts={0};
@@ -1806,7 +1806,7 @@ extern int outsolexs(uint8_t *buff, const sol_t *sol, const ssat_t *ssat,
 *          prcopt_t *opt    I   processing options
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void outprcopt(FILE *fp, const prcopt_t *opt)
+void outprcopt(FILE *fp, const prcopt_t *opt)
 {
     uint8_t buff[MAXSOLMSG+1];
     int n;
@@ -1823,7 +1823,7 @@ extern void outprcopt(FILE *fp, const prcopt_t *opt)
 *          solopt_t *opt    I   solution options
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void outsolhead(FILE *fp, const solopt_t *opt)
+void outsolhead(FILE *fp, const solopt_t *opt)
 {
     uint8_t buff[MAXSOLMSG+1];
     int n;
@@ -1842,7 +1842,7 @@ extern void outsolhead(FILE *fp, const solopt_t *opt)
 *          solopt_t *opt    I   solution options
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void outsol(FILE *fp, const sol_t *sol, const double *rb,
+void outsol(FILE *fp, const sol_t *sol, const double *rb,
                    const solopt_t *opt)
 {
     uint8_t buff[MAXSOLMSG+1];
@@ -1863,7 +1863,7 @@ extern void outsol(FILE *fp, const sol_t *sol, const double *rb,
 * return : output size (bytes)
 * notes  : only support nmea
 *-----------------------------------------------------------------------------*/
-extern void outsolex(FILE *fp, const sol_t *sol, const ssat_t *ssat,
+void outsolex(FILE *fp, const sol_t *sol, const ssat_t *ssat,
                      const solopt_t *opt)
 {
     uint8_t buff[MAXSOLMSG+1];

--- a/src/stream.c
+++ b/src/stream.c
@@ -2662,7 +2662,7 @@ static int statexmembuf(membuf_t *membuf, char *msg)
 * args   : none
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strinitcom(void)
+void strinitcom(void)
 {
 #ifdef WIN32
     WSADATA data;
@@ -2678,7 +2678,7 @@ extern void strinitcom(void)
 * args   : stream_t *stream IO  stream
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strinit(stream_t *stream)
+void strinit(stream_t *stream)
 {
     tracet(3,"strinit:\n");
     
@@ -2802,7 +2802,7 @@ extern void strinit(stream_t *stream)
 *                    tret  = download retry interval (s) (0:no retry)
 *
 *-----------------------------------------------------------------------------*/
-extern int stropen(stream_t *stream, int type, int mode, const char *path)
+int stropen(stream_t *stream, int type, int mode, const char *path)
 {
     tracet(3,"stropen: type=%d mode=%d path=%s\n",type,mode,path);
     
@@ -2837,7 +2837,7 @@ extern int stropen(stream_t *stream, int type, int mode, const char *path)
 * args   : stream_t *stream IO  stream
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strclose(stream_t *stream)
+void strclose(stream_t *stream)
 {
     tracet(3,"strclose: type=%d mode=%d\n",stream->type,stream->mode);
     
@@ -2879,7 +2879,7 @@ extern void strclose(stream_t *stream)
 * return : none
 * notes  : for replay files with time tags
 *-----------------------------------------------------------------------------*/
-extern void strsync(stream_t *stream1, stream_t *stream2)
+void strsync(stream_t *stream1, stream_t *stream2)
 {
     file_t *file1,*file2;
     if (stream1->type!=STR_FILE||stream2->type!=STR_FILE) return;
@@ -2892,8 +2892,8 @@ extern void strsync(stream_t *stream1, stream_t *stream2)
 * args   : stream_t *stream I  stream
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strlock  (stream_t *stream) {rtklib_lock  (&stream->lock);}
-extern void strunlock(stream_t *stream) {rtklib_unlock(&stream->lock);}
+void strlock  (stream_t *stream) {rtklib_lock  (&stream->lock);}
+void strunlock(stream_t *stream) {rtklib_unlock(&stream->lock);}
 
 /* read stream -----------------------------------------------------------------
 * read data from stream (unblocked)
@@ -2903,7 +2903,7 @@ extern void strunlock(stream_t *stream) {rtklib_unlock(&stream->lock);}
 * return : read data length
 * notes  : if no data, return immediately with no data
 *-----------------------------------------------------------------------------*/
-extern int strread(stream_t *stream, uint8_t *buff, int n)
+int strread(stream_t *stream, uint8_t *buff, int n)
 {
     uint32_t tick=tickget();
     char *msg=stream->msg;
@@ -2953,7 +2953,7 @@ extern int strread(stream_t *stream, uint8_t *buff, int n)
 * return : status (0:error,1:ok)
 * notes  : write data to buffer and return immediately
 *-----------------------------------------------------------------------------*/
-extern int strwrite(stream_t *stream, uint8_t *buff, int n)
+int strwrite(stream_t *stream, uint8_t *buff, int n)
 {
     uint32_t tick=tickget();
     char *msg=stream->msg;
@@ -3001,7 +3001,7 @@ extern int strwrite(stream_t *stream, uint8_t *buff, int n)
 *          char   *msg      IO  status message (NULL: no output)
 * return : status (-1:error,0:close,1:wait,2:connect,3:active)
 *-----------------------------------------------------------------------------*/
-extern int strstat(stream_t *stream, char *msg)
+int strstat(stream_t *stream, char *msg)
 {
     int state=0;
     
@@ -3042,7 +3042,7 @@ extern int strstat(stream_t *stream, char *msg)
 *          char   *msg      IO  extended status message
 * return : status (-1:error,0:close,1:wait,2:connect,3:active)
 *-----------------------------------------------------------------------------*/
-extern int strstatx(stream_t *stream, char *msg)
+int strstatx(stream_t *stream, char *msg)
 {
     int state=0;
     
@@ -3085,7 +3085,7 @@ extern int strstatx(stream_t *stream, char *msg)
 *          int    *outr     IO   bps of output   (NULL: no output)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strsum(stream_t *stream, int *inb, int *inr, int *outb, int *outr)
+void strsum(stream_t *stream, int *inb, int *inr, int *outb, int *outr)
 {
     tracet(4,"strsum:\n");
     
@@ -3109,7 +3109,7 @@ extern void strsum(stream_t *stream, int *inb, int *inr, int *outb, int *outr)
 *              opt[7]= reserved
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strsetopt(const int *opt)
+void strsetopt(const int *opt)
 {
     tracet(3,"strsetopt: opt=%d %d %d %d %d %d %d %d\n",opt[0],opt[1],opt[2],
            opt[3],opt[4],opt[5],opt[6],opt[7]);
@@ -3127,7 +3127,7 @@ extern void strsetopt(const int *opt)
 *          int     tirecon  I   reconnect interval (ms) (0: no reconnect)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strsettimeout(stream_t *stream, int toinact, int tirecon)
+void strsettimeout(stream_t *stream, int toinact, int tirecon)
 {
     tcpcli_t *tcpcli;
     
@@ -3149,7 +3149,7 @@ extern void strsettimeout(stream_t *stream, int toinact, int tirecon)
 * args   : char   *dir      I   directory for download files
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strsetdir(const char *dir)
+void strsetdir(const char *dir)
 {
     tracet(3,"strsetdir: dir=%s\n",dir);
     
@@ -3160,7 +3160,7 @@ extern void strsetdir(const char *dir)
 * args   : char   *addr     I   http/ntrip proxy address <address>:<port>
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strsetproxy(const char *addr)
+void strsetproxy(const char *addr)
 {
     tracet(3,"strsetproxy: addr=%s\n",addr);
     
@@ -3171,7 +3171,7 @@ extern void strsetproxy(const char *addr)
 * args   : stream_t *stream I   stream
 * return : current time or replay time for playback file
 *-----------------------------------------------------------------------------*/
-extern gtime_t strgettime(stream_t *stream)
+gtime_t strgettime(stream_t *stream)
 {
     file_t *file;
     if (stream->type==STR_FILE&&(stream->mode&STR_MODE_R)&&
@@ -3186,7 +3186,7 @@ extern gtime_t strgettime(stream_t *stream)
 *          sol_t *sol       I   solution
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strsendnmea(stream_t *stream, const sol_t *sol)
+void strsendnmea(stream_t *stream, const sol_t *sol)
 {
     uint8_t buff[1024];
     int n;
@@ -3242,7 +3242,7 @@ static int set_brate(stream_t *str, int brate)
 *          char   *cmd      I   receiver command strings
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strsendcmd(stream_t *str, const char *cmd)
+void strsendcmd(stream_t *str, const char *cmd)
 {
     uint8_t buff[1024];
     const char *p=cmd,*q;

--- a/src/stream.c
+++ b/src/stream.c
@@ -2689,7 +2689,7 @@ static int statexmembuf(const membuf_t *membuf, char *msg)
 * args   : none
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strinitcom(void)
+void strinitcom(void)
 {
 #ifdef WIN32
     WSADATA data;
@@ -2705,7 +2705,7 @@ extern void strinitcom(void)
 * args   : stream_t *stream IO  stream
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strinit(stream_t *stream)
+void strinit(stream_t *stream)
 {
     tracet(3,"strinit:\n");
     
@@ -2829,7 +2829,7 @@ extern void strinit(stream_t *stream)
 *                    tret  = download retry interval (s) (0:no retry)
 *
 *-----------------------------------------------------------------------------*/
-extern int stropen(stream_t *stream, int type, int mode, const char *path)
+int stropen(stream_t *stream, int type, int mode, const char *path)
 {
     tracet(3,"stropen: type=%d mode=%d path=%s\n",type,mode,path);
     
@@ -2864,7 +2864,7 @@ extern int stropen(stream_t *stream, int type, int mode, const char *path)
 * args   : stream_t *stream IO  stream
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strclose(stream_t *stream)
+void strclose(stream_t *stream)
 {
     tracet(3,"strclose: type=%d mode=%d\n",stream->type,stream->mode);
     
@@ -2906,7 +2906,7 @@ extern void strclose(stream_t *stream)
 * return : none
 * notes  : for replay files with time tags
 *-----------------------------------------------------------------------------*/
-extern void strsync(stream_t *stream1, stream_t *stream2)
+void strsync(stream_t *stream1, stream_t *stream2)
 {
     file_t *file1,*file2;
     if (stream1->type!=STR_FILE||stream2->type!=STR_FILE) return;
@@ -2919,8 +2919,8 @@ extern void strsync(stream_t *stream1, stream_t *stream2)
 * args   : stream_t *stream I  stream
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strlock  (stream_t *stream) {rtklib_lock  (&stream->lock);}
-extern void strunlock(stream_t *stream) {rtklib_unlock(&stream->lock);}
+void strlock  (stream_t *stream) {rtklib_lock  (&stream->lock);}
+void strunlock(stream_t *stream) {rtklib_unlock(&stream->lock);}
 
 /* read stream -----------------------------------------------------------------
 * read data from stream (unblocked)
@@ -2930,7 +2930,7 @@ extern void strunlock(stream_t *stream) {rtklib_unlock(&stream->lock);}
 * return : read data length
 * notes  : if no data, return immediately with no data
 *-----------------------------------------------------------------------------*/
-extern int strread(stream_t *stream, uint8_t *buff, int n)
+int strread(stream_t *stream, uint8_t *buff, int n)
 {
     uint32_t tick=tickget();
     char *msg=stream->msg;
@@ -2980,7 +2980,7 @@ extern int strread(stream_t *stream, uint8_t *buff, int n)
 * return : status (0:error,1:ok)
 * notes  : write data to buffer and return immediately
 *-----------------------------------------------------------------------------*/
-extern int strwrite(stream_t *stream, const uint8_t *buff, int n)
+int strwrite(stream_t *stream, const uint8_t *buff, int n)
 {
     uint32_t tick=tickget();
     char *msg=stream->msg;
@@ -3028,7 +3028,7 @@ extern int strwrite(stream_t *stream, const uint8_t *buff, int n)
 *          char   *msg      IO  status message (NULL: no output)
 * return : status (-1:error,0:close,1:wait,2:connect,3:active)
 *-----------------------------------------------------------------------------*/
-extern int strstat(stream_t *stream, char *msg)
+int strstat(stream_t *stream, char *msg)
 {
     int state=0;
     
@@ -3069,7 +3069,7 @@ extern int strstat(stream_t *stream, char *msg)
 *          char   *msg      IO  extended status message
 * return : status (-1:error,0:close,1:wait,2:connect,3:active)
 *-----------------------------------------------------------------------------*/
-extern int strstatx(stream_t *stream, char *msg)
+int strstatx(stream_t *stream, char *msg)
 {
     int state=0;
     
@@ -3112,7 +3112,7 @@ extern int strstatx(stream_t *stream, char *msg)
 *          int    *outr     IO   bps of output   (NULL: no output)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strsum(stream_t *stream, int *inb, int *inr, int *outb, int *outr)
+void strsum(stream_t *stream, int *inb, int *inr, int *outb, int *outr)
 {
     tracet(4,"strsum:\n");
     
@@ -3136,7 +3136,7 @@ extern void strsum(stream_t *stream, int *inb, int *inr, int *outb, int *outr)
 *              opt[7]= reserved
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strsetopt(const int *opt)
+void strsetopt(const int *opt)
 {
     tracet(3,"strsetopt: opt=%d %d %d %d %d %d %d %d\n",opt[0],opt[1],opt[2],
            opt[3],opt[4],opt[5],opt[6],opt[7]);
@@ -3154,7 +3154,7 @@ extern void strsetopt(const int *opt)
 *          int     tirecon  I   reconnect interval (ms) (0: no reconnect)
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strsettimeout(stream_t *stream, int toinact, int tirecon)
+void strsettimeout(stream_t *stream, int toinact, int tirecon)
 {
     tcpcli_t *tcpcli;
     
@@ -3176,7 +3176,7 @@ extern void strsettimeout(stream_t *stream, int toinact, int tirecon)
 * args   : char   *dir      I   directory for download files
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strsetdir(const char *dir)
+void strsetdir(const char *dir)
 {
     tracet(3,"strsetdir: dir=%s\n",dir);
     
@@ -3187,7 +3187,7 @@ extern void strsetdir(const char *dir)
 * args   : char   *addr     I   http/ntrip proxy address <address>:<port>
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strsetproxy(const char *addr)
+void strsetproxy(const char *addr)
 {
     tracet(3,"strsetproxy: addr=%s\n",addr);
     
@@ -3198,7 +3198,7 @@ extern void strsetproxy(const char *addr)
 * args   : stream_t *stream I   stream
 * return : current time or replay time for playback file
 *-----------------------------------------------------------------------------*/
-extern gtime_t strgettime(stream_t *stream)
+gtime_t strgettime(stream_t *stream)
 {
     file_t *file;
     if (stream->type==STR_FILE&&(stream->mode&STR_MODE_R)&&
@@ -3213,7 +3213,7 @@ extern gtime_t strgettime(stream_t *stream)
 *          sol_t *sol       I   solution
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strsendnmea(stream_t *stream, const sol_t *sol)
+void strsendnmea(stream_t *stream, const sol_t *sol)
 {
     uint8_t buff[1024];
     int n;
@@ -3269,7 +3269,7 @@ static int set_brate(stream_t *str, int brate)
 *          char   *cmd      I   receiver command strings
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strsendcmd(stream_t *str, const char *cmd)
+void strsendcmd(stream_t *str, const char *cmd)
 {
     uint8_t buff[1024];
     const char *p=cmd,*q;

--- a/src/streamsvr.c
+++ b/src/streamsvr.c
@@ -71,7 +71,7 @@ static int is_tint(gtime_t time, double tint)
 *          char   *opt      I   rtcm or receiver raw options
 * return : stream generator (NULL:error)
 *-----------------------------------------------------------------------------*/
-extern strconv_t *strconvnew(int itype, int otype, const char *msgs, int staid,
+strconv_t *strconvnew(int itype, int otype, const char *msgs, int staid,
                              int stasel, const char *opt)
 {
     strconv_t *conv;
@@ -120,7 +120,7 @@ extern strconv_t *strconvnew(int itype, int otype, const char *msgs, int staid,
 * args   : strconv_t *conv  IO  stream converter
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strconvfree(strconv_t *conv)
+void strconvfree(strconv_t *conv)
 {
     if (!conv) return;
     free_rtcm(&conv->rtcm);
@@ -566,7 +566,7 @@ static void *strsvrthread(void *arg)
 *          int    nout      I   number of output streams
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strsvrinit(strsvr_t *svr, int nout)
+void strsvrinit(strsvr_t *svr, int nout)
 {
     int i;
     
@@ -639,7 +639,7 @@ extern void strsvrinit(strsvr_t *svr, int nout)
 *          double *nmeapos  I   nmea request position (ecef) (m) (NULL: no)
 * return : status (0:error,1:ok)
 *-----------------------------------------------------------------------------*/
-extern int strsvrstart(strsvr_t *svr, int *opts, int *strs, const char **paths,
+int strsvrstart(strsvr_t *svr, int *opts, int *strs, const char **paths,
                        const char **logs, strconv_t **conv, const char **cmds,
                        const char **cmds_periodic, const double *nmeapos)
 {
@@ -733,7 +733,7 @@ extern int strsvrstart(strsvr_t *svr, int *opts, int *strs, const char **paths,
 *              ...
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strsvrstop(strsvr_t *svr, const char **cmds)
+void strsvrstop(strsvr_t *svr, const char **cmds)
 {
     int i;
     
@@ -761,7 +761,7 @@ extern void strsvrstop(strsvr_t *svr, const char **cmds)
 *          char   *msg      O   messages
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strsvrstat(strsvr_t *svr, int *stat, int *log_stat, int *byte,
+void strsvrstat(strsvr_t *svr, int *stat, int *log_stat, int *byte,
                        int *bps, char *msg)
 {
     char s[MAXSTRMSG]="",*p=msg;
@@ -788,7 +788,7 @@ extern void strsvrstat(strsvr_t *svr, int *stat, int *log_stat, int *byte,
 *          int    nmax      I   buffer size (bytes)
 * return : stream size (bytes)
 *-----------------------------------------------------------------------------*/
-extern int strsvrpeek(strsvr_t *svr, uint8_t *buff, int nmax)
+int strsvrpeek(strsvr_t *svr, uint8_t *buff, int nmax)
 {
     int n;
     

--- a/src/tides.c
+++ b/src/tides.c
@@ -958,7 +958,7 @@ static void tide_pole(gtime_t tutc, const double *pos, const double *erpv, doubl
 * Notes  : see ref [1], [2] chap 7
 *          see ref [4] 5.2.1, 5.2.2, 5.2.3
 *-----------------------------------------------------------------------------*/
-extern void tidedisp(gtime_t tutc, const double *rr, int opt, const erp_t *erp,
+void tidedisp(gtime_t tutc, const double *rr, int opt, const erp_t *erp,
                      const double odisp[2][11][3], double *dr) {
   char tstr[40];
   trace(3, "tidedisp: tutc=%s\n", time2str(tutc, tstr, 0));

--- a/src/tle.c
+++ b/src/tle.c
@@ -385,7 +385,7 @@ static int cmp_tle_data(const void *p1, const void *p2)
 *          name + TLE) format.
 *          the characters after # in a line are treated as comments.
 *-----------------------------------------------------------------------------*/
-extern int tle_read(const char *file, tle_t *tle)
+int tle_read(const char *file, tle_t *tle)
 {
     FILE *fp;
     tled_t data={{0}};
@@ -453,7 +453,7 @@ extern int tle_read(const char *file, tle_t *tle)
 *            satno: satellite catalog number
 *            desig: international designator (optional)
 *-----------------------------------------------------------------------------*/
-extern int tle_name_read(const char *file, tle_t *tle)
+int tle_name_read(const char *file, tle_t *tle)
 {
     FILE *fp;
     tled_t data;
@@ -513,7 +513,7 @@ extern int tle_name_read(const char *file, tle_t *tle)
 * notes  : the coordinates of the position and velocity are ECEF (ITRF)
 *          if erp == NULL, polar motion and ut1-utc are neglected
 *-----------------------------------------------------------------------------*/
-extern int tle_pos(gtime_t time, const char *name, const char *satno,
+int tle_pos(gtime_t time, const char *name, const char *satno,
                    const char *desig, const tle_t *tle, const erp_t *erp,
                    double *rs)
 {

--- a/src/trace.c
+++ b/src/trace.c
@@ -34,7 +34,7 @@ static void traceswap(void)
     }
     rtklib_unlock(&lock_trace);
 }
-extern void traceopen(const char *file)
+void traceopen(const char *file)
 {
     gtime_t time = utc2gpst(timeget());
     char path[1024];
@@ -46,15 +46,15 @@ extern void traceopen(const char *file)
     time_trace = time;
     rtklib_initlock(&lock_trace);
 }
-extern void traceclose(void)
+void traceclose(void)
 {
     if (fp_trace && fp_trace != stderr) fclose(fp_trace);
     fp_trace = NULL;
     file_trace[0] = '\0';
 }
-extern void tracelevel(int level) { level_trace = level; }
-extern int gettracelevel(void) { return level_trace; }
-extern void trace_impl(int level, const char *format, ...)
+void tracelevel(int level) { level_trace = level; }
+int gettracelevel(void) { return level_trace; }
+void trace_impl(int level, const char *format, ...)
 {
     va_list ap;
 
@@ -72,7 +72,7 @@ extern void trace_impl(int level, const char *format, ...)
     va_end(ap);
     fflush(fp_trace);
 }
-extern void tracet_impl(int level, const char *format, ...)
+void tracet_impl(int level, const char *format, ...)
 {
     va_list ap;
 
@@ -84,14 +84,14 @@ extern void tracet_impl(int level, const char *format, ...)
     va_end(ap);
     fflush(fp_trace);
 }
-extern void tracemat_impl(int level, const double *A, int n, int m, int p,
+void tracemat_impl(int level, const double *A, int n, int m, int p,
                           int q)
 {
     if (!fp_trace || level > level_trace) return;
     matfprint(A, n, m, p, q, fp_trace);
     fflush(fp_trace);
 }
-extern void traceobs_impl(int level, const obsd_t *obs, int n)
+void traceobs_impl(int level, const obsd_t *obs, int n)
 {
     char str[40], id[8];
     int i;
@@ -110,7 +110,7 @@ extern void traceobs_impl(int level, const obsd_t *obs, int n)
     }
     fflush(fp_trace);
 }
-extern void tracenav_impl(int level, const nav_t *nav)
+void tracenav_impl(int level, const nav_t *nav)
 {
     char s1[40], s2[40], id[8];
     int i;
@@ -130,7 +130,7 @@ extern void tracenav_impl(int level, const nav_t *nav)
     fprintf(fp_trace, "(ion) %9.4e %9.4e %9.4e %9.4e\n", nav->ion_gal[0],
             nav->ion_gal[1], nav->ion_gal[2], nav->ion_gal[3]);
 }
-extern void tracegnav_impl(int level, const nav_t *nav)
+void tracegnav_impl(int level, const nav_t *nav)
 {
     char s1[40], s2[40], id[8];
     int i;
@@ -145,7 +145,7 @@ extern void tracegnav_impl(int level, const nav_t *nav)
                 nav->geph[i].taun * 1E6);
     }
 }
-extern void tracehnav_impl(int level, const nav_t *nav)
+void tracehnav_impl(int level, const nav_t *nav)
 {
     char s1[40], s2[40], id[8];
     int i;
@@ -159,7 +159,7 @@ extern void tracehnav_impl(int level, const nav_t *nav)
                 nav->seph[i].svh, nav->seph[i].sva);
     }
 }
-extern void tracepeph_impl(int level, const nav_t *nav)
+void tracepeph_impl(int level, const nav_t *nav)
 {
     char s[40], id[8];
     int i, j;
@@ -181,7 +181,7 @@ extern void tracepeph_impl(int level, const nav_t *nav)
         }
     }
 }
-extern void tracepclk_impl(int level, const nav_t *nav)
+void tracepclk_impl(int level, const nav_t *nav)
 {
     char s[40], id[8];
     int i, j;
@@ -198,7 +198,7 @@ extern void tracepclk_impl(int level, const nav_t *nav)
         }
     }
 }
-extern void traceb_impl(int level, const uint8_t *p, int n)
+void traceb_impl(int level, const uint8_t *p, int n)
 {
     int i;
     if (!fp_trace || level > level_trace) return;


### PR DESCRIPTION
Functions are extern by default.

Touches a lot of code so likely to cause merge conflicts, but its a simple change. Might also be useful change to apply before using clang-format as it gives many function declarations a little more usable line length.