### PR TITLE
Windows winmm

### DIFF
--- a/app/consapp/CMakeLists.txt
+++ b/app/consapp/CMakeLists.txt
@@ -26,9 +26,9 @@ endif()
 
 # add additional libraries to compile on windows
 if(WIN32)
-  target_link_libraries(rnx2rtkp wsock32 ws2_32 winmm)
-  target_link_libraries(convbin wsock32 ws2_32 winmm)
-  target_link_libraries(pos2kml wsock32 ws2_32 winmm)
+  target_link_libraries(rnx2rtkp wsock32 ws2_32)
+  target_link_libraries(convbin wsock32 ws2_32)
+  target_link_libraries(pos2kml wsock32 ws2_32)
 endif()
 
 

--- a/app/consapp/convbin/bcc/_convbin.cbproj
+++ b/app/consapp/convbin/bcc/_convbin.cbproj
@@ -273,7 +273,6 @@
             <CfgParent>Base</CfgParent>
         </BuildConfiguration>
     </ItemGroup>
-    <Import Project="$(BDS)\Bin\CodeGear.Cpp.Targets"/>
     <ProjectExtensions>
         <Borland.Personality>CPlusPlusBuilder.Personality.12</Borland.Personality>
         <Borland.ProjectType>CppConsoleApplication</Borland.ProjectType>

--- a/app/consapp/convbin/msc/msc.vcxproj
+++ b/app/consapp/convbin/msc/msc.vcxproj
@@ -84,14 +84,14 @@
       <AdditionalIncludeDirectories>..\..\..\..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;WIN_STATIC;TRACE;_CRT_SECURE_NO_DEPRECATE;ENAGLO;ENAQZS;ENAGAL;ENACMP;ENAIRN;NFREQ=4;NEXOBS=3;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)convbin.exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
@@ -107,14 +107,14 @@
       <AdditionalIncludeDirectories>..\..\..\..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;WIN_STATIC;TRACE;_CRT_SECURE_NO_DEPRECATE;ENAGLO;ENAQZS;ENAGAL;ENACMP;ENAIRN;NFREQ=4;NEXOBS=3;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)convbin.exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
@@ -127,14 +127,14 @@
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\..\..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;WIN_STATIC;TRACE;_CRT_SECURE_NO_DEPRECATE;ENAGLO;ENAQZS;ENAGAL;ENACMP;ENAIRN;NFREQ=4;NEXOBS=3;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)convbin.exe</OutputFile>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -151,14 +151,14 @@
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\..\..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;WIN_STATIC;TRACE;_CRT_SECURE_NO_DEPRECATE;ENAGLO;ENAQZS;ENAGAL;ENACMP;ENAIRN;NFREQ=4;NEXOBS=3;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)convbin.exe</OutputFile>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/app/consapp/rnx2rtkp/msc/msc.vcxproj
+++ b/app/consapp/rnx2rtkp/msc/msc.vcxproj
@@ -84,7 +84,7 @@
       <AdditionalIncludeDirectories>..\..\..\..\src;%(AdditionalIncludeDirectories);..\</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;WIN_STATIC;TRACE;_CONSOLE;_CRT_SECURE_NO_DEPRECATE;ENAGLO;ENAQZS;ENAGAL;ENACMP;ENAIRN;NFREQ=4;NEXOBS=3;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
@@ -98,7 +98,7 @@
       <DataExecutionPrevention>
       </DataExecutionPrevention>
       <TargetMachine>MachineX86</TargetMachine>
-      <AdditionalDependencies>winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
     <ProjectReference>
@@ -111,7 +111,7 @@
       <AdditionalIncludeDirectories>..\..\..\..\src;%(AdditionalIncludeDirectories);..\</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;WIN_STATIC;TRACE;_CONSOLE;_CRT_SECURE_NO_DEPRECATE;ENAGLO;ENAQZS;ENAGAL;ENACMP;ENAIRN;NFREQ=4;NEXOBS=3;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
@@ -124,7 +124,7 @@
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention>
       </DataExecutionPrevention>
-      <AdditionalDependencies>winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
     <ProjectReference>
@@ -135,14 +135,14 @@
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\..\..\src;%(AdditionalIncludeDirectories);..\</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;WIN_STATIC;TRACE;_CONSOLE;_CRT_SECURE_NO_DEPRECATE;ENAGLO;ENAQZS;ENAGAL;ENACMP;ENAIRN;NFREQ=4;NEXOBS=3;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)rnx2rtkp.exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
@@ -159,14 +159,14 @@
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\..\..\src;%(AdditionalIncludeDirectories);..\</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;WIN_STATIC;TRACE;_CONSOLE;_CRT_SECURE_NO_DEPRECATE;ENAGLO;ENAQZS;ENAGAL;ENACMP;ENAIRN;NFREQ=4;NEXOBS=3;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)rnx2rtkp.exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>

--- a/app/qtapp/qtapp.pri
+++ b/app/qtapp/qtapp.pri
@@ -15,7 +15,7 @@ IERS_MODEL {
 }
 
 win* {
-    LIBS += -lws2_32 -lwinmm
+    LIBS += -lws2_32
 }
 
 

--- a/app/winapp/rtkconv/rtkconv.cbproj
+++ b/app/winapp/rtkconv/rtkconv.cbproj
@@ -389,7 +389,6 @@
             <CfgParent>Base</CfgParent>
         </BuildConfiguration>
     </ItemGroup>
