### PR TITLE
qt apps: avoid empty file selections

### DIFF
--- a/app/qtapp/appcmn_qt/fileoptdlg.cpp
+++ b/app/qtapp/appcmn_qt/fileoptdlg.cpp
@@ -153,10 +153,12 @@ QString FileOptDialog::getPath()
 //---------------------------------------------------------------------------
 void FileOptDialog::filePathSelect()
 {
+    QString filename;
     if (!options)
-        ui->lEFilePath->setText(QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, QString(), ui->lEFilePath->text())));
+        filename = QFileDialog::getOpenFileName(this, QString(), ui->lEFilePath->text());
     else
-        ui->lEFilePath->setText(QDir::toNativeSeparators(QFileDialog::getSaveFileName(this, QString(), ui->lEFilePath->text())));
+        filename = QFileDialog::getSaveFileName(this, QString(), ui->lEFilePath->text());
+    if (!filename.isEmpty()) ui->lEFilePath->setText(QDir::toNativeSeparators(filename));
 }
 //---------------------------------------------------------------------------
 void FileOptDialog::keyDialogShow()

--- a/app/qtapp/appcmn_qt/refdlg.cpp
+++ b/app/qtapp/appcmn_qt/refdlg.cpp
@@ -73,8 +73,9 @@ void RefDialog::accept()
 //---------------------------------------------------------------------------
 void RefDialog::loadStations()
 {
-    stationPositionFile = QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("Load Station List..."), stationPositionFile, tr("Position File (*.pos *.snx);;All (*.*)")));
-
+    QString filename = QFileDialog::getOpenFileName(this, tr("Load Station List..."), stationPositionFile, tr("Position File (*.pos *.snx);;All (*.*)"));
+    if (filename.isEmpty()) return;
+    stationPositionFile = QDir::toNativeSeparators(filename);
     loadList(stationPositionFile);
 }
 //---------------------------------------------------------------------------

--- a/app/qtapp/appcmn_qt/viewer.cpp
+++ b/app/qtapp/appcmn_qt/viewer.cpp
@@ -57,10 +57,13 @@ void TextViewer::reloadText()
 //---------------------------------------------------------------------------
 void TextViewer::readSaveFile()
 {
-    if (ui->btnReadSave->text() == tr("&Save..."))
-        save(QDir::toNativeSeparators(QFileDialog::getSaveFileName(this, QString(), file)));
-    else
-        read(QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, QString(), file)));
+    if (ui->btnReadSave->text() == tr("&Save...")) {
+        QString filename = QFileDialog::getSaveFileName(this, QString(), file);
+        if (!filename.isEmpty()) save(QDir::toNativeSeparators(filename));
+    } else {
+        QString filename = QFileDialog::getOpenFileName(this, QString(), file);
+        if (!filename.isEmpty()) read(QDir::toNativeSeparators(filename));
+    }
 }
 //---------------------------------------------------------------------------
 void TextViewer::showOptions()

--- a/app/qtapp/rtknavi_qt/logstrdlg.cpp
+++ b/app/qtapp/rtknavi_qt/logstrdlg.cpp
@@ -62,17 +62,20 @@ LogStrDialog::LogStrDialog(QWidget *parent)
 //---------------------------------------------------------------------------
 void LogStrDialog::selectFile1()
 {
-    ui->lEFilePath1->setText(QDir::toNativeSeparators(QFileDialog::getSaveFileName(this, tr("Open..."), ui->lEFilePath1->text())));
+    QString filename = QFileDialog::getSaveFileName(this, tr("Open..."), ui->lEFilePath1->text());
+    if (!filename.isEmpty()) ui->lEFilePath1->setText(QDir::toNativeSeparators(filename));
 }
 //---------------------------------------------------------------------------
 void LogStrDialog::selectFile2()
 {
-    ui->lEFilePath2->setText(QDir::toNativeSeparators(QFileDialog::getSaveFileName(this, tr("Open..."), ui->lEFilePath2->text())));
+    QString filename = QFileDialog::getSaveFileName(this, tr("Open..."), ui->lEFilePath2->text());
+    if (!filename.isEmpty()) ui->lEFilePath2->setText(QDir::toNativeSeparators(filename));
 }
 //---------------------------------------------------------------------------
 void LogStrDialog::selectFile3()
 {
-    ui->lEFilePath3->setText(QDir::toNativeSeparators(QFileDialog::getSaveFileName(this, tr("Open..."), ui->lEFilePath3->text())));
+    QString filename = QFileDialog::getSaveFileName(this, tr("Open..."), ui->lEFilePath3->text());
+    if (!filename.isEmpty()) ui->lEFilePath3->setText(QDir::toNativeSeparators(filename));
 }
 //---------------------------------------------------------------------------
 void LogStrDialog::showKeyDialog()

