### PR TITLE
rtknavi_qt: for error-snr use the library defaults

### DIFF
--- a/app/qtapp/appcmn_qt/navi_post_opt.cpp
+++ b/app/qtapp/appcmn_qt/navi_post_opt.cpp
@@ -1536,9 +1536,9 @@ void OptDialog::loadOptions(QSettings &settings)
     ui->sBMeasurementError3->setValue(settings.value("prcopt/err2", 0.003).toDouble());
     ui->sBMeasurementError4->setValue(settings.value("prcopt/err3", 0.0).toDouble());
     ui->sBMeasurementError5->setValue(settings.value("prcopt/err4", 1.0).toDouble());
-    ui->sBMeasurementErrorSNR_Max->setValue(settings.value("prcopt/err5", 1.0).toDouble());
-    ui->sBMeasurementErrorSNR->setValue(settings.value("prcopt/err6", 1.0).toDouble());
-    ui->sBMeasurementErrorReceiver->setValue(settings.value("prcopt/err7", 1.0).toDouble());
+    ui->sBMeasurementErrorSNR_Max->setValue(settings.value("prcopt/err5", 52.0).toDouble());
+    ui->sBMeasurementErrorSNR->setValue(settings.value("prcopt/err6", 0.000).toDouble());
+    ui->sBMeasurementErrorReceiver->setValue(settings.value("prcopt/err7", 0.000).toDouble());
     // std
     ui->sBProcessNoise1->setValue(settings.value("prcopt/prn0", 1E-4).toDouble());
     ui->sBProcessNoise2->setValue(settings.value("prcopt/prn1", 1E-3).toDouble());

--- a/app/qtapp/appcmn_qt/navi_post_opt.ui
+++ b/app/qtapp/appcmn_qt/navi_post_opt.ui
@@ -2001,6 +2001,9 @@
             <property name="decimals">
              <number>3</number>
             </property>
+            <property name="singleStep">
+             <double>0.001</double>
+            </property>
            </widget>
           </item>
           <item row="3" column="3" colspan="2">
@@ -2104,6 +2107,12 @@
            <widget class="QDoubleSpinBox" name="sBMeasurementErrorSNR">
             <property name="toolTip">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the SNR dependent terms of carrier-phase error standard deviation (option: &lt;span style=&quot; font-style:italic;&quot;&gt;stats-errsnr&lt;/span&gt;)&lt;/p&gt;&lt;p&gt;e * 10^(0.1*(SNR_MAX - snr))&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="decimals">
+             <number>3</number>
+            </property>
+            <property name="singleStep">
+             <double>0.001</double>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Noted the defaults are not helpful, just adding a large base error. This PR uses the system defaults. If these errors are not in the ballpark then the solution is off and a fix difficult.

Alternatively, the default for stats-errsnr is currently zero but adding some low error would seem appropriate, say 0.001m which would give 2mm at 45db, 7mm at 35db, and 12mm at 30db which is something. Also the default for the baseline error stats-errphasebl is zero and giving this a default value might be appropriate, say 5mm/10km, so 0.005. Would such defaults be helpful?

Use 3 decimal places for the error-snr, steps size of 0.001, and default to 0 - a value of 0.002 to 0.02 would be typical. Default the SNR max to 52, was 1.

Use 3 decimal places for the baseline error and a step size of 0.001. An error of 0.010m per 10km baseline would be typical.