-    <Import Project="$(BDS)\Bin\CodeGear.Cpp.Targets"/>
     <ProjectExtensions>
         <Borland.Personality>CPlusPlusBuilder.Personality.12</Borland.Personality>
         <Borland.ProjectType>CppVCLApplication</Borland.ProjectType>

--- a/app/winapp/rtkget/rtkget.cbproj
+++ b/app/winapp/rtkget/rtkget.cbproj
@@ -300,7 +300,6 @@
             <CfgParent>Base</CfgParent>
         </BuildConfiguration>
     </ItemGroup>
-    <Import Project="$(BDS)\Bin\CodeGear.Cpp.Targets"/>
     <ProjectExtensions>
         <Borland.Personality>CPlusPlusBuilder.Personality.12</Borland.Personality>
         <Borland.ProjectType>CppVCLApplication</Borland.ProjectType>

--- a/app/winapp/rtknavi/rtknavi.cbproj
+++ b/app/winapp/rtknavi/rtknavi.cbproj
@@ -534,7 +534,6 @@
             <CfgParent>Base</CfgParent>
         </BuildConfiguration>
     </ItemGroup>
-    <Import Project="$(BDS)\Bin\CodeGear.Cpp.Targets"/>
     <ProjectExtensions>
         <Borland.Personality>CPlusPlusBuilder.Personality.12</Borland.Personality>
         <Borland.ProjectType>CppVCLApplication</Borland.ProjectType>

--- a/app/winapp/rtkplot/rtkplot.cbproj
+++ b/app/winapp/rtkplot/rtkplot.cbproj
@@ -530,7 +530,6 @@
             <CfgParent>Base</CfgParent>
         </BuildConfiguration>
     </ItemGroup>
-    <Import Project="$(BDS)\Bin\CodeGear.Cpp.Targets"/>
     <ProjectExtensions>
         <Borland.Personality>CPlusPlusBuilder.Personality.12</Borland.Personality>
         <Borland.ProjectType>CppVCLApplication</Borland.ProjectType>

--- a/app/winapp/rtkpost/rtkpost.cbproj
+++ b/app/winapp/rtkpost/rtkpost.cbproj
@@ -412,7 +412,6 @@
             <CfgParent>Base</CfgParent>
         </BuildConfiguration>
     </ItemGroup>
-    <Import Project="$(BDS)\Bin\CodeGear.Cpp.Targets"/>
     <ProjectExtensions>
         <Borland.Personality>CPlusPlusBuilder.Personality.12</Borland.Personality>
         <Borland.ProjectType>CppVCLApplication</Borland.ProjectType>

--- a/app/winapp/srctblbrows/srctblbrows.cbproj
+++ b/app/winapp/srctblbrows/srctblbrows.cbproj
@@ -324,7 +324,6 @@
             <CfgParent>Base</CfgParent>
         </BuildConfiguration>
     </ItemGroup>
-    <Import Project="$(BDS)\Bin\CodeGear.Cpp.Targets"/>
     <ProjectExtensions>
         <Borland.Personality>CPlusPlusBuilder.Personality.12</Borland.Personality>
         <Borland.ProjectType>CppVCLApplication</Borland.ProjectType>

--- a/app/winapp/strsvr/strsvr.cbproj
+++ b/app/winapp/strsvr/strsvr.cbproj
@@ -431,7 +431,6 @@
             <CfgParent>Base</CfgParent>
         </BuildConfiguration>
     </ItemGroup>
-    <Import Project="$(BDS)\Bin\CodeGear.Cpp.Targets"/>
     <ProjectExtensions>
         <Borland.Personality>CPlusPlusBuilder.Personality.12</Borland.Personality>
         <Borland.ProjectType>CppVCLApplication</Borland.ProjectType>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,7 +48,7 @@ target_include_directories(rtklib
 )
 
 if(WIN32)
-  target_link_libraries(rtklib wsock32 ws2_32 winmm)
+  target_link_libraries(rtklib wsock32 ws2_32)
   add_definitions(-DWIN_DLL)
 else()
   target_link_libraries(rtklib m pthread)

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -2041,7 +2041,8 @@ extern int adjgpsweek(int week)
 extern uint32_t tickget(void)
 {
 #ifdef WIN32
-    return (uint32_t)timeGetTime();
+    // To avoid needing all windows.h and lib WinMM for timeGetTime().
+    return (uint32_t)GetTickCount64();
 #else
     struct timespec tp={0};
     struct timeval  tv={0};

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -42,7 +42,7 @@
 #include <ctype.h>
 #include <stdint.h>
 #ifdef WIN32
-#include <winsock2.h>
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #else
 #include <pthread.h>

--- a/src/stream.c
+++ b/src/stream.c
@@ -96,6 +96,10 @@
 #include <netdb.h>
 #endif
 
+#ifdef WIN32
+#include <winsock2.h>
+#endif
+
 /* constants -----------------------------------------------------------------*/
 
 #define TINTACT             200         /* period for stream active (ms) */


### PR DESCRIPTION
Had a frustrating time with windows.h and trying to use ws2tcpip.h, and we will need this to modernise the stream code. windows.h appears be selectively depending on the headers that proceed it, and with it being included in rtklib.h that can become an issue that is hard to resolve. There is a 'lean' mode for windows.h that includes less and that resolves this, but that creates an issues for library winmm. The only function that is used from winmm is the tick timer, and there is a newer replacement, so suggest removing the dependence on winmm. Tested this PR building all the code with BCC, win app and console, and the qt code in visual studio cmake, all fine.