--- a/app/qtapp/rtkplot_qt/plotmain.cpp
+++ b/app/qtapp/rtkplot_qt/plotmain.cpp
@@ -670,29 +670,29 @@ void Plot::dropEvent(QDropEvent *event)
 void Plot::openSolution1()
 {
     trace(3, "openSolution1\n");
-
-    readSolution(QStringList(QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("Open Solution 1"), solutionFiles[0].value(0), tr("Solution File (*.pos *.stat *.nmea *.nma *.txt *.ubx);;All (*.*)")))), 0);
+    QString filename = QFileDialog::getOpenFileName(this, tr("Open Solution 1"), solutionFiles[0].value(0), tr("Solution File (*.pos *.stat *.nmea *.nma *.txt *.ubx);;All (*.*)"));
+    if (!filename.isEmpty()) readSolution(QStringList(QDir::toNativeSeparators(filename)), 0);
 }
 // callback on menu-open-solution-2 -----------------------------------------
 void Plot::openSolution2()
 {
     trace(3, "openSolution2\n");
-
-    readSolution(QStringList(QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("Open Solution 2"), solutionFiles[1].value(0), tr("Solution File (*.pos *.stat *.nmea *.nma *.txt *.ubx);;All (*.*)")))), 1);
+    QString filename = QFileDialog::getOpenFileName(this, tr("Open Solution 2"), solutionFiles[1].value(0), tr("Solution File (*.pos *.stat *.nmea *.nma *.txt *.ubx);;All (*.*)"));
+    if (!filename.isEmpty()) readSolution(QStringList(QDir::toNativeSeparators(filename)), 1);
 }
 // callback on menu-open-map-image ------------------------------------------
 void Plot::openMapImage()
 {
     trace(3, "openMapImage\n");
-
-    readMapData(QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("Open Map Image"), mapImageFile, tr("JPEG File (*.jpg *.jpeg);;All (*.*)"))));
+    QString filename = QFileDialog::getOpenFileName(this, tr("Open Map Image"), mapImageFile, tr("JPEG File (*.jpg *.jpeg);;All (*.*)"));
+    if (!filename.isEmpty()) readMapData(QDir::toNativeSeparators(filename));
 }
 // callback on menu-open-track-points ---------------------------------------
 void Plot::openShapeFile()
 {
     trace(3, "openShapeFile\n");
-
     QStringList files = QFileDialog::getOpenFileNames(this, tr("Open Shape File"), QString(), tr("Shape File (*.shp);;All (*.*)"));
+    if (files.isEmpty()) return;
     for (int i = 0; i < files.size(); i++)
         files[i] = QDir::toNativeSeparators(files.at(i));
 
@@ -702,35 +702,37 @@ void Plot::openShapeFile()
 void Plot::openSkyImage()
 {
     trace(3, "openSkyImage\n");
-
-    readSkyData(QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("Open Sky Image"), skyImageFile, tr("JPEG File (*.jpg *.jpeg);;All (*.*)"))));
+    QString filename = QFileDialog::getOpenFileName(this, tr("Open Sky Image"), skyImageFile, tr("JPEG File (*.jpg *.jpeg);;All (*.*)"));
+    if (!filename.isEmpty()) readSkyData(QDir::toNativeSeparators(filename));
 }
 // callback on menu-oepn-waypoint -------------------------------------------
 void Plot::openWaypointsFile()
 {
     trace(3, "openWaypointFile\n");
-
-    readWaypoints(QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("Open Waypoints"), QString(), tr("Waypoints File (*.gpx *.pos);;All (*.*)"))));
+    QString filename = QFileDialog::getOpenFileName(this, tr("Open Waypoints"), QString(), tr("Waypoints File (*.gpx *.pos);;All (*.*)"));
+    if (!filename.isEmpty()) readWaypoints(QDir::toNativeSeparators(filename));
 }
 // callback on menu-open-obs-data -------------------------------------------
 void Plot::openObservationFile()
 {
     trace(3, "openObservationFile\n");
-    readObservation(QFileDialog::getOpenFileNames(this, tr("Open Obs/Nav Data"), observationFiles.value(0), tr("RINEX OBS (*.obs *.*o *.*O *.*d *.O.rnx *O.rnx *O.rnx.gz *O.crx *O.crx.gz *.*o.gz *.*o.Z *.d.gz *.d.Z);;All (*.*)")));
+    QStringList files = QFileDialog::getOpenFileNames(this, tr("Open Obs/Nav Data"), observationFiles.value(0), tr("RINEX OBS (*.obs *.*o *.*O *.*d *.O.rnx *O.rnx *O.rnx.gz *O.crx *O.crx.gz *.*o.gz *.*o.Z *.d.gz *.d.Z);;All (*.*)"));
+    if (!files.isEmpty()) readObservation(files);
 }
 // callback on menu-open-nav-data -------------------------------------------
 void Plot::openNavigationFile()
 {
     trace(3, "openNavigationFile\n");
-
-    readNavigation(QFileDialog::getOpenFileNames(this, tr("Open Raw Obs/Nav Messages"), navigationFiles.value(0), tr("RINEX NAV (*.nav *.gnav *.hnav *.qnav *.*n *.*g *.*h *.*q *.*p *N.rnx *N.rnx.gz);;All (*.*)")));
+    QStringList files = QFileDialog::getOpenFileNames(this, tr("Open Raw Obs/Nav Messages"), navigationFiles.value(0), tr("RINEX NAV (*.nav *.gnav *.hnav *.qnav *.*n *.*g *.*h *.*q *.*p *N.rnx *N.rnx.gz);;All (*.*)"));
+    if (!files.isEmpty()) readNavigation(files);
 }
 // callback on menu-open-elev-mask ------------------------------------------
 void Plot::openElevationMaskFile()
 {
     trace(3, "openElevationMaskFile\n");
 
-    readElevationMaskData(QDir::toNativeSeparators(QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("Open Elevation Mask"), QString(), tr("Text File (*.txt);;All (*.*)")))));
+    QString filename = QFileDialog::getOpenFileName(this, tr("Open Elevation Mask"), QString(), tr("Text File (*.txt);;All (*.*)"));
+    if (!filename.isEmpty()) readElevationMaskData(QDir::toNativeSeparators(filename));
 }
 // callback on menu-vis-analysis --------------------------------------------
 void Plot::visibilityAnalysis()
