### PR TITLE
raw input streams: remove redundant formats, cleanup

### DIFF
--- a/app/qtapp/rtknavi_qt/mondlg.cpp
+++ b/app/qtapp/rtknavi_qt/mondlg.cpp
@@ -33,14 +33,14 @@ MonitorDialog::MonitorDialog(QWidget *parent, rtksvr_t *server, stream_t* stream
 
     fontScale = QFontMetrics(ui->tWConsole->font()).height() * 4;
 
-    consoleFormat = 1;
+    consoleFormat = 1; // ASCII
     ui->cBSelectFormat->setCurrentIndex(consoleFormat);
     inputStream = solutionStream = 0;
 
     for (int i = 0; i <= MAXRCVFMT; i++) ui->cBSelectFormat->addItem(formatstrs[i]);
 
-	init_rtcm(&rtcm);
-    init_raw(&raw, -1);
+    init_rtcm(&rtcm);
+    memset(&raw, 0, sizeof(raw));
 
     connect(ui->btnClear, &QPushButton::clicked, this, &MonitorDialog::clearOutput);
     connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &MonitorDialog::reject);
@@ -106,14 +106,18 @@ int MonitorDialog::getDisplayType()
 //---------------------------------------------------------------------------
 void MonitorDialog::consoleFormatChanged()
 {
-    if (consoleFormat >= 3 && consoleFormat < 17)
-        free_raw(&raw);
+  if (consoleFormat >= 2) {
+    int fmt = consoleFormat - 2;
+    if (fmt > STRFMT_RTCM3 && fmt < STRFMT_RINEX) free_raw(&raw);
+  }
 
-    // update format marker
-    consoleFormat = ui->cBSelectFormat->currentIndex();
+  // Update format marker.
+  consoleFormat = ui->cBSelectFormat->currentIndex();
 
-    if (consoleFormat >= 3 && consoleFormat < 17)
-        init_raw(&raw, consoleFormat - 2);
+  if (consoleFormat >= 2) {
+    int fmt = consoleFormat - 2;
+    if (fmt > STRFMT_RTCM3 && fmt < STRFMT_RINEX) init_raw(&raw, fmt);
+  }
 }
 //---------------------------------------------------------------------------
 void MonitorDialog::inputStreamChanged()
@@ -285,36 +289,38 @@ void MonitorDialog::showBuffers()
     rtcm.outtype = raw.outtype = 1;
 
     if (displayType >= 17) {
-        addConsole(msg, len, 1, false);
+      addConsole(msg, len, 1, false);
+    } else if (consoleFormat == 0 || consoleFormat == 1) {  // Hex or ASCII.
+      addConsole(msg, len, consoleFormat, false);
+    } else {
+      int fmt = consoleFormat - 2;
+      if (fmt == STRFMT_RTCM2) {
+        for (i = 0; i < len; i++) {
+          input_rtcm2(&rtcm, msg[i]);
+          if (rtcm.msgtype[0]) {
+            addConsole((uint8_t *)rtcm.msgtype, strlen(rtcm.msgtype), 1, true);
+            rtcm.msgtype[0] = '\0';
+          }
+        }
+      } else if (fmt == STRFMT_RTCM3) {
+        for (i = 0; i < len; i++) {
+          input_rtcm3(&rtcm, msg[i]);
+          if (rtcm.msgtype[0]) {
+            addConsole((uint8_t *)rtcm.msgtype, strlen(rtcm.msgtype), 1, true);
+            rtcm.msgtype[0] = '\0';
+          }
+        }
+      } else if (fmt > STRFMT_RTCM3 && fmt < STRFMT_RINEX) {  // Raw
+        for (i = 0; i < len; i++) {
+          input_raw(&raw, msg[i]);
+          if (raw.msgtype[0]) {
+            addConsole((uint8_t *)raw.msgtype, strlen(raw.msgtype), 1, true);
+            raw.msgtype[0] = '\0';
+          }
+        }
+      }
     }
