### PR TITLE
rtkpos detslp_dop: use qsort, default off, doc fixes

### DIFF
--- a/app/qtapp/appcmn_qt/navi_post_opt.cpp
+++ b/app/qtapp/appcmn_qt/navi_post_opt.cpp
@@ -1554,7 +1554,7 @@ void OptDialog::loadOptions(QSettings &settings)
     ui->sBElevationMaskAR->setValue(settings.value("prcopt/elmaskar", 0.0).toDouble());
     ui->sBElevationMaskHold->setValue(settings.value("prcopt/elmaskhold", 0.0).toDouble());
     ui->sBSlipThreshold->setValue(settings.value("prcopt/thresslip", 0.05).toDouble());
-    ui->sBDopplerThreshold->setValue(settings.value("prcopt/thresdop", 0.05).toDouble());
+    ui->sBDopplerThreshold->setValue(settings.value("prcopt/thresdop", 0.00).toDouble());
     ui->sBVarHoldAmb->setValue(settings.value("prcopt/varholdamb", 0.1).toDouble());
     ui->sBGainHoldAmb->setValue(settings.value("prcopt/gainholdamb", 0.01).toDouble());
     ui->sBMaxAgeDifferences->setValue(settings.value("prcopt/maxtdiff", 30.0).toDouble());

--- a/app/qtapp/appcmn_qt/navi_post_opt.ui
+++ b/app/qtapp/appcmn_qt/navi_post_opt.ui
@@ -956,7 +956,7 @@
        <item row="9" column="1" colspan="2">
         <widget class="QDoubleSpinBox" name="sBDopplerThreshold">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the cycle-slip threshold (Hz) of difference between doppler and carrier phase difference between epochs, 0 = disabled (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-dopthres).&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the cycle-slip threshold (m/s) of difference between doppler and carrier phase difference between epochs, 0 = disabled (option: &lt;span style=&quot; font-style:italic;&quot;&gt;pos2-dopthres).&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="suffix">
           <string> Hz</string>

--- a/app/winapp/rtknavi/navimain.cpp
+++ b/app/winapp/rtknavi/navimain.cpp
@@ -2544,7 +2544,7 @@ void __fastcall TMainForm::LoadOpt(void)
     PrcOpt.thresar[4]=ini->ReadFloat ("prcopt", "thresar4",      1E-5);
     PrcOpt.elmaskar =ini->ReadFloat  ("prcopt", "elmaskar",  15.0*D2R);
     PrcOpt.elmaskhold=ini->ReadFloat ("prcopt", "elmaskhold",15.0*D2R);
-    PrcOpt.thresdop=ini->ReadFloat    ("prcopt", "thresdop",      0.00);
+    PrcOpt.thresdop=ini->ReadFloat   ("prcopt", "thresdop",      0.00);
     PrcOpt.thresslip=ini->ReadFloat  ("prcopt", "thresslip",     0.05);
     PrcOpt.maxtdiff =ini->ReadFloat  ("prcopt", "maxtdiff",      30.0);
     PrcOpt.maxinno[0]=ini->ReadFloat  ("prcopt", "maxphase",      5.0);

--- a/app/winapp/rtknavi/naviopt.dfm
+++ b/app/winapp/rtknavi/naviopt.dfm
@@ -439,7 +439,7 @@ object OptDialog: TOptDialog
         Top = 117
         Width = 206
         Height = 13
-        Caption = 'Slip Threshs: Doppler (Hz) / Geom-Free (m)'
+        Caption = 'Slip Threshs: Doppler (m/s) / Geom-Free (m)'
       end
       object Label14: TLabel
         Left = 24
@@ -608,7 +608,7 @@ object OptDialog: TOptDialog
         Width = 75
         Height = 21
         TabOrder = 11
-        Text = '0.0'
+        Text = '0.00'
       end
       object SlipThres: TEdit
         Left = 325

--- a/app/winapp/rtkpost/postmain.cpp
+++ b/app/winapp/rtkpost/postmain.cpp
@@ -1396,7 +1396,7 @@ void __fastcall TMainForm::LoadOpt(void)
     ElMaskHold         =ini->ReadFloat  ("opt","elmaskhold",  15.0);
     OutCntResetAmb     =ini->ReadInteger("opt","outcntresetbias",20);
     SlipThres          =ini->ReadFloat  ("opt","slipthres",   0.05);
-    DopThres           =ini->ReadFloat  ("opt","dopthres",     0.0);
+    DopThres           =ini->ReadFloat  ("opt","dopthres",    0.00);
     MaxAgeDiff         =ini->ReadFloat  ("opt","maxagediff",  30.0);
     RejectPhase        =ini->ReadFloat  ("opt","rejectphase",  5.0);
     VarHoldAmb         =ini->ReadFloat  ("opt","varholdamb",   0.1);

--- a/app/winapp/rtkpost/postopt.dfm
+++ b/app/winapp/rtkpost/postopt.dfm
@@ -460,7 +460,7 @@ object OptDialog: TOptDialog
         Top = 117
         Width = 206
         Height = 13
-        Caption = 'Slip Threshs: Doppler (Hz) / Geom-Free (m)'
+        Caption = 'Slip Threshs: Doppler (m/s) / Geom-Free (m)'
       end
       object Label14: TLabel
         Left = 24
@@ -627,7 +627,7 @@ object OptDialog: TOptDialog
         Width = 75
         Height = 21
         TabOrder = 11
-        Text = '0.100'
+        Text = '0.00'
       end
       object SlipThres: TEdit
         Left = 325

--- a/src/rtkpos.c
+++ b/src/rtkpos.c
@@ -749,12 +749,17 @@ static void detslp_gf(rtk_t *rtk, const obsd_t *obs, int i, int j,
         }
     }
 }
+static int cmpdop(const void *dop1, const void *dop2) {
+  double d1 = *(const double *)dop1;
+  double d2 = *(const double *)dop2;
+  return (d1 > d2) - (d1 < d2);
+}
 /* detect cycle slip by doppler and phase difference -------------------------*/
 static void detslp_dop(rtk_t *rtk, const obsd_t *obs, const int *ix, int ns,
                        int rcv, const nav_t *nav)
 {
-    int i,j,ii,f,sat,ndop=0,nf=rtk->opt.nf;
-    double dph,dpt,lam,med_dop,tmp;
+    int i,ii,f,sat,ndop=0,nf=rtk->opt.nf;
+    double dph,dpt,lam,med_dop;
     double dopdif[MAXSAT][NFREQ], tt[MAXSAT][NFREQ];
     double doplist[MAXSAT*NFREQ];
 
@@ -796,13 +801,7 @@ static void detslp_dop(rtk_t *rtk, const obsd_t *obs, const int *ix, int ns,
     if (ndop==0) return;
 
     /* median common range-rate error */
-    for (i=1;i<ndop;i++) {
-        tmp=doplist[i];
-        for (j=i;j>0&&doplist[j-1]>tmp;j--) {
-            doplist[j]=doplist[j-1];
-        }
-        doplist[j]=tmp;
-    }
+    qsort(doplist, ndop, sizeof(double), cmpdop);
     /* calc median doppler diff, most likely due to clock error */
     med_dop=ndop%2?doplist[ndop/2]:
                        (doplist[ndop/2-1]+doplist[ndop/2])/2.0;


### PR DESCRIPTION
Suggestion to use qsort rather than inline code.

Default the threshold to zero by default, which means disabled.

Correct documentation for the Hz to m/s change.