@@ -776,35 +778,36 @@ void Plot::visibilityAnalysis()
 void Plot::savePlotImage()
 {
     trace(3, "savePlotImage\n");
-    buffer.save(QDir::toNativeSeparators(QFileDialog::getSaveFileName(this, tr("Save Image"), QString(), tr("JPEG  (*.jpg);;Windows Bitmap (*.bmp)"))));
+    QString filename = QFileDialog::getSaveFileName(this, tr("Save Image"), QString(), tr("JPEG  (*.jpg);;Windows Bitmap (*.bmp)"));
+    if (!filename.isEmpty()) buffer.save(QDir::toNativeSeparators(filename));
 }
 // callback on menu-save-waypoint -------------------------------------------
 void Plot::saveWaypointsFile()
 {
     trace(3, "saveWaypointsFile\n");
-
-    saveWaypoints(QDir::toNativeSeparators(QFileDialog::getSaveFileName(this, tr("Save Waypoints"), QString(), tr("GPX File (*.gpx *.pos);;All (*.*)"))));
+    QString filename = QFileDialog::getSaveFileName(this, tr("Save Waypoints"), QString(), tr("GPX File (*.gpx *.pos);;All (*.*)"));
+    if (!filename.isEmpty()) saveWaypoints(QDir::toNativeSeparators(filename));
 }
 // callback on menu-save-# of sats/dop --------------------------------------
 void Plot::saveDopFile()
 {
     trace(3, "saveDopFile\n");
-
-    saveDop(QDir::toNativeSeparators(QFileDialog::getSaveFileName(this, tr("Save Data"), QString(), tr("All (*.*);;Text File (*.txt)"))));
+    QString filename = QFileDialog::getSaveFileName(this, tr("Save Data"), QString(), tr("All (*.*);;Text File (*.txt)"));
+    if (!filename.isEmpty()) saveDop(QDir::toNativeSeparators(filename));
 }
 // callback on menu-save-snr,azel -------------------------------------------
 void Plot::saveSnrMpFile()
 {
     trace(3, "saveSnrMpFile\n");
-
-    saveSnrMp(QDir::toNativeSeparators(QFileDialog::getSaveFileName(this, tr("Save Data"), QString(), tr("All (*.*);;Text File (*.txt)"))));
+    QString filename = QFileDialog::getSaveFileName(this, tr("Save Data"), QString(), tr("All (*.*);;Text File (*.txt)"));
+    if (!filename.isEmpty()) saveSnrMp(QDir::toNativeSeparators(filename));
 }
 // callback on menu-save-elmask ---------------------------------------------
 void Plot::saveElevationMaskFile()
 {
     trace(3, "saveElevationMaskFile\n");
-
-    saveElevationMask(QDir::toNativeSeparators(QFileDialog::getSaveFileName(this, tr("Save Data"), QString(), tr("All (*.*);;Text File (*.txt)"))));
+    QString filename = QFileDialog::getSaveFileName(this, tr("Save Data"), QString(), tr("All (*.*);;Text File (*.txt)"));
+    if (!filename.isEmpty()) saveElevationMask(QDir::toNativeSeparators(filename));
 }
 // callback on menu-connection-settings -------------------------------------
 void Plot::showConnectionSettingsDialog()