-    else if (consoleFormat < 2) {  // ASCII or HEX
-        addConsole(msg, len, consoleFormat, false);
-    } else if (consoleFormat - 2 == STRFMT_RTCM2) {
-        for (i = 0; i < len; i++) {
-            input_rtcm2(&rtcm, msg[i]);
-			if (rtcm.msgtype[0]) {
-                addConsole((uint8_t*)rtcm.msgtype, strlen(rtcm.msgtype), 1, true);
-                rtcm.msgtype[0] = '\0';
-			}
-        }
-    } else if (consoleFormat - 2 == STRFMT_RTCM3) {
-        for (i = 0; i < len; i++) {
-            input_rtcm3(&rtcm, msg[i]);
-			if (rtcm.msgtype[0]) {
-                addConsole((uint8_t*)rtcm.msgtype, strlen(rtcm.msgtype), 1, true);
-                rtcm.msgtype[0] = '\0';
-			}
-        }
-    } else if (consoleFormat < 17) {
-        for (i = 0; i < len; i++) {
-            input_raw(&raw, consoleFormat - 2, msg[i]);
-			if (raw.msgtype[0]) {
-                addConsole((uint8_t*)raw.msgtype, strlen(raw.msgtype), 1, true);
-                raw.msgtype[0] = '\0';
-			}
-        }
-	}
-	free(msg);
+    free(msg);
 }
 //---------------------------------------------------------------------------
 void MonitorDialog::addConsole(const uint8_t *msg, int n, int mode, bool newline)

