### PR TITLE
tcpopedlg qt: trim white space from the STR data

### DIFF
--- a/app/qtapp/appcmn_qt/tcpoptdlg.cpp
+++ b/app/qtapp/appcmn_qt/tcpoptdlg.cpp
@@ -219,7 +219,8 @@ void TcpOptDialog::btnNtripClicked()
     ui->cBMountPoint->clear();
     for (p = buff; (p  = strstr(p, "STR;")); p+=4) {
         if (sscanf(p, "STR;%255[^;]", mntpnt) == 1) {
-            ui->cBMountPoint->addItem(mntpnt, QString(p).split('\n', Qt::SkipEmptyParts).first());
+            QString str = QString(p).split('\n', Qt::SkipEmptyParts).first().trimmed();
+            ui->cBMountPoint->addItem(mntpnt, str);
         }
     }
     btn->setEnabled(true);


### PR DESCRIPTION
After getting the source table for the mount names, it was splitting at the new-line which left a trailing carriage return which was then passed along in the stream path causing issues.