--- a/app/qtapp/rtkplot_qt/plotopt.cpp
+++ b/app/qtapp/rtkplot_qt/plotopt.cpp
@@ -200,17 +200,20 @@ void PlotOptDialog::fontSelect()
 //---------------------------------------------------------------------------
 void PlotOptDialog::shapeFileOpen()
 {
-    ui->lEShapeFile->setText(QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("Open"), ui->lEShapeFile->text())));
+    QString filename = QFileDialog::getOpenFileName(this, tr("Open"), ui->lEShapeFile->text());
+    if (!filename.isEmpty()) ui->lEShapeFile->setText(QDir::toNativeSeparators(filename));
 }
 //---------------------------------------------------------------------------
 void PlotOptDialog::tleFileOpen()
 {
-    ui->lETLEFile->setText(QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("Open"), ui->lETLEFile->text(), tr("Text Files (*.txt);;Position Files (*.pos *.snx);;All (*.*)"))));
+    QString filename = QFileDialog::getOpenFileName(this, tr("Open"), ui->lETLEFile->text(), tr("Text Files (*.txt);;Position Files (*.pos *.snx);;All (*.*)"));
+    if (!filename.isEmpty()) ui->lETLEFile->setText(QDir::toNativeSeparators(filename));
 }
 //---------------------------------------------------------------------------
 void PlotOptDialog::tleSatelliteFileOpen()
 {
-    ui->lETLESatelliteFile->setText(QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("Open"), ui->lETLESatelliteFile->text(), tr("Text Files (*.txt);;Position Files (*.pos *.snx);;All (*.*)"))));
+    QString filename = QFileDialog::getOpenFileName(this, tr("Open"), ui->lETLESatelliteFile->text(), tr("Text Files (*.txt);;Position Files (*.pos *.snx);;All (*.*)"));
+    if (!filename.isEmpty()) ui->lETLESatelliteFile->setText(QDir::toNativeSeparators(filename));
 }
 //---------------------------------------------------------------------------
 void PlotOptDialog::referencePositionSelect()

--- a/app/qtapp/rtkplot_qt/skydlg.cpp
+++ b/app/qtapp/rtkplot_qt/skydlg.cpp
@@ -116,8 +116,9 @@ void SkyImgDialog::updateSkyEnabled()
 //---------------------------------------------------------------------------
 void SkyImgDialog::loadSkyImageTag()
 {
-    readSkyTag(QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("Open Tag"), plot->getSkyImageFileName(), tr("Tag File (*.tag);;All (*.*)"))));
-
+    QString filename = QFileDialog::getOpenFileName(this, tr("Open Tag"), plot->getSkyImageFileName(), tr("Tag File (*.tag);;All (*.*)"));
+    if (filename.isEmpty()) return;
+    readSkyTag(QDir::toNativeSeparators(filename));
     updateSky();
 }
 //---------------------------------------------------------------------------

--- a/app/qtapp/rtkpost_qt/kmzconv.cpp
+++ b/app/qtapp/rtkpost_qt/kmzconv.cpp
@@ -80,7 +80,9 @@ void ConvDialog::setInput(const QString &filename)
 //---------------------------------------------------------------------------
 void ConvDialog::selectInputFile()
 {
-    ui->lEInputFile->setText(QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("Open..."), ui->lEInputFile->text(), tr("All (*.*)"))));
+    QString filename = QFileDialog::getOpenFileName(this, tr("Open..."), ui->lEInputFile->text(), tr("All (*.*)"));
+    if (filename.isEmpty()) return;
+    ui->lEInputFile->setText(QDir::toNativeSeparators(filename));
     updateOutputFile();
 }
 //---------------------------------------------------------------------------