--- a/app/qtapp/strsvr_qt/mondlg.cpp
+++ b/app/qtapp/strsvr_qt/mondlg.cpp
@@ -36,63 +36,69 @@ StrMonDialog::StrMonDialog(QWidget *parent)
 //---------------------------------------------------------------------------
 void StrMonDialog::changeFormat()
 {
-    int streamFormat = getStreamFormat();
+  int streamFormat = getStreamFormat();
 
-    if ((streamFormat-3 == STRFMT_RTCM2) || (streamFormat-3 == STRFMT_RTCM3)) {
-        free_rtcm(&rtcm);
-    } else if (streamFormat >= 3) {
-        free_raw(&raw);
+  if (streamFormat >= 3) {
+    int fmt = streamFormat - 3;
+    if (fmt == STRFMT_RTCM2 || fmt == STRFMT_RTCM3)
+      free_rtcm(&rtcm);
+    else if (fmt > STRFMT_RTCM3 && fmt < STRFMT_RINEX)
+      free_raw(&raw);
+  }
+
+  streamFormat = ui->cBSelectFormat->currentIndex();
+  clearConsole();
+
+  if (streamFormat >= 3) {
+    int fmt = streamFormat - 3;
+    if (fmt == STRFMT_RTCM2 || fmt == STRFMT_RTCM3) {
+      init_rtcm(&rtcm);
+      rtcm.outtype = 1;
+    } else if (fmt > STRFMT_RTCM3 && fmt < STRFMT_RINEX) {
+      init_raw(&raw, fmt);
+      raw.outtype = 1;
     }
-
-    streamFormat = ui->cBSelectFormat->currentIndex();
-    clearConsole();
-
-    if ((streamFormat - 3 == STRFMT_RTCM2) || (streamFormat - 3 == STRFMT_RTCM3)) {
-        init_rtcm(&rtcm);
-        rtcm.outtype = 1;
-    } else if (streamFormat >= 3) {
-        init_raw(&raw, streamFormat - 3);
-        raw.outtype = 1;
-    }
+  }
 }
 //---------------------------------------------------------------------------
 void StrMonDialog::addMessage(unsigned char *msg, int len)
 {
-    int streamFormat = getStreamFormat();
-    int i;
+  if (len <= 0) return;
 
-    if (len <= 0) {
-        return;
-    }else if (streamFormat - 3 == STRFMT_RTCM2) {
-        for (i = 0; i < len; i++) {
-            input_rtcm2(&rtcm, msg[i]);
-            if (rtcm.msgtype[0]) {
-                addConsole((unsigned char*)rtcm.msgtype, strlen(rtcm.msgtype), 1, true);
-                rtcm.msgtype[0] = '\0';
-            }
+  int streamFormat = getStreamFormat();
+  if (streamFormat == 0) {  // Streams
+    consoleBuffer.clear();
+    addConsole(msg, len, 1, false);
+  } else if (streamFormat == 1 || streamFormat == 2) {  // Hex or ASCII.
+    addConsole(msg, len, streamFormat - 1, false);
+  } else {
+    int fmt = streamFormat - 3;
+    if (fmt == STRFMT_RTCM2) {
+      for (int i = 0; i < len; i++) {
+        input_rtcm2(&rtcm, msg[i]);
+        if (rtcm.msgtype[0]) {
+          addConsole((unsigned char *)rtcm.msgtype, strlen(rtcm.msgtype), 1, true);
+          rtcm.msgtype[0] = '\0';
         }
-    } else if (streamFormat - 3 == STRFMT_RTCM3) {
-        for (i = 0; i < len; i++) {
-            input_rtcm3(&rtcm, msg[i]);
-            if (rtcm.msgtype[0]) {
-                addConsole((unsigned char*)rtcm.msgtype, strlen(rtcm.msgtype), 1, true);
-                rtcm.msgtype[0] = '\0';
-            }
+      }
+    } else if (fmt == STRFMT_RTCM3) {
+      for (int i = 0; i < len; i++) {
+        input_rtcm3(&rtcm, msg[i]);
+        if (rtcm.msgtype[0]) {
+          addConsole((unsigned char *)rtcm.msgtype, strlen(rtcm.msgtype), 1, true);
+          rtcm.msgtype[0] = '\0';
         }
-    } else if (streamFormat >= 3) { // raw
-        for (i = 0; i < len; i++) {
-            input_raw(&raw, streamFormat - 3, msg[i]);
-            if (raw.msgtype[0]) {
-                addConsole((unsigned char*)raw.msgtype, strlen(raw.msgtype), 1, true);
-                raw.msgtype[0] = '\0';
-            }
+      }
+    } else if (fmt > STRFMT_RTCM3 && fmt < STRFMT_RINEX) {  // Raw
+      for (int i = 0; i < len; i++) {
+        input_raw(&raw, msg[i]);
+        if (raw.msgtype[0]) {
+          addConsole((unsigned char *)raw.msgtype, strlen(raw.msgtype), 1, true);
+          raw.msgtype[0] = '\0';
         }
-    } else if (streamFormat >= 1 ) { // HEX/ASC
-        addConsole(msg, len, streamFormat - 1, false);
-    } else { // Streams
-        consoleBuffer.clear();
-        addConsole(msg, len, 1, false);
+      }
     }
+  }
 }
 //---------------------------------------------------------------------------
 void StrMonDialog::addConsole(unsigned char *msg, int n, int mode, bool newline)

--- a/app/winapp/rtknavi/mondlg.cpp
+++ b/app/winapp/rtknavi/mondlg.cpp
@@ -35,7 +35,7 @@ __fastcall TMonitorDialog::TMonitorDialog(TComponent* Owner)
 	
 	ScrollPos=0;
 	ObsMode=0;
-	ConFmt=-1;
+	ConFmt = 1; // ASCII
 	ConBuff=new TStringList;
 	ConBuff->Add("");
 	DoubleBuffered=true;
@@ -45,7 +45,7 @@ __fastcall TMonitorDialog::TMonitorDialog(TComponent* Owner)
 		SelFmt->Items->Add(formatstrs[i]);
 	}
 	init_rtcm(&rtcm);
-	init_raw(&raw,-1);
+        memset(&raw, 0, sizeof(raw));
 }
 //---------------------------------------------------------------------------
 void __fastcall TMonitorDialog::FormShow(TObject *Sender)
@@ -90,16 +90,17 @@ void __fastcall TMonitorDialog::TypeChange(TObject *Sender)
 //---------------------------------------------------------------------------
 void __fastcall TMonitorDialog::SelFmtChange(TObject *Sender)
 {
-	AddConsole((uint8_t *)"\n",1,1);
-    
-    if (ConFmt>=3&&ConFmt<17) {
-        free_raw(&raw);
-    }
-    ConFmt=SelFmt->ItemIndex;
-    
-    if (ConFmt>=3&&ConFmt<17) {
-        init_raw(&raw,ConFmt-2);
-    }
+  AddConsole((uint8_t *)"\n", 1, 1);
+
+  if (ConFmt >= 2) {
+    int fmt = ConFmt - 2;
+    if (fmt > STRFMT_RTCM3 && fmt < STRFMT_RINEX) free_raw(&raw);
+  }
+  ConFmt = SelFmt->ItemIndex;
+  if (ConFmt >= 2) {
+    int fmt = ConFmt - 2;
+    if (fmt > STRFMT_RTCM3 && fmt < STRFMT_RINEX) init_raw(&raw, fmt);
+  }
 }
 //---------------------------------------------------------------------------
 void __fastcall TMonitorDialog::SelStrChange(TObject *Sender)
@@ -183,79 +184,77 @@ void __fastcall TMonitorDialog::ClearTable(void)
 //---------------------------------------------------------------------------
 void __fastcall TMonitorDialog::Timer2Timer(TObject *Sender)
 {
-	uint8_t *msg;
-	char buff[256];
-	int i,n,len;
-	
-	if (TypeF<16) return;
-	
-	rtksvrlock(&rtksvr);
-	
-	if (TypeF==16) { // input buffer
-		len=rtksvr.npb[Str1];
-		if (len>0&&(msg=(uint8_t *)malloc(len))) {
-			memcpy(msg,rtksvr.pbuf[Str1],len);
-			rtksvr.npb[Str1]=0;
-		}
-	}
-	else if (TypeF==17) { // solution buffer
-		len=rtksvr.nsb[Str2];
-		if (len>0&&(msg=(uint8_t *)malloc(len))) {
-			memcpy(msg,rtksvr.sbuf[Str2],len);
-			rtksvr.nsb[Str2]=0;
-		}
-	}
-	else { // error message buffer
-		len=rtksvr.rtk.neb;
-		if (len>0&&(msg=(uint8_t *)malloc(len))) {
-			memcpy(msg,rtksvr.rtk.errbuf,len);
-			rtksvr.rtk.neb=0;
-		}
-	}
-	rtksvrunlock(&rtksvr);
-	
-	if (len<=0||!msg) return;
-	
-	rtcm.outtype=raw.outtype=1;
-	
-	if (TypeF>=17) {
-		AddConsole(msg,len,1);
-	}
-	else if (ConFmt<2) {
-		AddConsole(msg,len,ConFmt);
-	}
-	else if (ConFmt==2) {
-		for (i=0;i<len;i++) {
-			input_rtcm2(&rtcm,msg[i]);
-			if (rtcm.msgtype[0]) {
-				n=sprintf(buff,"%s\n",rtcm.msgtype);
-				AddConsole((uint8_t *)buff,n,1);
-				rtcm.msgtype[0]='\0';
-			}
-	    }
-	}
-	else if (ConFmt==3) {
-		for (i=0;i<len;i++) {
-			input_rtcm3(&rtcm,msg[i]);
-			if (rtcm.msgtype[0]) {
-				n=sprintf(buff,"%s\n",rtcm.msgtype);
-				AddConsole((uint8_t *)buff,n,1);
-				rtcm.msgtype[0]='\0';
-			}
-	    }
-	}
-	else if (ConFmt<17) {
-		for (i=0;i<len;i++) {
-			input_raw(&raw,ConFmt-2,msg[i]);
-			if (raw.msgtype[0]) {
-				n=sprintf(buff,"%s\n",raw.msgtype);
-				AddConsole((uint8_t *)buff,n,1);
-				raw.msgtype[0]='\0';
-			}
-	    }
-	}
-	free(msg);
-	Console->Invalidate();
+  if (TypeF < 16) return;
+
+  rtksvrlock(&rtksvr);
+
+  int len = 0;
+  uint8_t *msg = NULL;
+  if (TypeF == 16) {  // Input buffer.
+    len = rtksvr.npb[Str1];
+    if (len > 0 && (msg = (uint8_t *)malloc(len))) {
+      memcpy(msg, rtksvr.pbuf[Str1], len);
+      rtksvr.npb[Str1] = 0;
+    }
+  } else if (TypeF == 17) {  // Solution buffer.
+    len = rtksvr.nsb[Str2];
+    if (len > 0 && (msg = (uint8_t *)malloc(len))) {
+      memcpy(msg, rtksvr.sbuf[Str2], len);
+      rtksvr.nsb[Str2] = 0;
+    }
+  } else {  // Error message buffer.
+    len = rtksvr.rtk.neb;
+    if (len > 0 && (msg = (uint8_t *)malloc(len))) {
+      memcpy(msg, rtksvr.rtk.errbuf, len);
+      rtksvr.rtk.neb = 0;
+    }
+  }
+  rtksvrunlock(&rtksvr);
+
+  if (len <= 0 || !msg) return;
+
+  rtcm.outtype = raw.outtype = 1;
+
+  if (TypeF >= 17) {
+    AddConsole(msg, len, 1);
+  } else if (ConFmt == 0 || ConFmt == 1) {  // Hex or ASCII.
+    AddConsole(msg, len, ConFmt);
+  } else {
+    int fmt = ConFmt - 2;
+    if (fmt == STRFMT_RTCM2) {
+      for (int i = 0; i < len; i++) {
+        input_rtcm2(&rtcm, msg[i]);
+        if (rtcm.msgtype[0]) {
+          char buff[256];
+          int n = sprintf(buff, "%s\n", rtcm.msgtype);
+          AddConsole((uint8_t *)buff, n, 1);
+          rtcm.msgtype[0] = '\0';
+        }
+      }
+    } else if (fmt == STRFMT_RTCM3) {
+      for (int i = 0; i < len; i++) {
+        input_rtcm3(&rtcm, msg[i]);
+        if (rtcm.msgtype[0]) {
+          char buff[256];
+          int n = sprintf(buff, "%s\n", rtcm.msgtype);
+          AddConsole((uint8_t *)buff, n, 1);
+          rtcm.msgtype[0] = '\0';
+        }
+      }
+    } else if (fmt < STRFMT_RINEX + 2) {
+      for (int i = 0; i < len; i++) {
+        input_raw(&raw, msg[i]);
+        if (raw.msgtype[0]) {
+          char buff[256];
+          int n = sprintf(buff, "%s\n", raw.msgtype);
+          AddConsole((uint8_t *)buff, n, 1);
+          raw.msgtype[0] = '\0';
+        }
+      }
+    }
+  }
+  free(msg);
+  Console->Invalidate();
 }
 //---------------------------------------------------------------------------
 void __fastcall TMonitorDialog::AddConsole(uint8_t *msg, int len, int mode)

--- a/app/winapp/strsvr/mondlg.cpp
+++ b/app/winapp/strsvr/mondlg.cpp
@@ -52,72 +52,74 @@ void __fastcall TStrMonDialog::BtnCopyClick(TObject *Sender)
 //---------------------------------------------------------------------------
 void __fastcall TStrMonDialog::SelFmtChange(TObject *Sender)
 {
-	if (StrFmt-3==STRFMT_RTCM2||StrFmt-3==STRFMT_RTCM3) {
-		free_rtcm(&rtcm);
-	}
-	else if (StrFmt>=3) {
-		free_raw(&raw);
-	}
-	StrFmt=SelFmt->ItemIndex;
-	ConBuff->Clear();
-	ConBuff->Add("");
-	
-	if (StrFmt-3==STRFMT_RTCM2||StrFmt-3==STRFMT_RTCM3) {
-		init_rtcm(&rtcm);
-		rtcm.outtype=1;
-	}
-	else if (StrFmt>=3) {
-		init_raw(&raw,StrFmt-2);
-		raw.outtype=1;
-	}
-	Console->Invalidate();
+  if (StrFmt >= 3) {
+    int fmt = StrFmt - 3;
+    if (fmt == STRFMT_RTCM2 || fmt == STRFMT_RTCM3)
+      free_rtcm(&rtcm);
+    else if (fmt > STRFMT_RTCM3 && fmt < STRFMT_RINEX)
+      free_raw(&raw);
+  }
+  StrFmt = SelFmt->ItemIndex;
+  ConBuff->Clear();
+  ConBuff->Add("");
+
+  if (StrFmt >= 3) {
+    int fmt = StrFmt - 3;
+    if (fmt == STRFMT_RTCM2 || fmt == STRFMT_RTCM3) {
+      init_rtcm(&rtcm);
+      rtcm.outtype = 1;
+    } else if (fmt > STRFMT_RTCM3 && fmt < STRFMT_RINEX) {
+      init_raw(&raw, fmt);
+      raw.outtype = 1;
+    }
+  }
+  Console->Invalidate();
 }
 //---------------------------------------------------------------------------
 void __fastcall TStrMonDialog::AddMsg(uint8_t *msg, int len)
 {
-	char buff[256];
-	int i,n;
-	
-	if (len<=0) return;
-	
-	else if (StrFmt-3==STRFMT_RTCM2) {
-		for (i=0;i<len;i++) {
-			input_rtcm2(&rtcm,msg[i]);
-			if (rtcm.msgtype[0]) {
-				n=sprintf(buff,"%s\n",rtcm.msgtype);
-				AddConsole((uint8_t *)buff,n,1);
-				rtcm.msgtype[0]='\0';
-			}
-	    }
-	}
-	else if (StrFmt-3==STRFMT_RTCM3) {
-		for (i=0;i<len;i++) {
-			input_rtcm3(&rtcm,msg[i]);
-			if (rtcm.msgtype[0]) {
-				n=sprintf(buff,"%s\n",rtcm.msgtype);
-				AddConsole((uint8_t *)buff,n,1);
-				rtcm.msgtype[0]='\0';
-			}
-	    }
-	}
-	else if (StrFmt>=3) { // raw
-		for (i=0;i<len;i++) {
-			input_raw(&raw,StrFmt-3,msg[i]);
-			if (raw.msgtype[0]) {
-				n=sprintf(buff,"%s\n",raw.msgtype);
-				AddConsole((uint8_t *)buff,n,1);
-				raw.msgtype[0]='\0';
-			}
-	    }
-	}
-	else if (StrFmt>=1) { // HEX/ASC
-		AddConsole(msg,len,StrFmt-1);
-	}
-	else { // Streams
-		ConBuff->Clear();
-		ConBuff->Add("");
-		AddConsole(msg,len,1);
-	}
+  if (len <= 0) return;
+
+  if (StrFmt == 0) {  // Streams.
+    ConBuff->Clear();
+    ConBuff->Add("");
+    AddConsole(msg, len, 1);
+  } else if (StrFmt == 1 || StrFmt == 2) {  // Hex or ASCII.
+    AddConsole(msg, len, StrFmt - 1);
+  } else {
+    int fmt = StrFmt - 3;
+    if (fmt == STRFMT_RTCM2) {
+      for (int i = 0; i < len; i++) {
+        input_rtcm2(&rtcm, msg[i]);
+        if (rtcm.msgtype[0]) {
+          char buff[256];
+          int n = sprintf(buff, "%s\n", rtcm.msgtype);
+          AddConsole((uint8_t *)buff, n, 1);
+          rtcm.msgtype[0] = '\0';
+        }
+      }
+    } else if (fmt == STRFMT_RTCM3) {
+      for (int i = 0; i < len; i++) {
+        input_rtcm3(&rtcm, msg[i]);
+        if (rtcm.msgtype[0]) {
+          char buff[256];
+          int n = sprintf(buff, "%s\n", rtcm.msgtype);
+          AddConsole((uint8_t *)buff, n, 1);
+          rtcm.msgtype[0] = '\0';
+        }
+      }
+    } else if (fmt > STRFMT_RTCM3 && fmt < STRFMT_RINEX) {  // Raw.
+      for (int i = 0; i < len; i++) {
+        input_raw(&raw, msg[i]);
+        if (raw.msgtype[0]) {
+          char buff[256];
+          int n = sprintf(buff, "%s\n", raw.msgtype);
+          AddConsole((uint8_t *)buff, n, 1);
+          raw.msgtype[0] = '\0';
+        }
+      }
+    }
+  }
 }
 //---------------------------------------------------------------------------
 void __fastcall TStrMonDialog::AddConsole(uint8_t *msg, int n, int mode)

--- a/src/convrnx.c
+++ b/src/convrnx.c
@@ -280,7 +280,7 @@ static int input_strfile(strfile_t *str)
         }
     }
     else if (str->format<=MAXRCVFMT) {
-        if ((type=input_rawf(&str->raw,str->format,str->fp))>=1) {
+        if ((type=input_rawf(&str->raw,str->fp))>=1) {
             str->time=str->raw.time;
             str->ephsat=str->raw.ephsat;
             str->ephset=str->raw.ephset;

--- a/src/rcvraw.c
+++ b/src/rcvraw.c
@@ -1329,7 +1329,7 @@ extern int init_raw(raw_t *raw, int format)
     raw->tod=-1;
     for (i=0;i<MAXRAWLEN;i++) raw->buff[i]=0;
     raw->opt[0]='\0';
-    raw->format=-1;
+    raw->format=format;
     raw->rcvtype=0;
     
     raw->obs.data =NULL;
@@ -1380,7 +1380,6 @@ extern int init_raw(raw_t *raw, int format)
     raw->nav.ng = raw->nav.ngmax = MAXPRNGLO;
 
     /* initialize receiver dependent data */
-    raw->format=format;
     switch (format) {
         case STRFMT_RT17: ret=init_rt17(raw); break;
         case STRFMT_SEPT: ret=init_sbf(raw); break;
@@ -1417,14 +1416,14 @@ extern void free_raw(raw_t *raw)
 /* input receiver raw data from stream -----------------------------------------
 * fetch next receiver raw data and input a message from stream
 * args   : raw_t  *raw   IO     receiver raw data control struct
-*          int    format I      receiver raw data format (STRFMT_???)
 *          uint8_t data     I   stream data (1 byte)
 * return : status (-1: error message, 0: no message, 1: input observation data,
 *                  2: input ephemeris, 3: input sbas message,
 *                  9: input ion/utc parameter)
 *-----------------------------------------------------------------------------*/
-extern int input_raw(raw_t *raw, int format, uint8_t data)
+int input_raw(raw_t *raw, uint8_t data)
 {
+    int format = raw->format;
     trace(5,"input_raw: format=%d data=0x%02x\n",format,data);
     
     switch (format) {
@@ -1447,12 +1446,12 @@ extern int input_raw(raw_t *raw, int format, uint8_t data)
 /* input receiver raw data from file -------------------------------------------
 * fetch next receiver raw data and input a message from file
 * args   : raw_t  *raw   IO     receiver raw data control struct
-*          int    format I      receiver raw data format (STRFMT_???)
 *          FILE   *fp    I      file pointer
 * return : status(-2: end of file/format error, -1...31: same as above)
 *-----------------------------------------------------------------------------*/
-extern int input_rawf(raw_t *raw, int format, FILE *fp)
+int input_rawf(raw_t *raw, FILE *fp)
 {
+    int format = raw->format;
     trace(4,"input_rawf: format=%d\n",format);
     
     switch (format) {

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1709,8 +1709,8 @@ EXPORT int decode_irn_nav(const uint8_t *buff, eph_t *eph, double *ion,
 
 EXPORT int init_raw   (raw_t *raw, int format);
 EXPORT void free_raw  (raw_t *raw);
-EXPORT int input_raw  (raw_t *raw, int format, uint8_t data);
-EXPORT int input_rawf (raw_t *raw, int format, FILE *fp);
+EXPORT int input_raw  (raw_t *raw, uint8_t data);
+EXPORT int input_rawf (raw_t *raw, FILE *fp);
 
 EXPORT int init_rt17  (raw_t *raw);
 EXPORT int init_sbf   (raw_t *raw);

--- a/src/rtksvr.c
+++ b/src/rtksvr.c
@@ -426,7 +426,7 @@ static int decoderaw(rtksvr_t *svr, int index)
             ephset=svr->rtcm[index].ephset;
         }
         else {
-            ret=input_raw(svr->raw+index,svr->format[index],svr->buff[index][i]);
+            ret=input_raw(svr->raw+index,svr->buff[index][i]);
             obs=&svr->raw[index].obs;
             nav=&svr->raw[index].nav;
             ephsat=svr->raw[index].ephsat;

--- a/src/streamsvr.c
+++ b/src/streamsvr.c
@@ -440,7 +440,7 @@ static void strconv(stream_t *str, strconv_t *conv, uint8_t *buff, int n)
         }
         /* input receiver raw messages */
         else {
-            ret=input_raw(&conv->raw,conv->itype,buff[i]);
+            ret=input_raw(&conv->raw,buff[i]);
             raw2rtcm(&conv->out,&conv->raw,ret);
         }
         /* write obs and nav data messages to stream */


### PR DESCRIPTION
The input_raw functions need not pass in the format as it is stored in the raw_t structure when initialized and switching the format on each call is not supported so at best it could have been a check.

There were STRFMT_* constants baked into the code which has been reworked to use the definitions. There were a few errors too that were corrected.