@@ -232,7 +234,8 @@ void ConvDialog::updateOutputFile()
 //---------------------------------------------------------------------------
 void ConvDialog::selectGoogleEarthFile()
 {
-    ui->lEGoogleEarthFile->setText(QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("Google Earth Exe File"), ui->lEGoogleEarthFile->text())));
+    QString filename = QFileDialog::getOpenFileName(this, tr("Google Earth Exe File"), ui->lEGoogleEarthFile->text());
+    if (!filename.isEmpty()) ui->lEGoogleEarthFile->setText(QDir::toNativeSeparators(filename));
 }
 //---------------------------------------------------------------------------
 void ConvDialog::callGoogleEarth()

--- a/app/qtapp/rtkpost_qt/postmain.cpp
+++ b/app/qtapp/rtkpost_qt/postmain.cpp
@@ -560,45 +560,53 @@ void MainForm::showStopTimeDialog()
 // callback on button-inputfile-1 -------------------------------------------
 void MainForm::selectInputFile1()
 {
-    ui->cBInputFile1->setCurrentText(QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("RINEX OBS (Rover) File"), ui->cBInputFile1->currentText(),
-                                                                                           tr("All (*.*);;RINEX OBS (*.rnx *.obs *.*O *.*D)"))));
+    QString filename = QFileDialog::getOpenFileName(this, tr("RINEX OBS (Rover) File"), ui->cBInputFile1->currentText(),
+                                                    tr("All (*.*);;RINEX OBS (*.rnx *.obs *.*O *.*D)"));
+    if (filename.isEmpty()) return;
+    ui->cBInputFile1->setCurrentText(QDir::toNativeSeparators(filename));
     setOutputFile();
 }
 // callback on button-inputfile-2 ------------------------------------------
 void MainForm::selectInputFile2()
 {
-    ui->cBInputFile2->setCurrentText(QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("RINEX OBS (Base Station) File"), ui->cBInputFile2->currentText(),
-                                                                                           tr("All (*.*);;RINEX OBS (*.rnx *.obs *.*O *.*D)"))));
+    QString filename = QFileDialog::getOpenFileName(this, tr("RINEX OBS (Base Station) File"), ui->cBInputFile2->currentText(),
+                                                    tr("All (*.*);;RINEX OBS (*.rnx *.obs *.*O *.*D)"));
+    if (!filename.isEmpty()) ui->cBInputFile2->setCurrentText(QDir::toNativeSeparators(filename));
 }
 // callback on button-inputfile-3 -------------------------------------------
 void MainForm::selectInputFile3()
 {
-    ui->cBInputFile3->setCurrentText(QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("RINEX NAV/CLK,SP3,Bias-SINEX,IONEX or SBAS/EMS File"), ui->cBInputFile3->currentText(),
-                                                                                           tr("All (*.*);;RINEX NAV (*.rnx *.*nav *.*N *.*P *.*G *.*H *.*Q)"))));
+    QString filename = QFileDialog::getOpenFileName(this, tr("RINEX NAV/CLK,SP3,Bias-SINEX,IONEX or SBAS/EMS File"), ui->cBInputFile3->currentText(),
+                                                    tr("All (*.*);;RINEX NAV (*.rnx *.*nav *.*N *.*P *.*G *.*H *.*Q)"));
+    if (!filename.isEmpty()) ui->cBInputFile3->setCurrentText(QDir::toNativeSeparators(filename));
 }
 // callback on button-inputfile-4 -------------------------------------------
 void MainForm::selectInputFile4()
 {
-    ui->cBInputFile4->setCurrentText(QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("RINEX NAV/CLK,SP3,Bias-SINEX,IONEX or SBAS/EMS File"), ui->cBInputFile4->currentText(),
-                                                                                           tr("All (*.*);;Precise Ephemeris/Clock/Biases (*.SP3 *.sp3 *.eph* *.CLK *.clk* *.BIA)"))));
+    QString filename = QFileDialog::getOpenFileName(this, tr("RINEX NAV/CLK,SP3,Bias-SINEX,IONEX or SBAS/EMS File"), ui->cBInputFile4->currentText(),
+                                                    tr("All (*.*);;Precise Ephemeris/Clock/Biases (*.SP3 *.sp3 *.eph* *.CLK *.clk* *.BIA)"));
+    if (!filename.isEmpty()) ui->cBInputFile4->setCurrentText(QDir::toNativeSeparators(filename));
 }
 // callback on button-inputfile-5 -------------------------------------------
 void MainForm::selectInputFile5()
 {
-    ui->cBInputFile5->setCurrentText(QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("RINEX NAV/CLK,SP3,Bias-SINEX,IONEX or SBAS/EMS File"), ui->cBInputFile5->currentText(),
-                                                                                           tr("All (*.*);;Precise Ephemeris/Clock/Biases (*.SP3 *.sp3 *.eph* *.CLK *.clk* *.BIA)"))));
+    QString filename = QFileDialog::getOpenFileName(this, tr("RINEX NAV/CLK,SP3,Bias-SINEX,IONEX or SBAS/EMS File"), ui->cBInputFile5->currentText(),
+                                                    tr("All (*.*);;Precise Ephemeris/Clock/Biases (*.SP3 *.sp3 *.eph* *.CLK *.clk* *.BIA)"));
+    if (!filename.isEmpty()) ui->cBInputFile5->setCurrentText(QDir::toNativeSeparators(filename));
 }
 // callback on button-inputfile-6 -------------------------------------------
 void MainForm::selectInputFile6()
 {
-    ui->cBInputFile6->setCurrentText(QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("RINEX NAV/CLK,SP3,Bias-SINEX,IONEX or SBAS/EMS File"), ui->cBInputFile6->currentText(),
-                                                                                           tr("All (*.*);;Bias-SINEX (*.BIA *.BSX),IONEX (*.*i *.ionex, *.inx),SBAS (*.sbs *.ems)"))));
+    QString filename = QFileDialog::getOpenFileName(this, tr("RINEX NAV/CLK,SP3,Bias-SINEX,IONEX or SBAS/EMS File"), ui->cBInputFile6->currentText(),
+                                                    tr("All (*.*);;Bias-SINEX (*.BIA *.BSX),IONEX (*.*i *.ionex, *.inx),SBAS (*.sbs *.ems)"));
+    if (!filename.isEmpty()) ui->cBInputFile6->setCurrentText(QDir::toNativeSeparators(filename));
 }
 // callback on button-outputfile --------------------------------------------
 void MainForm::selectOutputFile()
 {
-    ui->cBOutputFile->setCurrentText(QDir::toNativeSeparators(QFileDialog::getSaveFileName(this, tr("Output File"), ui->cBOutputFile->currentText(),
-                                                                                           tr("All (*.*);;Position Files (*.pos)"))));
+    QString filename = QFileDialog::getSaveFileName(this, tr("Output File"), ui->cBOutputFile->currentText(),
+                                                    tr("All (*.*);;Position Files (*.pos)"));
+    if (!filename.isEmpty()) ui->cBOutputFile->setCurrentText(QDir::toNativeSeparators(filename));
 }
 // callback on button-inputview-1 -------------------------------------------
 void MainForm::viewInputFile1()
@@ -711,7 +719,8 @@ void MainForm::plotInputFile2()
 // callback on button-output-directory --------------------------------------
 void MainForm::selectOutputDirectory()
 {
-    ui->lEOutputDirectory->setText(QDir::toNativeSeparators(QFileDialog::getExistingDirectory(this, tr("Output Directory"), ui->lEOutputDirectory->text())));
+    QString dir = QFileDialog::getExistingDirectory(this, tr("Output Directory"), ui->lEOutputDirectory->text());
+    if (!dir.isEmpty()) ui->lEOutputDirectory->setText(QDir::toNativeSeparators(dir));
 }
 // callback on button keyword -----------------------------------------------
 void MainForm::showKeyDialog()

--- a/app/qtapp/strsvr_qt/svroptdlg.cpp
+++ b/app/qtapp/strsvr_qt/svroptdlg.cpp
@@ -178,6 +178,7 @@ void SvrOptDialog::updateEnable()
 //---------------------------------------------------------------------------
 void SvrOptDialog::logFileSelect()
 {
-    ui->lELogFile->setText(QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("Log File"), ui->lELogFile->text(), tr("All (*.*)"))));
+    QString filename = QFileDialog::getOpenFileName(this, tr("Log File"), ui->lELogFile->text(), tr("All (*.*)"));
+    if (!filename.isEmpty()) ui->lELogFile->setText(QDir::toNativeSeparators(filename));
 }
 //---------------------------------------------------------------------------


### PR DESCRIPTION
Avoid using an empty result of file selection which occurs when the selection is cancelled. So that when a file selection is cancelled then an existing filename setting is retained.